### PR TITLE
Get rid of "precompiling..." message

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,6 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
-    println("Precompiling...")
 #    @assert precompile(HTTP.request, (String, String,))
 #    @assert precompile(HTTP.request, (String, URI, Headers, Vector{UInt8},))
 #=


### PR DESCRIPTION
This one usually comes with zero context:

```jl
julia> using FemtoCleaner
INFO: Recompiling stale cache file /Users/kristoffer/.julia/lib/v0.6/MbedTLS.ji for module MbedTLS.
INFO: Recompiling stale cache file /Users/kristoffer/.julia/lib/v0.6/GitHub.ji for module GitHub.
Precompiling... # Wut?
INFO: Recompiling stale cache file /Users/kristoffer/.julia/lib/v0.6/CSTParser.ji for module CSTParser.
INFO: Recompiling stale cache file /Users/kristoffer/.julia/lib/v0.6/Revise.ji for module Revise.
```