### PR TITLE
Add a few more deprecations/cleanups in preparation for a new tag

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -8,6 +8,9 @@ import MbedTLS: SSLContext
 
 const DEBUG_LEVEL = 0
 
+Base.@deprecate escape escapeuri
+Base.@deprecate URL URI
+
 include("compat.jl")
 include("debug.jl")
 
@@ -23,6 +26,7 @@ include("Parsers.jl")                  ;import .Parsers: Parser, Headers, Header
                                                          ParsingError, ByteView
 include("ConnectionPool.jl")
 include("Messages.jl")                 ;using .Messages
+
 include("Streams.jl")                  ;using .Streams
 
 
@@ -578,6 +582,7 @@ include("client.jl")
 include("sniff.jl")
 include("Handlers.jl")                 ;using .Handlers
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
+Base.@deprecate_binding(Nitrogen, Servers, false)
 
 include("WebSockets.jl")               ;using .WebSockets
 

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -60,7 +60,7 @@ Streaming of request and response bodies is handled by the
 module Messages
 
 export Message, Request, Response, HeaderSizeError,
-       reset!,
+       reset!, status, method, headers, uri, body,
        iserror, isredirect, ischunked, issafe, isidempotent,
        header, hasheader, setheader, defaultheader, appendheader,
        mkheaders, readheaders, headerscomplete, readtrailers, writeheaders,
@@ -139,6 +139,9 @@ function reset!(r::Response)
     end
 end
 
+status(r::Response) = r.status
+headers(r::Response) = r.headers
+body(r::Response) = r.body
 
 """
     Request <: Message
@@ -196,6 +199,11 @@ Request(bytes) = parse(Request, bytes)
 
 mkheaders(h::Headers) = h
 mkheaders(h)::Headers = Header[string(k) => string(v) for (k,v) in h]
+
+method(r::Request) = r.method
+uri(r::Request) = r.target
+headers(r::Request) = r.headers
+body(r::Request) = r.body
 
 """
     issafe(::Request)

--- a/src/fifobuffer.jl
+++ b/src/fifobuffer.jl
@@ -1,6 +1,7 @@
 module FIFOBuffers
 
 import ..bytesavailable
+import ..bytes
 using ..IOExtras
 import Base.==
 
@@ -87,6 +88,7 @@ FIFOBuffer(io::IO) = FIFOBuffer(readavailable(io))
 ==(a::FIFOBuffer, b::FIFOBuffer) = String(a) == String(b)
 Base.length(f::FIFOBuffer) = f.nb
 bytesavailable(f::FIFOBuffer) = f.nb
+bytes(f::FIFOBuffer) = readavailable(f)
 Base.wait(f::FIFOBuffer) = wait(f.cond)
 Base.read(f::FIFOBuffer) = readavailable(f)
 Base.flush(f::FIFOBuffer) = nothing


### PR DESCRIPTION
I pulled almost all of the current HTTP.jl downstream packages and tried to run through their tests to see what would potentially break w/ a new HTTP.jl back. Fortunately, there _isn't_ a ton of breakage out there, so I think w/ this PR, we should be good to go for a new tag. GitHub.jl is the most extensive user and I got most of the way through a PR for the changes they'd need.

Anyway, heading to bed for now, but let's see what CI says and hopefully tag in the morning.