### PR TITLE
Modify testget

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -11,8 +11,6 @@ else # Julia v0.6
     pairs(x) = [k => v for (k,v) in x]
 
     Base.SubString(s) = SubString(s, 1)
-
-    using MicroLogging
 end
 
 macro uninit(expr)


### PR DESCRIPTION
This is (maybe) a slight improvement to `testget`. 

The prior version wrote the output of `curl` to a temp file and then searched the file for `"HTTP/1.1 200 OK"`. This version just extracts the status of `curl` directly from a `Pipe()` so no tmp file is create AND it avoids the use of `bash`, which is problematic on Windows.

The output of the new `testget` is just a string representing the status, e.g. `"200"`. I added a second argument to `testget` for the number of repeated urls you want to call with the single call to `curl`. For example, if `n = 3`, it will call `curl` with the url repeated three times and the output of the function for a successful call would be `"200200200", i.e. the status for each url is appended as strings. 

Not very pretty, but I hope it is ok.