### PR TITLE
Allow any Associative as a header

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -365,7 +365,7 @@ request(client::Client, req::Request;
 
 # build Request
 function request(client::Client, method, uri::URI;
-                 headers::Dict=Headers(),
+                 headers::Associative=Headers(),
                  body=FIFOBuffers.EMPTYBODY,
                  stream::Bool=false,
                  verbose::Bool=false,
@@ -408,7 +408,7 @@ an `IOBuffer` for in-memory data, or even an `HTTP.FIFOBuffer`. For complete con
 
 Additional keyword arguments supported, include:
 
-  * `headers::Dict`: headers given as Dict to be sent with the request
+  * `headers::Associative`: headers given as Dict to be sent with the request
   * `body`: a request body can be given as a `String`, `Vector{UInt8}`, `IO`, `HTTP.FIFOBuffer` or `Dict`; see example below for how to utilize `HTTP.FIFOBuffer` for "streaming" request bodies; a `Dict` argument will be converted to a multipart form upload
   * `stream::Bool=false`: enable response body streaming; depending on the response body size, the request will return before the full body has been received; as the response body is read, additional bytes will be recieved and put in the response body. Readers should read until `eof(response.body) == true`; see below for an example of response streaming
   * `chunksize::Int`: if a request body is larger than `chunksize`, the "chunked-transfer" http mechanism will be used and chunks will be sent no larger than `chunksize`; default = `nothing`

--- a/src/client.jl
+++ b/src/client.jl
@@ -324,7 +324,7 @@ function request(client::Client, req::Request, opts::RequestOptions, stream::Boo
     # maybe allow retrying for all kinds of errors?
     p = port(u)
     conn = @retryif ClosedError 4 connectandsend(client, sch, host, ifelse(p == "", "80", p), req, opts, verbose)
-    
+
     response = Response(stream ? 2^24 : FIFOBuffers.DEFAULT_MAX, req)
     reset!(conn.parser)
     success, err = processresponse!(client, conn, response, host, HTTP.method(req), current_task(), stream, opts.readtimeout::Float64, opts.canonicalizeheaders::Bool, verbose)
@@ -346,7 +346,7 @@ function request(client::Client, req::Request, opts::RequestOptions, stream::Boo
     end
 end
 
-request(req::Request; 
+request(req::Request;
             opts::RequestOptions=RequestOptions(),
             stream::Bool=false,
             history::Vector{Response}=Response[],
@@ -443,7 +443,7 @@ Access-Control-Allow-Origin: *
 Server: meinheld/0.6.1
 Content-Length: 32
 
-{ 
+{
   "origin": "50.207.241.62"
 }
 \"\"\"

--- a/src/types.jl
+++ b/src/types.jl
@@ -136,9 +136,9 @@ defaultheaders(::Type{Request}) = Headers(
     "User-Agent" => "HTTP.jl/0.0.0",
     "Accept" => "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json; charset=utf-8"
 )
-makeheaders(d::Dict) = Headers((string(k), string(v)) for (k, v) in d)
+makeheaders(d::Associative) = Headers((string(k), string(v)) for (k, v) in d)
 
-function Request(m::HTTP.Method, uri::URI, userheaders::Dict, b;
+function Request(m::HTTP.Method, uri::URI, userheaders::Associative, b;
                     options::RequestOptions=RequestOptions(),
                     verbose::Bool=false,
                     logger::Option{IO}=STDOUT)


### PR DESCRIPTION
Allows alternative `Dict` types such as `PyCall.PyDict` to be used as a header.