### PR TITLE
proxy= option

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -488,6 +488,15 @@ end
 function getconnection(::Type{SSLContext},
                        host::AbstractString,
                        port::AbstractString;
+                       kw...)::SSLContext
+
+    port = isempty(port) ? "443" : port
+    @debug 2 "SSL connect: $host:$port..."
+    tcp = getconnection(TCPSocket, host, port; kw...)
+    return sslconnection(tcp, host; kw...)
+end
+
+function sslconnection(tcp::TCPSocket, host::AbstractString;
                        require_ssl_verification::Bool=true,
                        sslconfig::SSLConfig=nosslconfig,
                        kw...)::SSLContext
@@ -496,14 +505,19 @@ function getconnection(::Type{SSLContext},
         sslconfig = global_sslconfig(require_ssl_verification)
     end
 
-    port = isempty(port) ? "443" : port
-    @debug 2 "SSL connect: $host:$port..."
     io = SSLContext()
     setup!(io, sslconfig)
-    associate!(io, getconnection(TCPSocket, host, port; kw...))
+    associate!(io, tcp)
     hostname!(io, host)
     handshake!(io)
     return io
+end
+
+function sslupgrade(t::Transaction{TCPSocket},
+                    host::AbstractString; kw...)::Transaction{SSLContext}
+    tls = sslconnection(t.c.io, host; kw...)
+    c = Connection(tls)
+    return client_transaction(c)
 end
 
 function Base.show(io::IO, c::Connection)

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -23,18 +23,47 @@ abstract type ConnectionPoolLayer{Next <: Layer} <: Layer end
 export ConnectionPoolLayer
 
 function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
+                 proxy=nothing,
                  socket_type::Type=TCPSocket, kw...) where Next
+
+    if proxy != nothing
+        target_url = url
+        url = URI(proxy)
+        if target_url.scheme == "http"
+            req.target = string(target_url)
+        end
+    end
 
     IOType = ConnectionPool.Transaction{sockettype(url, socket_type)}
     io = getconnection(IOType, url.host, url.port; kw...)
 
     try
+
+        if proxy != nothing && target_url.scheme == "https"
+            target = "$(URIs.hoststring(target_url.host)):$(target_url.port)"
+            @debug 1 "📡  CONNECT HTTPS tunnel to $target"
+            r = Request("CONNECT", target)
+            writeheaders(io, r)
+            startread(io)
+            readheaders(io, r.response)
+            if r.response.status != 200
+                return r
+            end
+            io = ConnectionPool.sslupgrade(io, target_url.host; kw...)
+        end
+
         return request(Next, io, req, body; kw...)
+
     catch e
         @debug 1 "❗️  ConnectionLayer $e. Closing: $io"
         close(io)
         rethrow(isioerror(e) ? IOError(e, "during request($url)") : e)
+    finally
+        if proxy != nothing && target_url.scheme == "https"
+            close(io)
+        end
     end
+
 end
 
 sockettype(url::URI, default) = url.scheme in ("wss", "https") ? SSLContext : default

--- a/src/MessageRequest.jl
+++ b/src/MessageRequest.jl
@@ -23,7 +23,6 @@ function request(::Type{MessageLayer{Next}},
                  method::String, url::URI, headers::Headers, body;
                  http_version=v"1.1",
                  target=resource(url),
-                 proxy=nothing,
                  parent=nothing, iofunction=nothing, kw...) where Next
 
     defaultheader(headers, "Host" => url.host)
@@ -37,11 +36,6 @@ function request(::Type{MessageLayer{Next}},
         elseif method == "GET" && iofunction isa Function
             setheader(headers, "Content-Length" => "0")
         end
-    end
-
-    if proxy != nothing
-        target = string(url)
-        url = URI(proxy)
     end
 
     req = Request(method, target, headers, bodybytes(body);

--- a/src/MessageRequest.jl
+++ b/src/MessageRequest.jl
@@ -23,6 +23,7 @@ function request(::Type{MessageLayer{Next}},
                  method::String, url::URI, headers::Headers, body;
                  http_version=v"1.1",
                  target=resource(url),
+                 proxy=nothing,
                  parent=nothing, iofunction=nothing, kw...) where Next
 
     defaultheader(headers, "Host" => url.host)
@@ -36,6 +37,11 @@ function request(::Type{MessageLayer{Next}},
         elseif method == "GET" && iofunction isa Function
             setheader(headers, "Content-Length" => "0")
         end
+    end
+
+    if proxy != nothing
+        target = string(url)
+        url = URI(proxy)
     end
 
     req = Request(method, target, headers, bodybytes(body);


### PR DESCRIPTION
This supports plain old proxying of HTTP requests, and CONNECT tunnelling of HTTPS requests.
See #218 
Needs tests.