### PR TITLE
Custom Associative type for Header

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -25,6 +25,7 @@ include("uri.jl")
 include("cookies.jl")
 using .Cookies
 
+include("headers.jl")
 include("types.jl")
 include("parser.jl")
 include("client.jl")

--- a/src/headers.jl
+++ b/src/headers.jl
@@ -58,11 +58,11 @@ immutable AlreadyCanonical
 end
 
 """
-    Headers() <: Associative{String,String}()
+    Headers <: Associative{String,String}
 
 A type to represent headers. Keys containing invalid characters are returned as is. Valid keys are canonicalized, uppercasing the first character and characters following a '-' and lowercasing other characters. So, for valid keys, Headers is case-insensitive.
 """
-immutable Headers{K<:String,V<:String} <: Associative{K,V}
+immutable Headers{K<:String,V<:String} <: Associative{String,String}
     d::Dict{K,V}
 
     function Headers{K,V}() where V where K

--- a/src/headers.jl
+++ b/src/headers.jl
@@ -1,0 +1,246 @@
+# See https://httpwg.github.io/specs/rfc7230.html#rule.token.separators
+const validHeaderBytes = IntSet(Int(c) for c in
+   raw"!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUWVXYZ^_`abcdefghijklmnopqrstuvwxyz|~"
+)
+
+validHeaderChar(c::Char) = isascii(c) && UInt8(c) in validHeaderBytes
+
+function canonicalHeaderKey(s::String)
+    # fast path for valid header keys
+    upper = true
+    for c in s
+        if !validHeaderChar(c)
+            return s
+        end
+        if upper && 'a' <= c <= 'z'
+            return _chk(s)
+        end
+        if !upper && 'A' <= c <= 'Z'
+            return _chk(s)
+        end
+
+        upper = c == '-'
+    end
+
+    return s
+end
+
+const toUpper = 'A' - 'a'
+
+function _chk(s::String)
+    # confirm its fixable before changing anything
+    for c in s
+        if !validHeaderChar(c)
+            return s
+        end
+    end
+
+    a = copy(Array{UInt8}(s))
+    upper = true
+    for (i, b) in enumerate(a)
+        if upper && UInt8('a') <= b <= UInt8('z')
+            b += toUpper
+        elseif !upper && UInt8('A') <= b <= UInt8('Z')
+            b -= toUpper
+        end
+        @inbounds a[i] = b
+        upper = b == UInt8('-')
+    end
+
+    return String(a)
+end
+
+"""
+Internal type used to enable fast merge, copy, and filter of Headers
+"""
+immutable AlreadyCanonical
+    d::Dict{String,String}
+end
+
+"""
+    Headers() <: Associative{String,String}()
+
+A type to represent headers. Keys containing invalid characters are returned as is. Valid keys are canonicalized, uppercasing the first character and characters following a '-' and lowercasing other characters. So, for valid keys, Headers is case-insensitive.
+"""
+immutable Headers{K<:String,V<:String} <: Associative{K,V}
+    d::Dict{K,V}
+
+    function Headers{K,V}() where V where K
+        new(Dict{K,V}())
+    end
+    function Headers{K,V}(kv) where V where K
+        d = Dict{K,V}()
+        for (k, v) in kv
+            ck = canonicalHeaderKey(k)
+            if haskey(d, ck)
+                error("Key collision -- multiple keys canonize as '$ck'")
+            else
+                d[ck] = v
+            end
+        end
+        new(d)
+    end
+    function Headers{K,V}(c::AlreadyCanonical) where V where K
+        new(c.d)
+    end
+end
+Headers() = Headers{String,String}()
+Headers(x) = Headers{String,String}(x)
+Headers(x::Pair...) = Headers{String,String}(x)
+
+Base.convert(::Type{Headers}, x::Associative{String,String}) = Headers(x)
+
+Base.similar(h::Headers{K,V}) where {K,V} = Headers{K,V}()
+
+Base.length(h::Headers) = length(h.d)
+Base.start(h::Headers) = start(h.d)
+Base.done(h::Headers, args...) = done(h.d, args...)
+Base.next(h::Headers, args...) = next(h.d, args...)
+
+Base.getindex(h::Headers, k) = getindex(h.d, canonicalHeaderKey(k))
+Base.get(h::Headers, k, d) = Base.get(h.d, canonicalHeaderKey(k), d)
+Base.get(d::Base.Callable, h::Headers, k) = Base.get(d, h.d, canonicalHeaderKey(k))
+Base.get!(h::Headers, k, d) = get!(h.d, canonicalHeaderKey(k), d)
+Base.get!(d::Base.Callable, h::Headers, k) = get!(d, h.d, canonicalHeaderKey(k))
+Base.setindex!(h::Headers, v, k) = setindex!(h.d, v, canonicalHeaderKey(k))
+
+Base.pop!(h::Headers, k) = pop!(h.d, canonicalHeaderKey(k))
+function Base.delete!(h::Headers, k)
+    delete!(h.d, canonicalHeaderKey(k))
+    h
+end
+function Base.filter!(f, h::Headers)
+    filter!(f, h.d)
+    h
+end
+function Base.merge!(h::Headers, others::Headers...)
+    for other in others
+        merge!(h.d, other.d)
+    end
+    h
+end
+function Base.merge!(combine::Function, h::Headers, others::Headers...)
+    for other in others
+        merge!(combine, h.d, other.d)
+    end
+    h
+end
+function Base.empty!(h::Headers)
+    empty!(h.d)
+    h
+end
+
+Base.filter(f, h::Headers) = Headers(AlreadyCanonical(filter(f, h.d)))
+Base.copy(h::Headers) = Headers(AlreadyCanonical(copy(h.d)))
+Base.merge(h::Headers, others::Headers...) = merge!(copy(h), others...)
+
+# Form request body
+"""
+    Form(dict::Dict)
+
+A type representing a request body using the multipart/form-data encoding.
+The key-value pairs in the Dict argument will constitute the name and value of each multipart boundary chunk.
+Files and other large data arguments can be provided as values as IO arguments: either an `IOStream` such as returned via `open(file)`,
+an `IOBuffer` for in-memory data, or even an `HTTP.FIFOBuffer`. For complete control over a multipart chunk's details, an
+`HTTP.Multipart` type is provided to support setting the `Content-Type`, `filename`, and `Content-Transfer-Encoding` if desired. See `?HTTP.Multipart` for more details.
+"""
+type Form <: IO
+    data::Vector{IO}
+    index::Int
+    boundary::String
+end
+
+Form(f::Form) = f
+Base.eof(f::Form) = f.index > length(f.data)
+Base.length(f::Form) = sum(x->isa(x, IOStream) ? filesize(x) - position(x) : nb_available(x), f.data)
+
+Base.readavailable(f::Form) = read(f)
+function Base.read(f::Form)
+    result = UInt8[]
+    for io in f.data
+        append!(result, read(io))
+    end
+    f.index = length(f.data) + 1
+    return result
+end
+
+function Base.read(f::Form, n::Integer)
+    nb = 0
+    result = UInt8[]
+    while nb < n
+        d = read(f.data[f.index], n - nb)
+        nb += length(d)
+        append!(result, d)
+        eof(f.data[f.index]) && (f.index += 1)
+        f.index > length(f.data) && break
+    end
+    return result
+end
+
+function Form(d::Dict)
+    boundary = hex(rand(UInt128))
+    data = IO[]
+    io = IOBuffer()
+    len = length(d)
+    for (i, (k, v)) in enumerate(d)
+        write(io, (i == 1 ? "" : "$CRLF") * "--" * boundary * "$CRLF")
+        write(io, "Content-Disposition: form-data; name=\"$k\"")
+        if isa(v, IO)
+            writemultipartheader(io, v)
+            seekstart(io)
+            push!(data, io)
+            push!(data, v)
+            io = IOBuffer()
+        else
+            write(io, "$CRLF$CRLF")
+            write(io, escape(v))
+        end
+        i == len && write(io, "$CRLF--" * boundary * "--" * "$CRLF")
+    end
+    seekstart(io)
+    push!(data, io)
+    return Form(data, 1, boundary)
+end
+
+function writemultipartheader(io::IOBuffer, i::IOStream)
+    write(io, "; filename=\"$(i.name[7:end-1])\"$CRLF")
+    write(io, "Content-Type: $(HTTP.sniff(i))$CRLF$CRLF")
+    return
+end
+function writemultipartheader(io::IOBuffer, i::IO)
+    write(io, "$CRLF$CRLF")
+    return
+end
+
+"""
+    Multipart(filename::String, data::IO, content_type=HTTP.sniff(data), content_transfer_encoding="")
+
+A type to represent a single multipart upload chunk for a file. This type would be used as the value in a
+key-value pair of a Dict passed to an http request, like `HTTP.post(url; body=Dict("key"=>HTTP.Multipart("MyFile.txt", open("MyFile.txt"))))`.
+The `data` argument must be an `IO` type such as `IOStream`, `IOBuffer`, or `HTTP.FIFOBuffer`.
+The `content_tyep` and `content_transfer_encoding` arguments allow the manual setting of these multipart headers. `Content-Type` will default to the result
+of the `HTTP.sniff(data)` mimetype detection algorithm, whereas `Content-Transfer-Encoding` will be left out if not specified.
+"""
+type Multipart{T <: IO} <: IO
+    filename::String
+    data::T
+    contenttype::String
+    contenttransferencoding::String
+end
+Multipart{T}(f::String, data::T, ct="", cte="") = Multipart(f, data, ct, cte)
+Base.show{T}(io::IO, m::Multipart{T}) = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", data=::$T, contenttype=\"$(m.contenttype)\", contenttransferencoding=\"$(m.contenttransferencoding)\")")
+
+Base.nb_available{T}(m::Multipart{T}) = isa(m.data, IOStream) ? filesize(m.data) - position(m.data) : nb_available(m.data)
+Base.eof{T}(m::Multipart{T}) = eof(m.data)
+Base.read{T}(m::Multipart{T}, n::Integer) = read(m.data, n)
+Base.read{T}(m::Multipart{T}) = read(m.data)
+Base.mark{T}(m::Multipart{T}) = mark(m.data)
+Base.reset{T}(m::Multipart{T}) = reset(m.data)
+
+function writemultipartheader(io::IOBuffer, i::Multipart)
+    write(io, "; filename=\"$(i.filename)\"$CRLF")
+    contenttype = i.contenttype == "" ? HTTP.sniff(i.data) : i.contenttype
+    write(io, "Content-Type: $(contenttype)$CRLF")
+    write(io, i.contenttransferencoding == "" ? "$CRLF" : "Content-Transfer-Encoding: $(i.contenttransferencoding)$CRLF$CRLF")
+    return
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -10,8 +10,6 @@ sockettype(::Type{https}) = TLS.SSLContext
 schemetype(::Type{TCPSocket}) = http
 schemetype(::Type{TLS.SSLContext}) = https
 
