### PR TITLE
Fix is_upgrade when checking a POST request

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -56,10 +56,11 @@ end
 
 # Handshake
 
-is_upgrade(r::HTTP.Message) =
-    (r isa HTTP.Request && r.method == "GET" || r.status == 101) &&
+function is_upgrade(r::HTTP.Message)
+    ((r isa HTTP.Request && r.method == "GET") || (r isa HTTP.Response && r.status == 101)) &&
     HTTP.hasheader(r, "Connection", "upgrade") &&
     HTTP.hasheader(r, "Upgrade", "websocket")
+end
 
 
 function check_upgrade(http)


### PR DESCRIPTION
I was getting ready to tag a new version of Pages and noticed that POST request was failing.

This line

```julia
 (r isa HTTP.Request && r.method == "GET" || r.status == 101)
```
checks to see if a `Requet` is a `GET` and if not, it checks whether the `status` is 101, but `status` is not a property of a `Request`. It is only a property of a `Response`, so if this line receives a POST request, it fails because their is no property `status` in the POST `Request`.