### PR TITLE
Add a missing import for `sprintcompact` to RetryRequest

### DIFF
--- a/src/RetryRequest.jl
+++ b/src/RetryRequest.jl
@@ -6,7 +6,7 @@ using ..Sockets
 using ..IOExtras
 using ..MessageRequest
 using ..Messages
-import ..@debug, ..DEBUG_LEVEL
+import ..@debug, ..DEBUG_LEVEL, ..sprintcompact
 
 """
     request(RetryLayer, ::URI, ::Request, body) -> HTTP.Response


### PR DESCRIPTION
Currently an `UndefVarError` is emitted when debugging is enabled.