### PR TITLE
add escaping for symbols

### DIFF
--- a/src/uri.jl
+++ b/src/uri.jl
@@ -173,6 +173,7 @@ escape(str::AbstractString, safe::Function=issafe) =
 
 escape(bytes::Vector{UInt8}) = bytes
 escape(v::Number) = escape(string(v))
+escape(v::Symbol) = escape(string(v))
 escape(v::Nullable) = Base.isnull(v) ? "" : escape(get(v))
 
 escape(key, value) = string(escape(key), "=", escape(value))


### PR DESCRIPTION
Fixes an error when using symbols as keys in Dicts passed to HTTP.