### PR TITLE
Add a context field to requests

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -182,6 +182,9 @@ Represents a HTTP Request Message.
 - `parent`, the `Response` (if any) that led to this request
   (e.g. in the case of a redirect).
    [RFC7230 6.4](https://tools.ietf.org/html/rfc7231#section-6.4)
+
+- `context::Dict{String, Any}`, allows storage of additional information
+  related to the request.
 """
 mutable struct Request <: Message
     method::String
@@ -192,12 +195,14 @@ mutable struct Request <: Message
     response::Response
     txcount::Int
     parent
+    context::Dict{String, Any}
 end
 
 Request() = Request("", "")
 
 function Request(method::String, target, headers=[], body=UInt8[];
-                 version=v"1.1", parent=nothing)
+                 version=v"1.1", parent=nothing,
+                 context=Dict{String, Any}())
     r = Request(method,
                 target == "" ? "/" : target,
                 version,
@@ -205,7 +210,8 @@ function Request(method::String, target, headers=[], body=UInt8[];
                 bytes(body),
                 Response(0),
                 0,
-                parent)
+                parent,
+                context)
     r.response.request = r
     return r
 end


### PR DESCRIPTION
As per discussions with @JockLawrie and @quinnj, I suggest that we add an additional `context` field to `HTTP.Request` of type `Dict{String, Any}`.  The goal of this is to hold additional information related to the request that doesn't fit in the structure of the current `Request` type, such as authentication and session information.  

Many web frameworks in other languages allow something like this: [Go](https://joeshaw.org/revisiting-context-and-http-handler-for-go-17/), Node/Express, [Python/Flask](https://pythonhosted.org/Flask-Session/), [Ruby](http://www.rubydoc.info/docs/rails/4.1.7/ActionDispatch/Request/Session), etc.  It complicates the `Request` object slightly, but makes it easier for downstream packages.  