### PR TITLE
Add ability to getsockname on an HTTP.Stream type; fixes #254

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -5,6 +5,7 @@ export Stream, closebody, isaborted,
        setstatus, setheader
 
 import ..HTTP
+using ..Sockets
 using ..IOExtras
 using ..Messages
 import ..bytesavailable, ..compat_string
@@ -55,6 +56,8 @@ header(http::Stream, a...) = header(http.message, a...)
 setstatus(http::Stream, status) = (http.message.response.status = status)
 setheader(http::Stream, a...) = setheader(http.message.response, a...)
 getrawstream(http::Stream) = getrawstream(http.stream)
+
+Sockets.getsockname(http::Stream) = Sockets.getsockname(getrawstream(http))
 
 IOExtras.isopen(http::Stream) = isopen(http.stream)
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -82,3 +82,7 @@ end
 @static if !applicable(bytesavailable, MbedTLS.SSLContext())
     Base.bytesavailable(ssl::MbedTLS.SSLContext) = nb_available(ssl)
 end
+
+@static if !applicable(Sockets.getsockname, MbedTLS.SSLContext())
+    Sockets.getsockname(ctx::SSLContext) = Sockets.getsockname(ctx.bio)
+end

--- a/test/async.jl
+++ b/test/async.jl
@@ -1,6 +1,7 @@
 include("compat.jl")
 using HTTP
 using HTTP.Base64
+using HTTP.Sockets
 using JSON
 using MbedTLS: digest, MD_MD5, MD_SHA256
 
@@ -16,6 +17,7 @@ println("async tests")
 stop_pool_dump = false
 
 @async HTTP.listen() do http
+    @show HTTP.Sockets.getsockname(http)
     startwrite(http)
     write(http, """
         <html><head>


### PR DESCRIPTION
cc: @essenciary, you can now call `Sockets.getsockname(stream)` where `stream::HTTP.Stream`. Basically, if you do a request/server in streaming mode, you get access to the underlying sockets, so we can just provide `Sockets.getsockname` on the `HTTP.Stream` type directly for convenience.