### PR TITLE
Warning for new users about precompile problems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ julia> Pkg.add("HTTP")
 
 The package is tested against Julia 0.6 & current master on Linux, OS X, and Windows.
 
+## Known Limitations
+
+- The first HTTP request may be delayed up to 5 seconds [due to precompilation issues](https://discourse.julialang.org/t/package-compilation-woes/5658).
+
 ## Contributing and Questions
 
 Contributions are very welcome, as are feature requests and suggestions. Please open an


### PR DESCRIPTION
Hi @quinnj,

It might be a good idea to say something on README.md about the start-up delay.
For some of my HTTP.jl use-cases it's a show-stopper, but for others, it makes no difference at all because there are other packages that already take a long time to start up.