### PR TITLE
Allow HEAD to redirect, but default to it not

### DIFF
--- a/src/RedirectRequest.jl
+++ b/src/RedirectRequest.jl
@@ -19,7 +19,7 @@ export RedirectLayer
 
 function request(::Type{RedirectLayer{Next}},
                  method::String, url::URI, headers, body;
-                 redirect_limit=3, forwardheaders=false, kw...) where Next
+                 redirect_limit=method=="HEAD" ? 0 : 3, forwardheaders=false, kw...) where Next
     count = 0
     while true
     
@@ -27,8 +27,7 @@ function request(::Type{RedirectLayer{Next}},
 
         if (count == redirect_limit
         ||  !isredirect(res)
-        ||  (location = header(res, "Location")) == ""
-        ||  method == "HEAD") #FIXME why not redirect HEAD?
+        ||  (location = header(res, "Location")) == "")
             return res
         end
             


### PR DESCRIPTION
Right now, if you are doing a `HEAD` request redirects are never followed.
but they are for `GET` and all other methods.

My [reading of the spec ](https://tools.ietf.org/html/rfc2616#section-10.3)
is that HEAD and GET are both allowed to follow redirects.
though I understand why maybe one would not want to with HEAD since you could be looking to check if there was a redirect going on or some other header information at that point.

So the way I made it possible to have it both ways (and not change behaviour (much))
is to make using the HEAD method set the default value of  maxredirects to 0, 
rather than blocking redirects directly.
I thinking any user setting `maxredirects` to any value (other than 0 themselves) when using HEAD, clearly does want redirects to happen.


This needs tests and docs, but I wanted to put it forward for discussion before I took it any further