### PR TITLE
Add an abstract type Handler, and Routing capabilties

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -31,6 +31,8 @@ include("multipart.jl")
 include("types.jl")
 include("parser.jl")
 include("client.jl")
+include("handlers.jl")
+using .Handlers
 include("server.jl")
 
 end # module

--- a/src/client.jl
+++ b/src/client.jl
@@ -99,6 +99,7 @@ function request(client::Client, method, uri::URI;
                     verbose::Bool=false,
                     args...)
     opts = RequestOptions(; args...)
+    not(opts.tlsconfig) && (opts.tlsconfig = TLS.SSLConfig(true))
     not(client.logger) && (client.logger = STDOUT)
     client.logger != STDOUT && (verbose = true)
     req = Request(method, uri, headers, body; options=opts, verbose=verbose, io=client.logger)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -1,0 +1,117 @@
+module Handlers
+
+export handle, Handler, HandlerFunction, Router, register!
+
+using HTTP
+
+function handle end
+handle(handler, req, resp, vals...) = handle(handler, req, resp)
+
+abstract type Handler end
+
+struct HandlerFunction{F <: Function} <: Handler
+    func::F # func(req, resp)
+end
+
+handle(h::HandlerFunction, req, resp) = h.func(req, resp)
+
+const FourOhFour = HandlerFunction((req, resp) -> Response(404))
+
+"""
+
+A Router maps urls/paths to Handlers.
+
+/     f(m, s, h, args...)                              # default mapping, matches all requests, returns 404
+/api  f(::Val{:api}, args...)
+/api/social  f(::Val{:api}, ::Val{:social}, args...)
+/api/social/v4
+/api/social/v4/alerts
+/api/social/v4/alerts/*  f(::Val{:api}, ::Val{:social}, ::Val{:v4}, ::Val{:alerts}, ::Any)
+/api/social/v4/alerts/1/evaluate
+
+/test  f(::Val{:test})
+/test/{var::String}  f(::Val{:test}, ::Any)  
+/test/sarv/ghotra    f(::Val{:test}, ::Val{:sarv}, ::Val{:ghotra})
+
+scheme, subdomain, host, method, path
+
+"""
+struct Router <: Handler
+    segments::Dict{String, Val}
+    sym::Symbol
+    func::Function
+    function Router(ff::Union{Handler, Function, Void}=nothing)
+        sym = gensym()
+        if ff == nothing
+            f = @eval $sym(args...) = FourOhFour
+        else
+            f = ff isa Function ? HandlerFunction(ff) : ff
+        end
+        r = new(Dict{String, Val}(), sym, f)
+        return r
+    end
+end
+
+const SCHEMES = Dict{String, Val}("http" => Val(:http), "https" => Val(:https))
+const METHODS = Dict{String, Val}()
+for m in instances(HTTP.Method)
+    METHODS[string(m)] = Val(Symbol(m))
+end
+const EMPTYVAL = Val(())
+
+register!(r::Router, url, handler) = register!(r, "", url, handler)
+register!(r::Router, m::Method, url, handler) = register!(r, string(m), url, handler)
+
+function register!(r::Router, method::String, url, handler)
+    m = isempty(method) ? Any : typeof(METHODS[method])
+    # get scheme, host, split path into strings & vals
+    uri = url isa String ? HTTP.URI(url) : url
+    s = HTTP.scheme(uri)
+    sch = HTTP.hasscheme(uri) ? typeof(get!(SCHEMES, s, Val(s))) : Any
+    h = HTTP.hashostname(uri) ? Val{Symbol(HTTP.hostname(uri))} : Any
+    hand = handler isa Function ? HandleFunction(handler) : handler
+    register!(r, m, sch, h, HTTP.path(uri), hand)
+end
+
+function splitsegments(r::Router, h::Handler, segments)
+    vals = Expr[]
+    for s in segments
+        if s == "*" #TODO: or variable, keep track of variable types and store in handler
+            T = Any
+        else
+            v = Val(Symbol(s))
+            r.segments[s] = v
+            T = typeof(v)
+        end
+        push!(vals, Expr(:(::), T))
+    end
+    return vals
+end
+
+function register!(r::Router, method::DataType, scheme, host, path, handler)
+    # save string => Val mappings in r.segments
+    segments = map(String, split(path, '/'; keep=false))
+    vals = splitsegments(r, handler, segments)
+    # return a method to get dispatched to
+    #TODO: detect whether defining this method will create ambiguity?
+    @eval $(r.sym)(::$method, ::$scheme, ::$host, $(vals...), args...) = $handler
+    return
+end
+
+function handle(r::Router, req, resp)
+    # get the url/path of the request
+    m = Val(HTTP.method(req))
+    uri = HTTP.uri(req)
+    # get scheme, host, split path into strings and get Vals
+    s = get(SCHEMES, HTTP.scheme(uri), EMPTYVAL)
+    h = Val(Symbol(HTTP.hostname(uri)))
+    p = HTTP.path(uri)
+    segments = split(p, '/'; keep=false)
+    # dispatch to the most specific handler, given the path
+    vals = (get(r.segments, s, EMPTYVAL) for s in segments)
+    handler = r.func(m, s, h, vals...)
+    # pass the request & response to the handler and return
+    return handle(handler, req, resp, vals...)
+end
+
+end # module

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -1,0 +1,48 @@
+reload("HTTP")
+using Base.Test
+
+@testset "HTTP.Handler" begin
+
+f = HTTP.HandlerFunction((req, resp) -> HTTP.Response(200))
+@test HTTP.handle(f, HTTP.Request(), HTTP.Response()) == HTTP.Response(200)
+
+r = HTTP.Router()
+@test length(methods(r.func)) == 1
+@test HTTP.handle(r, HTTP.Request(), HTTP.Response()) == HTTP.Response(404)
+
+HTTP.register!(r, "/path/to/greatness", f)
+@test length(methods(r.func)) == 2
+req = HTTP.Request()
+req.uri = HTTP.URI("/path/to/greatness")
+@test HTTP.handle(r, req, HTTP.Response()) == HTTP.Response(200)
+
+p = "/next/path/to/greatness"
+f2 = HTTP.HandlerFunction((req, resp) -> HTTP.Response(201))
+HTTP.register!(r, p, f2)
+@test length(methods(r.func)) == 3
+req = HTTP.Request()
+req.uri = HTTP.URI("/next/path/to/greatness")
+@test HTTP.handle(r, req, HTTP.Response()) == HTTP.Response(201)
+
+r = HTTP.Router()
+HTTP.register!(r, "/test", f)
+HTTP.register!(r, "/test/*", f2)
+f3 = HTTP.HandlerFunction((req, resp) -> HTTP.Response(202))
+HTTP.register!(r, "/test/sarv/ghotra", f3)
+f4 = HTTP.HandlerFunction((req, resp) -> HTTP.Response(203))
+HTTP.register!(r, "/test/*/ghotra/seven", f4)
+
+req = HTTP.Request()
+req.uri = HTTP.URI("/test")
+@test HTTP.handle(r, req, HTTP.Response()) == HTTP.Response(200)
+
+req.uri = HTTP.URI("/test/sarv")
+@test HTTP.handle(r, req, HTTP.Response()) == HTTP.Response(201)
+
+req.uri = HTTP.URI("/test/sarv/ghotra")
+@test HTTP.handle(r, req, HTTP.Response()) == HTTP.Response(202)
+
+req.uri = HTTP.URI("/test/sar/ghotra/seven")
+@test HTTP.handle(r, req, HTTP.Response()) == HTTP.Response(203)
+
+end


### PR DESCRIPTION
A Server uses a `Handler` to handle requests/responses. Includes implementations for `HandlerFunction` which just wraps a function of the form `f(request, response) => Response`, and `Router`, which can register mappings for method/scheme/host/paths to specific handlers.

This is a pretty decent baseline for routing capabilities. I took a decent amount of inspiration from goLang's basic routing functionalities, and sprinkled some good julia dispatch on the problem and I like how simple the implementation is.

I need to add some more docs here too before merging.