### PR TITLE
make http client based get requests work again

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -39,6 +39,7 @@ global const DEFAULT_CLIENT = Client()
 function request(client::Client, method, url::URI;
                  headers=Header[],
                  body="",
+                 query=nothing,
                  enablechunked::Bool=true,
                  stream::Bool=false,
                  verbose=false,
@@ -47,6 +48,9 @@ function request(client::Client, method, url::URI;
     # Add default values from client options to args...
     if VERSION > v"0.7.0-DEV.2338"
     args = merge(client.options, args)
+    if query != nothing
+       url = merge(url, query=query)
+    end
     getarg = Base.get
     else
     for option in client.options


### PR DESCRIPTION
hi, 
after struggling quite a bit with the new version of HTTP.jl (and julia 0.6.2) I finally figured out that the query parameters gets ignored when calling via the Client api. (I think a similar issue exists with HTTP.get function and friends)

With this fix it is working for me again. Let me know if you are happy with this and if I should attempt to add a test..

thanks
marius