-const Headers = Dict{String,String}
-
 ?{T}(::Type{T}) = Union{T, Void}
 const null = nothing
 isnull(v::Void) = true
@@ -73,117 +71,6 @@ function update!(opts1::RequestOptions, opts2::RequestOptions)
         isnull(getfield(opts1, f)) && setfield!(opts1, f, getfield(opts2, f))
     end
     return opts1
-end
-
-# Form request body
-"""
-    Form(dict::Dict)
-
-A type representing a request body using the multipart/form-data encoding.
-The key-value pairs in the Dict argument will constitute the name and value of each multipart boundary chunk.
-Files and other large data arguments can be provided as values as IO arguments: either an `IOStream` such as returned via `open(file)`,
-an `IOBuffer` for in-memory data, or even an `HTTP.FIFOBuffer`. For complete control over a multipart chunk's details, an
-`HTTP.Multipart` type is provided to support setting the `Content-Type`, `filename`, and `Content-Transfer-Encoding` if desired. See `?HTTP.Multipart` for more details.
-"""
-type Form <: IO
-    data::Vector{IO}
-    index::Int
-    boundary::String
-end
-
-Form(f::Form) = f
-Base.eof(f::Form) = f.index > length(f.data)
-Base.length(f::Form) = sum(x->isa(x, IOStream) ? filesize(x) - position(x) : nb_available(x), f.data)
-
-Base.readavailable(f::Form) = read(f)
-function Base.read(f::Form)
-    result = UInt8[]
-    for io in f.data
-        append!(result, read(io))
-    end
-    f.index = length(f.data) + 1
-    return result
-end
-
-function Base.read(f::Form, n::Integer)
-    nb = 0
-    result = UInt8[]
-    while nb < n
-        d = read(f.data[f.index], n - nb)
-        nb += length(d)
-        append!(result, d)
-        eof(f.data[f.index]) && (f.index += 1)
-        f.index > length(f.data) && break
-    end
-    return result
-end
-
-function Form(d::Dict)
-    boundary = hex(rand(UInt128))
-    data = IO[]
-    io = IOBuffer()
-    len = length(d)
-    for (i, (k, v)) in enumerate(d)
-        write(io, (i == 1 ? "" : "$CRLF") * "--" * boundary * "$CRLF")
-        write(io, "Content-Disposition: form-data; name=\"$k\"")
-        if isa(v, IO)
-            writemultipartheader(io, v)
-            seekstart(io)
-            push!(data, io)
-            push!(data, v)
-            io = IOBuffer()
-        else
-            write(io, "$CRLF$CRLF")
-            write(io, escape(v))
-        end
-        i == len && write(io, "$CRLF--" * boundary * "--" * "$CRLF")
-    end
-    seekstart(io)
-    push!(data, io)
-    return Form(data, 1, boundary)
-end
-
-function writemultipartheader(io::IOBuffer, i::IOStream)
-    write(io, "; filename=\"$(i.name[7:end-1])\"$CRLF")
-    write(io, "Content-Type: $(HTTP.sniff(i))$CRLF$CRLF")
-    return
-end
-function writemultipartheader(io::IOBuffer, i::IO)
-    write(io, "$CRLF$CRLF")
-    return
-end
-
-"""
-    Multipart(filename::String, data::IO, content_type=HTTP.sniff(data), content_transfer_encoding="")
-
-A type to represent a single multipart upload chunk for a file. This type would be used as the value in a
-key-value pair of a Dict passed to an http request, like `HTTP.post(url; body=Dict("key"=>HTTP.Multipart("MyFile.txt", open("MyFile.txt"))))`.
-The `data` argument must be an `IO` type such as `IOStream`, `IOBuffer`, or `HTTP.FIFOBuffer`.
-The `content_tyep` and `content_transfer_encoding` arguments allow the manual setting of these multipart headers. `Content-Type` will default to the result
-of the `HTTP.sniff(data)` mimetype detection algorithm, whereas `Content-Transfer-Encoding` will be left out if not specified.
-"""
-type Multipart{T <: IO} <: IO
-    filename::String
-    data::T
-    contenttype::String
-    contenttransferencoding::String
-end
-Multipart{T}(f::String, data::T, ct="", cte="") = Multipart(f, data, ct, cte)
-Base.show{T}(io::IO, m::Multipart{T}) = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", data=::$T, contenttype=\"$(m.contenttype)\", contenttransferencoding=\"$(m.contenttransferencoding)\")")
-
-Base.nb_available{T}(m::Multipart{T}) = isa(m.data, IOStream) ? filesize(m.data) - position(m.data) : nb_available(m.data)
-Base.eof{T}(m::Multipart{T}) = eof(m.data)
-Base.read{T}(m::Multipart{T}, n::Integer) = read(m.data, n)
-Base.read{T}(m::Multipart{T}) = read(m.data)
-Base.mark{T}(m::Multipart{T}) = mark(m.data)
-Base.reset{T}(m::Multipart{T}) = reset(m.data)
-
-function writemultipartheader(io::IOBuffer, i::Multipart)
-    write(io, "; filename=\"$(i.filename)\"$CRLF")
-    contenttype = i.contenttype == "" ? HTTP.sniff(i.data) : i.contenttype
-    write(io, "Content-Type: $(contenttype)$CRLF")
-    write(io, i.contenttransferencoding == "" ? "$CRLF" : "Content-Transfer-Encoding: $(i.contenttransferencoding)$CRLF$CRLF")
-    return
 end
 
 # Request
