### PR TITLE
Remove MicroLogging

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -11,8 +11,6 @@ else # Julia v0.6
     pairs(x) = [k => v for (k,v) in x]
 
     Base.SubString(s) = SubString(s, 1)
-
-    using MicroLogging
 end
 
 macro uninit(expr)


### PR DESCRIPTION
Servers.jl makes use of `@info`, `@warn` and `@error` macros, which are not supported on v0.6. 

We tried adding some macros to compat.jl, but I was still having trouble on Windows, so I added MicroLogging, which got merged and seemed ok.

However, subsequently, I found MicroLogging was wreaking havoc on stdout to REPL (on Windows) so this PR changes all uses of `@info`, `@warn` and `@error` macros to the v0.6 compatible `info`, `warn` and `error` methods.