### PR TITLE
Rename is_websocket_upgrade -> is_upgrade

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -56,7 +56,7 @@ end
 
 # Handshake
 
-is_websocket_upgrade(r::HTTP.Message) =
+is_upgrade(r::HTTP.Message) =
     (r isa HTTP.Request && r.method == "GET" || r.status == 101) &&
     HTTP.hasheader(r, "Connection", "upgrade") &&
     HTTP.hasheader(r, "Upgrade", "websocket")

--- a/test/WebSockets.jl
+++ b/test/WebSockets.jl
@@ -19,15 +19,13 @@ for s in ["ws", "wss"]
         buf = IOBuffer()
         write(buf, io)
         @test String(take!(buf)) == "Hello There World!"
-
-        close(io)
     end
 
 end
 
 p = UInt16(8000)
 @async HTTP.listen("127.0.0.1",p) do http
-    if HTTP.WebSockets.is_websocket_upgrade(http.message)
+    if HTTP.WebSockets.is_upgrade(http.message)
         HTTP.WebSockets.upgrade(http) do ws
             while !eof(ws)
                 data = readavailable(ws)


### PR DESCRIPTION
This is just cosmetic. Since `is_websocket_upgrade` is not exported, we will always call it as `WebSockets.is_websocket_upgrade`. That seems slightly redundant to me.

I think `WebSockets.is_upgrade` is already clear enough. Not a big deal 😊 