@@ -264,7 +151,7 @@ end
 
 Request{T}(method, uri, h, body::T; options::RequestOptions=RequestOptions(), io::IO=STDOUT, verbose::Bool=false) =
     Request(convert(HTTP.Method, method), isa(uri, String) ? URI(uri; isconnect=(method == "CONNECT" || method == CONNECT)) : uri,
-            h, body; options=options, io=io, verbose=verbose)
+            convert(HTTP.Headers, h), body; options=options, io=io, verbose=verbose)
 
 Request() = Request(GET, Int16(1), Int16(1), URI(""), Headers(), FIFOBuffer())
 
@@ -327,16 +214,16 @@ Base.String(r::Union{Request, Response}) = String(body(r))
 
 Response(; status::Int=200,
          cookies::Vector{Cookie}=Cookie[],
-         headers::Headers=Headers(),
+         headers=Headers(),
          body::FIFOBuffer=FIFOBuffer(),
          request::Nullable{Request}=Nullable{Request}(),
          history::Vector{Response}=Response[]) =
-    Response(status, Int16(1), Int16(1), cookies, headers, body, request, history)
+    Response(status, Int16(1), Int16(1), cookies, convert(Headers, headers), body, request, history)
 
 Response(n::Integer, r::Request) = Response(; body=FIFOBuffer(n), request=Nullable(r))
 Response(s::Integer) = Response(; status=s)
 Response(b::Union{Vector{UInt8}, String}) = Response(; headers=defaultheaders(Response), body=FIFOBuffer(b))
