### PR TITLE
Fix and improve Dates.format calls

### DIFF
--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -55,8 +55,8 @@ function sign_aws4!(method::String,
 
 
     # ISO8601 date/time strings for time of request...
-    date = Dates.format(t,"yyyymmdd")
-    datetime = Dates.format(t,"yyyymmddTHHMMSSZ")
+    date = Dates.format(t, dateformat"yyyymmdd")
+    datetime = Dates.format(t, dateformat"yyyymmddTHHMMSS\Z")
 
     # Authentication scope...
     scope = [date, aws_region, aws_service, "aws4_request"]


### PR DESCRIPTION
1. Escaped 'Z' as it has a special meaning when TimeZones is loaded (and the code errors)
2. Used the `dateformat` string macro to avoid compiling the date format every time the function is called