### PR TITLE
WIP/RFC: added parser for multipart form

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -500,7 +500,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 ││   │ request(StreamLayer,               ::IO,  ::Request, body) │           │
 ││   └──────────────┬───────────────────┬─────────────────────────┘         │ │
 │└──────────────────┼────────║──────────┼───────────────║─────────────────────┘
-│                   │        ║          │               ║                   │  
+│                   │        ║          │               ║                   │
 │┌──────────────────▼───────────────┐   │  ┌──────────────────────────────────┐
 ││ HTTP.Request                     │   │  │ HTTP.Response                  │ │
 ││                                  │   │  │                                  │
@@ -524,7 +524,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 ││ writestartline(::IO, ::Request)  │ │  ║ │ parse_status_line(bytes, ::Req') │
 ││ writeheaders(::IO, ::Request)    │ │  ║ │ parse_header_field(bytes, ::Req')│
 │└──────────────────────────────────┘ │  ║ └──────────────────────────────────┘
-│                            ║        │  ║                                     
+│                            ║        │  ║
 │┌───────────────────────────║────────┼──║────────────────────────────────────┐
 └▶ HTTP.ConnectionPool       ║        │  ║                                    │
  │                     ┌──────────────▼────────┐ ┌───────────────────────┐    │
@@ -544,7 +544,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
  │                           ║           ║       │ Base.TCPSocket <:IO   │    │
  │                           ║           ║       └───────────────────────┘    │
  └───────────────────────────║───────────║────────────────────────────────────┘
-                             ║           ║                                     
+                             ║           ║
  ┌───────────────────────────║───────────║──────────────┐  ┏━━━━━━━━━━━━━━━━━━┓
  │ HTTP Server               ▼                          │  ┃ data flow: ════▶ ┃
  │                        Request     Response          │  ┃ reference: ────▶ ┃
@@ -587,6 +587,8 @@ include("client.jl")
 include("Handlers.jl")                 ;using .Handlers
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
 Base.@deprecate_binding(Nitrogen, Servers, false)
+
+include("parsemultipart.jl")
 
 include("WebSockets.jl")               ;using .WebSockets
 

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -44,7 +44,7 @@ struct ParseError <: Exception
     bytes::SubString{String}
 end
 
-ParseError(code::Symbol, bytes="") = 
+ParseError(code::Symbol, bytes="") =
     ParseError(code, first(split(String(bytes), '\n')))
 
 # Regular expressions for parsing HTTP start-line and header-fields

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -98,12 +98,13 @@ The `content_type` and `content_transfer_encoding` arguments allow the manual se
 of the `HTTP.sniff(data)` mimetype detection algorithm, whereas `Content-Transfer-Encoding` will be left out if not specified.
 """
 mutable struct Multipart{T <: IO} <: IO
-    filename::String
+    filename::Union{String, Nothing}
     data::T
     contenttype::String
     contenttransferencoding::String
+    name::String
 end
-Multipart(f::String, data::T, ct="", cte="") where {T} = Multipart(f, data, ct, cte)
+Multipart(f::Union{String, Nothing}, data::T, ct="", cte="", name="") where {T} = Multipart(f, data, ct, cte, name)
 Base.show(io::IO, m::Multipart{T}) where {T} = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", data=::$T, contenttype=\"$(m.contenttype)\", contenttransferencoding=\"$(m.contenttransferencoding)\")")
 
 bytesavailable(m::Multipart{T}) where {T} = isa(m.data, IOStream) ? filesize(m.data) - position(m.data) : bytesavailable(m.data)

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -104,7 +104,12 @@ mutable struct Multipart{T <: IO} <: IO
     contenttransferencoding::String
     name::String
 end
-Multipart(f::Union{String, Nothing}, data::T, ct="", cte="", name="") where {T} = Multipart(f, data, ct, cte, name)
+
+function Multipart(f::Union{AbstractString, Nothing}, data::T, ct::AbstractString="", cte::AbstractString="", name::AbstractString="") where {T}
+    f = f !== nothing ? String(f) : nothing
+    Multipart(f, data, String(ct), String(cte), String(name))
+end
+
 Base.show(io::IO, m::Multipart{T}) where {T} = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", data=::$T, contenttype=\"$(m.contenttype)\", contenttransferencoding=\"$(m.contenttransferencoding)\")")
 
 bytesavailable(m::Multipart{T}) where {T} = isa(m.data, IOStream) ? filesize(m.data) - position(m.data) : bytesavailable(m.data)

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -1,6 +1,6 @@
-function find_boundary(bytes::Vector{UInt8}, str, dashes)
+function find_boundary(bytes::AbstractVector{UInt8}, str, dashes; start::Int = 1)
     l = length(bytes)
-    i = 1
+    i = start
     cons_dash = 0
     while i+length(str) <= l
         @inbounds cons_dash = (bytes[i] == 0x2d) ? cons_dash + 1 : 0
@@ -12,35 +12,58 @@ function find_boundary(bytes::Vector{UInt8}, str, dashes)
     nothing
 end
 
-function find_boundary(body::Vector{UInt8}, boundary)
+function find_boundaries(bytes::AbstractVector{UInt8}, str, dashes; start = 1)
+    idxs = Vector{Int}[]
+    j = find_boundary(bytes, str, dashes; start = start)
+    while j !== nothing
+        push!(idxs, j)
+        j = find_boundary(bytes, str, dashes; start = j[2]+1)
+    end
+    return idxs
+end
+
+function find_boundaries(bytes::AbstractVector{UInt8}, boundary; start::Int = 1)
     m =  match(r"^(-*)(.*)$", boundary)
     m === nothing && return nothing
     d, str = m[1], m[2]
-    find_boundary(body, unsafe_wrap(Array{UInt8, 1}, String(str)), length(d))
+    find_boundaries(bytes, unsafe_wrap(Array{UInt8, 1}, String(str)), length(d); start = start)
 end
 
-function find_content(bytes::Vector{UInt8})
+function remove_trailing(bytes::AbstractVector{UInt8}, charlist::AbstractVector{UInt8})
+    i = findlast(in(charlist), bytes)
+    j = i !== nothing ? i-1 : lastindex(bytes)
+    view(bytes, 1:j)
+end
+
+remove_trailing(bytes::AbstractVector{UInt8}, char::UInt8) = remove_trailing(bytes, [char])
+
+function find_returns(bytes::AbstractVector{UInt8})
     l = length(bytes)
     i = 1
-    while i <= l-1
-        matched = false
-        bytes[i] == 0x0d && bytes[i+1] == 0x0d && (matched = true)
-        bytes[i] == 0x0a && bytes[i+1] == 0x0a && (matched = true)
-        matched && return [i-1, i+1]
-        bytes[i] == 0x0d && bytes[i+1] == 0x0a && (i+3 <= l) && bytes[i+2] == 0x0d && bytes[i+3] == 0x0a && (matched = true)
-        matched && return [i-1, i+3]
-
+    returns = UInt8[]
+    returnbytes = [0x0d, 0x0a]
+    while i <= l
+        @inbounds byte = bytes[i]
+        if byte in returnbytes
+            push!(returns, byte)
+            if i==l || !(bytes[i+1] in returnbytes)
+                len = length(returns)
+                uniquelen = length(unique(returns))
+                len >= 2 * uniquelen && return [i-len, i]
+            end
+        else
+            isempty(returns) || empty!(returns)
+        end
         i += 1
     end
     nothing
 end
 
-function parse_multipart_chunk!(chunk, d)
-    re = r"(\n){2,}|(\r){2,}|[\r\n]{4,}"
-    Parsers.exec(re, chunk) || return nothing
-    i, j = re.ovec
-    description = String(chunk[1:i])
-    content = Parsers.nextbytes(re, chunk)
+function parse_multipart_chunk!(d, chunk)
+    i = find_returns(chunk)
+    i == nothing && return
+    description = String(view(chunk, 1:i[1]))
+    content = view(chunk, i[2]+1:lastindex(chunk))
 
     v = match(r"Content-Disposition: form-data; name=\"(.*)\"; filename=\"(.*)\"[\r\n]+Content-Type: (\S*)", description)
     if v !== nothing
@@ -55,28 +78,22 @@ function parse_multipart_chunk!(chunk, d)
         push!(d["contenttype"], nothing)
     end
 
-    re = r"(?:[\r\n]*)(?:-*)$"
-    Parsers.exec(re, content) && (content = content[1:re.ovec[1]])
+    content = remove_trailing(content, 0xd)
+    content = remove_trailing(content, [0x0d, 0x0a])
     push!(d["content"], content)
 end
 
-parse_multipart_body(body, boundary) =
-    parse_multipart_body(String(body), boundary)
-
-function parse_multipart_body(body::AbstractString, boundary)
+function parse_multipart_body(body::Vector{UInt8}, boundary)
     dict = Dict(
         "name" => String[],
         "filename" => Union{String, Nothing}[],
         "contenttype" => Union{String, Nothing}[],
         "content" => Any[]
     )
-    re = Regex(boundary)
-    Parsers.exec(re, body) || return nothing
-    str = Parsers.nextbytes(re, body)
-    while Parsers.exec(re, str)
-        chunk = str[1:re.ovec[1]]
-        isempty(chunk) || parse_multipart_chunk!(chunk, dict)
-        str = Parsers.nextbytes(re, str)
+    idxs = find_boundaries(body, boundary)
+    for i in 1:length(idxs)-1
+        chunk = view(body, idxs[i][2]+1:idxs[i+1][1])
+        parse_multipart_chunk!(dict, chunk)
     end
     return dict
 end

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -1,3 +1,40 @@
+function find_boundary(bytes::Vector{UInt8}, str, dashes)
+    l = length(bytes)
+    i = 1
+    cons_dash = 0
+    while i+length(str) <= l
+        @inbounds cons_dash = (bytes[i] == 0x2d) ? cons_dash + 1 : 0
+        if cons_dash >= dashes && bytes[(i+1):(i+length(str))] == str
+            return [i-dashes, i+length(str)]
+        end
+        i += 1
+    end
+    nothing
+end
+
+function find_boundary(body::Vector{UInt8}, boundary)
+    m =  match(r"^(-*)(.*)$", boundary)
+    m === nothing && return nothing
+    d, str = m[1], m[2]
+    find_boundary(body, unsafe_wrap(Array{UInt8, 1}, String(str)), length(d))
+end
+
+function find_content(bytes::Vector{UInt8})
+    l = length(bytes)
+    i = 1
+    while i <= l-1
+        matched = false
+        bytes[i] == 0x0d && bytes[i+1] == 0x0d && (matched = true)
+        bytes[i] == 0x0a && bytes[i+1] == 0x0a && (matched = true)
+        matched && return [i-1, i+1]
+        bytes[i] == 0x0d && bytes[i+1] == 0x0a && (i+3 <= l) && bytes[i+2] == 0x0d && bytes[i+3] == 0x0a && (matched = true)
+        matched && return [i-1, i+3]
+
+        i += 1
+    end
+    nothing
+end
+
 function parse_multipart_chunk!(chunk, d)
     re = r"(\n){2,}|(\r){2,}|[\r\n]{4,}"
     Parsers.exec(re, chunk) || return nothing
@@ -23,15 +60,14 @@ function parse_multipart_chunk!(chunk, d)
     push!(d["content"], content)
 end
 
-parse_multipart_body(body::AbstractArray{UInt8}, boundary) =
+parse_multipart_body(body, boundary) =
     parse_multipart_body(String(body), boundary)
 
-function parse_multipart_body(body, boundary)
-    body = String(body)
+function parse_multipart_body(body::AbstractString, boundary)
     dict = Dict(
         "name" => String[],
-        "filename" => Union{String, Void}[],
-        "contenttype" => Union{String, Void}[],
+        "filename" => Union{String, Nothing}[],
+        "contenttype" => Union{String, Nothing}[],
         "content" => Any[]
     )
     re = Regex(boundary)

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -39,7 +39,7 @@ function parse_multipart_body(body, boundary)
     str = Parsers.nextbytes(re, body)
     while Parsers.exec(re, str)
         chunk = str[1:re.ovec[1]]
-        parse_multipart_chunk!(chunk, dict)
+        isempty(chunk) || parse_multipart_chunk!(chunk, dict)
         str = Parsers.nextbytes(re, str)
     end
     return dict

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -2,7 +2,7 @@ const RETURN_BYTES = [0x0d, 0x0a]
 const DASH_BYTE = 0x2d
 
 const FORMDATA_REGEX = r"Content-Disposition: form-data"
-const NAME_REGEX = r"name=\"(.*)\""
+const NAME_REGEX = r" name=\"(.*)\""
 const FILENAME_REGEX = r"filename=\"(.*)\""
 const CONTENTTYPE_REGEX = r"Content-Type: (\S*)"
 

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -1,0 +1,48 @@
+function parse_multipart_chunk!(chunk, d)
+    re = r"(\n){2,}|(\r){2,}|[\r\n]{4,}"
+    Parsers.exec(re, chunk) || return nothing
+    i, j = re.ovec
+    description = String(chunk[1:i])
+    content = chunk[nextind(chunk, j):end]
+
+    v = match(r"Content-Disposition: form-data; name=\"(.*)\"; filename=\"(.*)\"[\r\n]+Content-Type: (\S*)", description)
+    if v !== nothing
+        push!(d["name"], v[1])
+        push!(d["filename"], v[2])
+        push!(d["contenttype"], v[3])
+    else
+        v = match(r"Content-Disposition: form-data; name=\"(.*)\"", description)
+        v == nothing && return
+        push!(d["name"], v[1])
+        push!(d["filename"], nothing)
+        push!(d["contenttype"], nothing)
+    end
+
+    re = r"(?:[\r\n]*)(?:-*)$"
+    Parsers.exec(re, content) && (content = content[1:re.ovec[1]])
+    push!(d["content"], content)
+end
+
+function parse_multipart_body(body, boundary)
+    dict = Dict(
+        "name" => String[],
+        "filename" => Union{String, Void}[],
+        "contenttype" => Union{String, Void}[],
+        "content" => Any[]
+    )
+    re = Regex(boundary)
+    Parsers.exec(re, body) || return nothing
+    str = body[nextind(body, re.ovec[2]):endof(body)]
+    while Parsers.exec(re, str)
+        chunk = str[1:re.ovec[1]]
+        parse_multipart_chunk!(chunk, dict)
+        str = str[nextind(str, re.ovec[2]):endof(str)]
+    end
+    return dict
+end
+
+function parse_multipart_form(req::Request)
+    m = match(r"multipart/form-data; boundary=(.*)$", req["Content-Type"])
+    m === nothing && return nothing
+    parse_multipart_body(req.body, m[1])
+end


### PR DESCRIPTION
This is an attempt to solve #263. I've tested with a simple form with a textbox and a file input (I updated a PNG) and it seems to work fine (still need to add tests though).

The "content" of each section add a newline and a couple of dashes at the end that I'm removing (`\r\n--`, though the type of newline may vary I guess), though maybe I'm not 100% correct in how I do so (on whether they should be removed at all): I'm taking out the match of  `r"[\r\n]*-*$"`