### PR TITLE
unuriescape basic auth before setting the header

### DIFF
--- a/src/BasicAuthRequest.jl
+++ b/src/BasicAuthRequest.jl
@@ -20,7 +20,7 @@ export BasicAuthLayer
 function request(::Type{BasicAuthLayer{Next}},
                  method::String, url::URI, headers, body; kw...) where Next
 
-    userinfo = url.userinfo
+    userinfo = unescapeuri(url.userinfo)
     
     if !isempty(userinfo) && getkv(headers, "Authorization", "") == ""
         @debug 1 "Adding Authorization: Basic header."


### PR DESCRIPTION
RFC3986 specifies
```
userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
```
Meaning userinfo can be percent encoded (e.g. if the password contains an `@`).
Strip the encoding here before putting it in the header.