### PR TITLE
Fix documentation to say HTTP.setstatus/HTTP.setheader

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -1,7 +1,7 @@
 __precompile__()
 module HTTP
 
-export startwrite, startread, closewrite, closeread
+export startwrite, startread, closewrite, closeread, setstatus, setheader
 
 using MbedTLS
 import MbedTLS: SSLContext


### PR DESCRIPTION
I was unable to run the example from the manual, and it turns out that setheader/setstatus are not exported.   This PR just adds these methods to the export statement.

From the manual:
```
    HTTP.listen() do http::HTTP.Stream
        @show http.message
        @show HTTP.header(http, "Content-Type")
        while !eof(http)
            println("body data: ", String(readavailable(http)))
        end
        setstatus(http, 404)
        setheader(http, "Foo-Header" => "bar")
        startwrite(http)
        write(http, "response body")
        write(http, "more response body")
    end
```

Error message without this PR:
```
I- Accept:  🔗    0↑     0↓    127.0.0.1:8081:0 ≣16
http.message = HTTP.Messages.Request:
"""
GET / HTTP/1.1
Host: localhost:8081
User-Agent: curl/7.58.0
Accept: */*

"""
HTTP.header(http, "Content-Type") = ""
E- UndefVarError(:setstatus)
|  catch_stacktrace() = StackFrame[(::##1#2)(::HTTP.Streams.Stream{HTTP.Messages.Request,HTTP.ConnectionPool.Transaction{TCPSocket}}) at REPL[2]:7, handle_stream(::##1#2, ::HTTP.Streams.Stream{HTTP.Messages.Request,HTTP.ConnectionPool.Transaction{TCPSocket}}) at Servers.jl:446, (::HTTP.Servers.##46#47{##1#2,HTTP.ConnectionPool.Transaction{TCPSocket},HTTP.Streams.Stream{HTTP.Messages.Request,HTTP.ConnectionPool.Transaction{TCPSocket}}})() at task.jl:335]
I- Closed:  💀    1↑     1↓🔒   127.0.0.1:8081:0 ≣16
```