### PR TITLE
Remove assertion which breaks under Mocking

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -612,7 +612,6 @@ end
 
 
 const STATUS_MESSAGES = (()->begin
-    @assert ccall(:jl_generating_output, Cint, ()) == 1
     v = fill("Unknown Code", 530)
     v[100] = "Continue"
     v[101] = "Switching Protocols"


### PR DESCRIPTION
When this package is used while Mocking.jl is enabled, the assertion throws. I don't think it's actually necessary; can it be removed?