### PR TITLE
Avoid early EOF

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -866,6 +866,7 @@ function parse!(r::Union{Request, Response}, parser, bytes, len=length(bytes);
                             @err(HPE_BODY_OVERFLOW)
                         end
                         parser.content_length = t
+                        r.body.expectedlength = Int64(t)
                      end
 
                 #= Transfer-Encoding: chunked =#

--- a/test/fifobuffer.jl
+++ b/test/fifobuffer.jl
@@ -202,18 +202,20 @@
     # Ensure that we don't encounter an EOF when reading before data is written
     f = HTTP.FIFOBuffer(5)
     bytes = [0x01, 0x02, 0x03, 0x04]
-    write(f, bytes)
+    @test eof(f)
+    f.expectedlength = length(bytes)  # We know how many bytes there are to read before EOF
     @test !eof(f)
     @sync begin
         @async begin
             bytes_read = UInt8[]
             while !eof(f)
-                println("reading byte...")
                 push!(bytes_read, read(f, UInt8))
             end
             @test bytes_read == bytes
         end
-        close(f)
+        yield()
+        write(f, bytes)
     end
+    close(f)
     @test eof(f)
 end; # testset


### PR DESCRIPTION
Fix #45. When we get a Content-Length header, set the resulting FIFOBuffer's expectedlength field to ensure we don't get an early eof in cases where we're streaming responses.

cc: @omus 

This is mostly the same PR as #49, but I wanted to try to implement from scratch to ensure I fully understood the issues. I made a few changes, like when we set the `expectedlength` field (in the parser itself, we track the content-length header, so we piggy back on that).

Overall I'm on board with this, and my original hesitation of "ruining the FIFOBuffer" type by tying it too close to HTTP is assuaged; this is a natural operation to expect w/ a type like FIFOBuffer where things can be read/written simultaneously. You want a way to "set" an expected length.