### PR TITLE
Explicitly test versions on Travis, mention 0.6 in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.5-img]][pkg-0.5-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.5-img]][pkg-0.5-url] [![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
@@ -22,7 +22,7 @@ julia> Pkg.add("HTTP")
 
 ## Project Status
 
-The package is tested against Julia `0.5` on Linux, OS X, and Windows.
+The package is tested against Julia 0.5 and 0.6 on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 
@@ -50,3 +50,6 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 [pkg-0.5-img]: http://pkg.julialang.org/badges/HTTP_0.5.svg
 [pkg-0.5-url]: http://pkg.julialang.org/?pkg=HTTP
+
+[pkg-0.6-img]: http://pkg.julialang.org/badges/HTTP_0.6.svg
+[pkg-0.6-url]: http://pkg.julialang.org/?pkg=HTTP


### PR DESCRIPTION
I changed `release` in the Travis YAML to explicit entries for 0.5 and 0.6. The latter is currently equivalent to `nightly` but won't be once 0.6 branches into a release, so I figured it's easier to change it now and it'll just continue to work as expected once 0.6 is released. I also made the 0.6 support clear in the README.