### PR TITLE
Overhaul multipart

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -320,15 +320,25 @@ for f in [:get, :post, :put, :delete, :head,
     $($f)(uri) -> Response
     $($f)(client::HTTP.Client, uri) -> Response
 
-Build and execute an http "$($f_str)" request. Query parameters can be passed via the `query` keyword argument as a `Dict`.
+Build and execute an http "$($f_str)" request. Query parameters can be passed via the `query` keyword argument as a `Dict`. Multiple
+query parameters with the same key can be passed like `Dict("key1"=>["value1", "value2"], "key2"=>...)`.
 Returns a `Response` object that includes the resulting status code (`HTTP.status(r)` and `HTTP.statustext(r)`),
 response headers (`HTTP.headers(r)`), cookies (`HTTP.cookies(r)`), response history if redirects were involved
-(`HTTP.history(r)`), and response body (`HTTP.body(r)` or `string(r)` or `HTTP.bytes(r)`).
+(`HTTP.history(r)`), and response body (`HTTP.body(r)` or `take!(String, r)` or `take!(r)`).
+
+The body or payload for a request can be given through the `body` keyword arugment.
+The body can be given as a `String`, `Vector{UInt8}`, `IO`, `HTTP.FIFOBuffer` or `Dict` argument type.
+See examples below for how to use an `HTTP.FIFOBuffer` for asynchronous streaming uploads.
+If the body is provided as a `Dict`, the request body will be uploaded using the multipart/form-data encoding.
+The key-value pairs in the Dict will constitute the name and value of each multipart boundary chunk.
+Files and other large data arguments can be provided as values as IO arguments: either an `IOStream` such as returned via `open(file)`,
+an `IOBuffer` for in-memory data, or even an `HTTP.FIFOBuffer`. For complete control over the multipart details, an
+`HTTP.Multipart` type is provided to support setting the `Content-Type`, `filename`, and `Content-Transfer-Encoding` if desired. See `?HTTP.Multipart` for more details.
 
 Additional keyword arguments supported, include:
 
 * `headers::Dict{String,String}`: headers given as Dict to be sent with the request
-* `body`: a request body can be given as a `String`, `Vector{UInt8}`, `IO`, or `HTTP.FIFOBuffer`; see example below for how to utilize `HTTP.FIFOBuffer` for "streaming" request bodies
+* `body`: a request body can be given as a `String`, `Vector{UInt8}`, `IO`, `HTTP.FIFOBuffer` or `Dict`; see example below for how to utilize `HTTP.FIFOBuffer` for "streaming" request bodies; a `Dict` argument will be converted to a multipart form upload
 * `stream::Bool=false`: enable response body streaming; depending on the response body size, the request will return before the full body has been received; as the response body is read, additional bytes will be recieved and put in the response body. Readers should read until `eof(response.body) == true`; see below for an example of response streaming
 * `chunksize::Int`: if a request body is larger than `chunksize`, the "chunked-transfer" http mechanism will be used and chunks will be sent no larger than `chunksize`
 * `connecttimeout::Float64`: sets a timeout on how long to wait when trying to connect to a remote host; default = 10.0 seconds

--- a/src/client.jl
+++ b/src/client.jl
@@ -410,10 +410,9 @@ function download(uri::AbstractString, file; threshold::Int=50000000, verbose::B
     nbytes = 0
     open(file, "w") do f
         while !eof(body)
-            # should we replace \N here too?
             nbytes += write(f, readavailable(body))
             if nbytes > threshold
-                println("[$(now())]: downloaded $nbytes bytes..."); flush(STDOUT)
+                verbose && println("[$(now())]: downloaded $nbytes bytes..."); flush(STDOUT)
                 threshold += 50000000
             end
         end

--- a/src/fifobuffer.jl
+++ b/src/fifobuffer.jl
@@ -73,7 +73,10 @@ FIFOBuffer(io::IO) = FIFOBuffer(readavailable(io))
 
 ==(a::FIFOBuffer, b::FIFOBuffer) = String(a) == String(b)
 Base.length(f::FIFOBuffer) = f.nb
+Base.nb_available(f::FIFOBuffer) = f.nb
 Base.wait(f::FIFOBuffer) = wait(f.cond)
+Base.read(f::FIFOBuffer) = readavailable(f)
+
 function Base.eof(f::FIFOBuffer)
     if current_task() == f.task
         # not asynchronous, just read until buffer is empty

--- a/src/sniff.jl
+++ b/src/sniff.jl
@@ -2,10 +2,11 @@
 const ZIP = UInt8[0x50, 0x4b, 0x03, 0x04]
 const GZIP = UInt8[0x1f, 0x8b, 0x08]
 
-iscompressed(bytes) = length(bytes) > 3 && (all(bytes[1:4] .== ZIP) || all(bytes[1:3] .== GZIP))
+iscompressed(bytes::Vector{UInt8}) = length(bytes) > 3 && (all(bytes[1:4] .== ZIP) || all(bytes[1:3] .== GZIP))
 iscompressed(str::String) = iscompressed(Vector{UInt8}(str))
 iscompressed(f::FIFOBuffer) = iscompressed(String(f))
 iscompressed(d::Dict) = false
+iscompressed(d) = false
 
 # Based on the net/http/sniff.go implementation of DetectContentType
 # sniff implements the algorithm described

--- a/src/types.jl
+++ b/src/types.jl
@@ -122,7 +122,7 @@ function Form(d::Dict)
             io = IOBuffer()
         else
             write(io, "$CRLF$CRLF")
-            write(io, escape(v), "$CRLF")
+            write(io, escape(v))
         end
         i == len && write(io, "--" * boundary * "--" * "$CRLF")
     end
@@ -148,7 +148,7 @@ type Multipart{T <: IO} <: IO
     contenttransferencoding::String
 end
 Multipart{T}(f::String, data::T, ct="", cte="") = Multipart(f, data, ct, cte)
-Base.show{T}(io::IO, m::Multipart{T}) = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", contenttransferencoding=\"$(m.contenttransferencoding)\", contenttype=\"$(m.contenttype)\", data=::$T)")
+Base.show{T}(io::IO, m::Multipart{T}) = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", data=::$T, contenttype=\"$(m.contenttype)\", contenttransferencoding=\"$(m.contenttransferencoding)\")")
 
 Base.nb_available{T}(m::Multipart{T}) = isa(m.data, IOStream) ? filesize(m.data) - position(m.data) : nb_available(m.data)
 Base.eof{T}(m::Multipart{T}) = eof(m.data)

