### PR TITLE
ConnectionPool: monitor idle connections

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6.2
-MbedTLS 0.5.7
+julia 0.6.3
+MbedTLS 0.5.9
 IniFile


### PR DESCRIPTION
When a connection is returned to the (read) pool,
add a monitor to it for receiving unexpected data (or EOF),
and kill / close the Connection object if any activity occurs
before the next write (when it should have simply been waiting idle in the pool)

per https://github.com/JuliaWeb/MbedTLS.jl/pull/145#issuecomment-381832442

closes #214
closes #199
closes #220
closes JuliaWeb/GitHub.jl#106
replaces #235