### PR TITLE
fix serialization with precompilation

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -54,7 +54,7 @@ struct Router <: Handler
     function Router(ff::Union{Handler, Function, Nothing}=nothing)
         sym = gensym()
         if ff == nothing
-            f = @eval $sym(args...) = FourOhFour
+            f = (args...)-> FourOhFour
         else
             f = ff isa Function ? HandlerFunction(ff) : ff
         end


### PR DESCRIPTION
Not sure if it's important that f has the same name as sym... one could do `Symbol(f)` to also get a unique name from the closure.