-Response(s::Integer, h::Headers, body) = Response(; status=s, headers=h, body=FIFOBuffer(body))
+Response(s::Integer, h, body) = Response(; status=s, headers=convert(Headers, h), body=FIFOBuffer(body))
 
 defaultheaders(::Type{Response}) = Headers(
     "Server"            => "Julia/$VERSION",

--- a/test/headers.jl
+++ b/test/headers.jl
@@ -1,0 +1,63 @@
+@testset "HTTP.Headers" begin
+    HTTP.Headers{String,String}()
+    HTTP.Headers()
+
+    @test_throws ErrorException HTTP.Headers("accept" => "a", "Accept" => "b")
+
+    h = HTTP.Headers(string(c) => "b" for c in "abcd")
+    first(h)
+
+    @test haskey(h, "c")
+    @test in("c" => "b", h)
+    @test in("c", keys(h))
+    @test in("C", keys(h))
+    @test !in("c", collect(keys(h)))
+    @test in("C", collect(keys(h)))
+
+    h["eXcept-this"] = "true"
+    @test h["exCept-This"] == "true"
+    @test get(h, "exCept-This", "") == "true"
+    @test get!(() -> "def", h, "not fixable") == "def"
+    @test get!(h, "not-valid", "ault") == "ault"
+    @test h["not-valid"] == "ault"
+
+    pluto = "♇"
+    h["C"] = pluto
+    @test pop!(h, "C") == pluto
+    @test delete!(h, "a") == h
+    @test filter!((k, v) -> k != "D", h) == h
+
+    h["bλ-a"] = "a"
+    h["b>a"] = ">"
+
+    ks = ["B", "Except-This", "not fixable", "Not-Valid", "bλ-a", "b>a"]
+    @test Set(ks) == Set(keys(h))
+
+    @test length(h) == length(ks)
+    @test !isempty(h)
+    @test similar(h) == HTTP.Headers()
+    empty!(h)
+    @test length(h) == 0
+    @test isempty(h)
+
+    mk_h() = HTTP.Headers("server" => "x", "mime-version" => "y")
+    h = mk_h()
+    o = HTTP.Headers("Server" => "z", "to" => "q")
+    hm_expected = HTTP.Headers("Server" => "z", "Mime-Version" => "y", "To" => "q")
+
+    hm = merge(h, o)
+    @test hm == hm_expected
+    @test h == mk_h()
+
+    hm_bang = merge!(h, o)
+    @test h == hm_expected
+    @test hm_bang === h
+
+    hc = copy(h)
+    filter!((k, v) -> v != "y", hc)
+    @test h == hm_expected
+    @test hc != hm_expected
+
+    @test filter((k, v) -> v == "q", h) == HTTP.Headers("To" => "q")
+    @test h == hm_expected
+end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -103,7 +103,7 @@ const requests = Message[
   ,request_url= "/dumbfuck"
   ,num_headers= 1
   ,headers=Dict{String,String}(
-      "aaaaaaaaaaaaa"=>  "++++++++++"
+      "Aaaaaaaaaaaaa"=>  "++++++++++"
   )
   ,body= ""
 ), Message(name= "fragment in url"
@@ -165,7 +165,7 @@ const requests = Message[
   ,request_url= "/get_funky_content_length_body_hello"
   ,num_headers= 1
   ,headers=Dict{String,String}(
-       "conTENT-Length" => "5"
+       "Content-Length" => "5"
   )
   ,body= "HELLO"
 ), Message(name= "post identity body world"
@@ -358,10 +358,10 @@ const requests = Message[
   ,upgrade="Hot diggity dogg"
   ,headers=Dict{String,String}( "Host"=> "example.com"
              , "Connection"=> "Upgrade"
-             , "Sec-WebSocket-Key2"=> "12998 5 Y3 1  .P00"
-             , "Sec-WebSocket-Protocol"=> "sample"
+             , "Sec-Websocket-Key2"=> "12998 5 Y3 1  .P00"
+             , "Sec-Websocket-Protocol"=> "sample"
              , "Upgrade"=> "WebSocket"
-             , "Sec-WebSocket-Key1"=> "4 @1  46546xW%0l 1 5"
+             , "Sec-Websocket-Key1"=> "4 @1  46546xW%0l 1 5"
              , "Origin"=> "http://example.com"
            )
   ,body= ""
@@ -384,8 +384,8 @@ const requests = Message[
   ,request_url= "0-home0.netscape.com:443"
   ,num_headers= 2
   ,upgrade="some data\r\nand yet even more data"
-  ,headers=Dict{String,String}( "User-agent"=> "Mozilla/1.1N"
-             , "Proxy-authorization"=> "basic aGVsbG86d29ybGQ="
+  ,headers=Dict{String,String}( "User-Agent"=> "Mozilla/1.1N"
+             , "Proxy-Authorization"=> "basic aGVsbG86d29ybGQ="
            )
   ,body= ""
 ), Message(name= "report request"
@@ -431,9 +431,9 @@ const requests = Message[
   ,request_path= "*"
   ,request_url= "*"
   ,num_headers= 3
-  ,headers=Dict{String,String}( "HOST"=> "239.255.255.250:1900"
-             , "MAN"=> "\"ssdp:discover\""
-             , "ST"=> "\"ssdp:all\""
+  ,headers=Dict{String,String}( "Host"=> "239.255.255.250:1900"
+             , "Man"=> "\"ssdp:discover\""
+             , "St"=> "\"ssdp:all\""
            )
   ,body= ""
 ), Message(name= "host terminated by a query string"
@@ -523,8 +523,8 @@ const requests = Message[
   ,port="443"
   ,num_headers= 2
   ,upgrade=""
-  ,headers=Dict{String,String}( "User-agent"=> "Mozilla/1.1N"
-             , "Proxy-authorization"=> "basic aGVsbG86d29ybGQ="
+  ,headers=Dict{String,String}( "User-Agent"=> "Mozilla/1.1N"
+             , "Proxy-Authorization"=> "basic aGVsbG86d29ybGQ="
            )
   ,body= ""
 ), Message(name= "utf-8 path request"
@@ -559,8 +559,8 @@ const requests = Message[
   ,port="443"
   ,num_headers= 2
   ,upgrade=""
-  ,headers=Dict{String,String}( "User-agent"=> "Mozilla/1.1N"
-             , "Proxy-authorization"=> "basic aGVsbG86d29ybGQ="
+  ,headers=Dict{String,String}( "User-Agent"=> "Mozilla/1.1N"
+             , "Proxy-Authorization"=> "basic aGVsbG86d29ybGQ="
            )
   ,body= ""
 ), Message(name = "eat CRLF between requests, no \"Connection: close\" header"
@@ -694,8 +694,8 @@ const requests = Message[
   ,port="443"
   ,num_headers= 3
   ,upgrade="blarfcicle"
-  ,headers=Dict{String,String}( "User-agent"=> "Mozilla/1.1N"
-             , "Proxy-authorization"=> "basic aGVsbG86d29ybGQ="
+  ,headers=Dict{String,String}( "User-Agent"=> "Mozilla/1.1N"
+             , "Proxy-Authorization"=> "basic aGVsbG86d29ybGQ="
              , "Content-Length"=> "10"
            )
   ,body= ""
@@ -760,10 +760,10 @@ const requests = Message[
   ,upgrade="Hot diggity dogg"
   ,headers=Dict{String,String}( "Host"=> "example.com"
              , "Connection"=> "Something, Upgrade, ,Keep-Alive"
-             , "Sec-WebSocket-Key2"=> "12998 5 Y3 1  .P00"
-             , "Sec-WebSocket-Protocol"=> "sample"
+             , "Sec-Websocket-Key2"=> "12998 5 Y3 1  .P00"
+             , "Sec-Websocket-Protocol"=> "sample"
              , "Upgrade"=> "WebSocket"
-             , "Sec-WebSocket-Key1"=> "4 @1  46546xW%0l 1 5"
+             , "Sec-Websocket-Key1"=> "4 @1  46546xW%0l 1 5"
              , "Origin"=> "http://example.com"
            )
   ,body= ""
@@ -904,7 +904,7 @@ const responses = Message[
     , "Content-Type"=> "text/html; charset=UTF-8"
     , "Date"=> "Sun, 26 Apr 2009 11:11:49 GMT"
     , "Expires"=> "Tue, 26 May 2009 11:11:49 GMT"
-    , "X-\$PrototypeBI-Version"=> "1.6.0.3"
+    , "X-\$prototypebi-Version"=> "1.6.0.3"
     , "Cache-Control"=> "public, max-age=2592000"
     , "Server"=> "gws"
     , "Content-Length"=> "219  "
@@ -1056,7 +1056,7 @@ const responses = Message[
       "Server"=> "DCLK-AdSvr"
     , "Content-Type"=> "text/xml"
     , "Content-Length"=> "0"
-    , "DCLK_imp"=> "v7;x;114750856;0-0;0;17820020;0/0;21603567/21621457/1;;~okv=;dcmt=text/xml;;~cs=o"
+    , "Dclk_imp"=> "v7;x;114750856;0-0;0;17820020;0/0;21603567/21621457/1;;~okv=;dcmt=text/xml;;~cs=o"
   )
   ,body= ""
 ), Message(name= "bonjourmadame.fr"
@@ -1305,9 +1305,9 @@ const responses = Message[
   ,num_headers= 9
   ,headers=Dict{String,String}( "Date"=> "Wed, 15 May 2013 17:06:33 GMT"
              , "Server"=> "Server"
-             , "x-amz-id-1"=> "0GPHKXSJQ826RK7GZEB2"
-             , "p3p"=> "policyref=\"http://www.amazon.com/w3c/p3p.xml\",CP=\"CAO DSP LAW CUR ADM IVAo IVDo CONo OTPo OUR DELi PUBi OTRi BUS PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA HEA PRE LOC GOV OTC \""
-             , "x-amz-id-2"=> "STN69VZxIFSz9YJLbz1GDbxpbjG6Qjmmq5E3DxRhOUw+Et0p4hr7c/Q8qNcx4oAD"
+             , "X-Amz-Id-1"=> "0GPHKXSJQ826RK7GZEB2"
+             , "P3p"=> "policyref=\"http://www.amazon.com/w3c/p3p.xml\",CP=\"CAO DSP LAW CUR ADM IVAo IVDo CONo OTPo OUR DELi PUBi OTRi BUS PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA HEA PRE LOC GOV OTC \""
+             , "X-Amz-Id-2"=> "STN69VZxIFSz9YJLbz1GDbxpbjG6Qjmmq5E3DxRhOUw+Et0p4hr7c/Q8qNcx4oAD"
              , "Location"=> "http://www.amazon.com/Dan-Brown/e/B000AP9DSU/ref=s9_pop_gw_al1?_encoding=UTF8&refinementId=618073011&pf_rd_m=ATVPDKIKX0DER&pf_rd_s=center-2&pf_rd_r=0SHYY5BZXN3KR20BNFAY&pf_rd_t=101&pf_rd_p=1263340922&pf_rd_i=507846"
              , "Vary"=> "Accept-Encoding,User-Agent"
              , "Content-Type"=> "text/html; charset=ISO-8859-1"
@@ -1384,7 +1384,7 @@ const responses = Message[
 
         req = HTTP.Request()
         req.uri = HTTP.URI("http://www.techcrunch.com/")
-        req.headers = Dict("Content-Length"=>"7","Host"=>"www.techcrunch.com","Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8","Accept-Charset"=>"ISO-8859-1,utf-8;q=0.7,*;q=0.7","Proxy-Connection"=>"keep-alive","Accept-Language"=>"en-us,en;q=0.5","Keep-Alive"=>"300","User-Agent"=>"Fake","Accept-Encoding"=>"gzip,deflate")
+        req.headers = HTTP.Headers("Content-Length"=>"7","Host"=>"www.techcrunch.com","Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8","Accept-Charset"=>"ISO-8859-1,utf-8;q=0.7,*;q=0.7","Proxy-Connection"=>"keep-alive","Accept-Language"=>"en-us,en;q=0.5","Keep-Alive"=>"300","User-Agent"=>"Fake","Accept-Encoding"=>"gzip,deflate")
 
         @test HTTP.parse(HTTP.Request, reqstr) == req
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -9,9 +9,12 @@
 
 @test HTTP.status(HTTP.Response(300)) == 300
 @test String(HTTP.body(HTTP.Response("hello world"))) == "hello world"
-@test HTTP.status(HTTP.Response(300, Dict{String,String}(), "")) == 300
+@test HTTP.status(HTTP.Response(300, HTTP.Headers(), "")) == 300
 
 @test HTTP.Response(200) == HTTP.Response(200)
+@test HTTP.Response(300, HTTP.Headers(), "") == HTTP.Response(300, Dict{String,String}(), "")
+
+@test_throws ErrorException HTTP.Response(200, Dict("redundant" => "1", "Redundant" => "2"), "")
 
 io = IOBuffer()
 show(io, HTTP.Response(200))
@@ -25,5 +28,4 @@ show(io, HTTP.Request())
 
 showcompact(io, HTTP.Request())
 @test String(take!(io)) == "Request(\"\", 0 headers, 0 bytes in body)"
-
 end


### PR DESCRIPTION
Makes Header keys case-insensitive. Motivated by http libs in other
languages and https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2.

I haven't worked much with the current iteration of the type system or the new String type -- open to any hints.

I was surprised there wasn't something in place already. I thought of two approaches:

- custom subtype of `Associative` with feature parity w/ `Dict` (undertaken here)
- custom subtype of `AbstractString`

The custom string method would be more pervasively efficient (e.g. skip canonization when manually inserting keys that were previously in a Headers object), but I shied away from it for a couple reasons:

-  for automatic conversion on Dict insert, `CanonicalHeaderKey(s) == s` would have to hold
- ordering would have to disagree with ordering of the underlying `Char`s
- wasn't sure how subtle or involved getting feature parity with `String` would be
- `AbstractString` isn't as widely accepted as String, or as it should be

If you'd go the other way, I'd love to hear more.

Where I wasn't sure about implementation, I took inspiration from Go's 'net' suite of packages. Main thing I noticed there and didn't add is a global store of common header keys. I'm guessing the cost of `String(v::Vector{UInt8})` is noticeable since I've seen optimizations for common headers elsewhere. Didn't want to get that involved before this made it in.

I also left the values strings rather than vectors. I haven't used both enough to have useful opinions there. For the use case where someone wants so say, send two different cookies each including commas, manually reaching into the dict (via `header.d`) seems like a convenient-enough escape hatch.

N.b. I hit #60 in local testing.