### PR TITLE
do not output the default port in the header

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -114,7 +114,7 @@ function Request(m::HTTP.Method, uri::URI, userheaders::Headers, body::FIFOBuffe
                     io::IO=STDOUT)
     if m != CONNECT
         headers = defaultheaders(Request)
-        headers["Host"] = host(uri)
+        headers["Host"] = string(hostname(uri), hasport(uri) ? string(':', port(uri)) : "")
     else
         headers = Headers()
     end


### PR DESCRIPTION
Removing default port number in the Host field would be a conventional way for HTTP clients (at least, curl and Google Chrome do this by default). Some silly web servers do not support this and throw an error when a port number is included in the host field (e.g. https://rest.ensembl.org/documentation/info/archive_id_get).