--- a/src/uri.jl
+++ b/src/uri.jl
@@ -166,6 +166,7 @@ function escape(str::AbstractString, f=shouldencode)
     end
     return String(take!(out))
 end
+escape(bytes::Vector{UInt8}) = bytes
 
 escape(io, k, v) = write(io, escape(k), "=", escape(v))
 function escape(io, k, A::Vector{String})

--- a/test/client.jl
+++ b/test/client.jl
@@ -108,9 +108,9 @@ for sch in ("http", "https")
     r = HTTP.post("$sch://httpbin.org/post"; body=Dict("hey"=>"there", "iostream"=>io))
     close(io); rm(tmp)
     @test HTTP.status(r) == 200
-    str = take!(String
+    str = take!(String, r)
     @show str
-    @test startswith(str, r), "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"iostream\": \"hey\"\n  }, \n  \"form\": {\n    \"hey\": \"there\"\n  }")
+    @test startswith(str, "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"iostream\": \"hey\"\n  }, \n  \"form\": {\n    \"hey\": \"there\"\n  }")
 
     tmp = tempname()
     open(f->write(f, "hey"), tmp, "w")

--- a/test/client.jl
+++ b/test/client.jl
@@ -108,7 +108,9 @@ for sch in ("http", "https")
     r = HTTP.post("$sch://httpbin.org/post"; body=Dict("hey"=>"there", "iostream"=>io))
     close(io); rm(tmp)
     @test HTTP.status(r) == 200
-    @test startswith(take!(String, r), "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"iostream\": \"hey\"\n  }, \n  \"form\": {\n    \"hey\": \"there\"\n  }")
+    str = take!(String
+    @show str
+    @test startswith(str, r), "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"iostream\": \"hey\"\n  }, \n  \"form\": {\n    \"hey\": \"there\"\n  }")
 
     tmp = tempname()
     open(f->write(f, "hey"), tmp, "w")


### PR DESCRIPTION
 to make code cleaner and more flexible in terms of letting users specify a full Multipart if desired.

cc: @staticfloat 

supersedes #32 