### PR TITLE
export handle_request

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -1,6 +1,6 @@
 module Handlers
 
-export handle, gethandler, Handler, HandlerFunction, Router, register!
+export handle, gethandler, handle_request, Handler, HandlerFunction, Router, register!
 
 import ..Nothing, ..Cvoid, ..Val
 
@@ -141,6 +141,6 @@ function handle(r::Router, req)
     return handle(handler, req)
 end
 
-handle(hf::HandlerFunction, http::HTTP.Stream) = HTTP.handle_request(hf.func,http)
+handle_request(f::Function, http::HTTP.Stream) = HTTP.Servers.handle_request(f, http)
 
 end # module


### PR DESCRIPTION
Hi @samoconnor 👋 

Thanks for merging my PR 👍 

There was one change you reverted and suggested a neat trick in this comment ( https://github.com/JuliaWeb/HTTP.jl/pull/159#issuecomment-359580010 )

> Re:
```
            handler = HTTP.gethandler(router,http.message)
            HTTP.handle(handler,http)
```
> Why not do this ?
```
            HTTP.handle_request(http) do request::HTTP.Request
                HTTP.handle(router, request)
            end
```

This works for me, but I can't do it precisely like that because `handle_request` is not exported from `Servers`. I would need to make that

```
            HTTP.Servers.handle_request(http) do request::HTTP.Request
                HTTP.handle(router, request)
            end
```

which is not very appealing to me aesthetically so this PR just exports `handle_request` from `Servers` and uses it in `HTTP` so we can call it with `HTTP.handle_request` as suggested.

HOWEVER...

I actually like my original approach better, i.e. rename

`HTTP.handle_request`

to

`HTTP.handle`

This makes sense to me. It is nice to have an easily accessible method that handles streams AND it avoids the need to export `handle_request` because `handle` is already exported.

Then your solution would be

```
            HTTP.handle(http) do request::HTTP.Request
                HTTP.handle(router, request)
            end
```

THAT ☝️  looks very pretty to me. Any reason you don't like it?

If you are ok, I'd prefer to close this PR and submit a new one that changes `HTTP.handle_request` to `HTTP.handle`.

What do you think?