### PR TITLE
Replace HTTP.download

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -597,6 +597,9 @@ function stack(;redirect=true,
     }}}}}}}}}}}}
 end
 
+include("download.jl")
+
+
 include("Handlers.jl")                 ;using .Handlers
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
 Base.@deprecate_binding(Nitrogen, Servers, false)

--- a/src/download.jl
+++ b/src/download.jl
@@ -2,15 +2,15 @@ using .Pairs
 
 """
     safer_joinpath(basepart, parts...)
-A variation on `joinpath`, that is more resistant to directory traveral attack
+A variation on `joinpath`, that is more resistant to directory traversal attacks.
 The parts to be joined (excluding the `basepart`),
 are not allowed to contain `..`, or begin with a `/`.
 If they do then this throws an `DomainError`.
 """
 function safer_joinpath(basepart, parts...)
-    explain =  "Possible Directory Traversal Attack detected."
+    explain =  "Possible directory traversal attack detected."
     for part in parts
-        occursin("..", part) && throw(DomainError(part, "contains illegal string \"..\". $explain"))
+        occursin("..", part) && throw(DomainError(part, "contains \"..\". $explain"))
         startswith(part, '/') && throw(DomainError(part, "begins with \"/\". $explain"))
     end
     joinpath(basepart, parts...)

--- a/src/download.jl
+++ b/src/download.jl
@@ -72,6 +72,7 @@ from the rules of the HTTP.
 
 """
 function download(url::AbstractString, local_path=nothing; update_period=0.5)
+    @debug 1 "downloading $url"
     local file
     HTTP.open("GET", url) do stream
         resp = startread(stream)

--- a/src/download.jl
+++ b/src/download.jl
@@ -1,0 +1,114 @@
+using .Pairs
+
+function try_get_filename_from_headers(headers)
+    content_disp = getkv(headers, "Content-Disposition")
+    if content_disp != nothing
+        # extract out of Content-Disposition line
+        # rough version of what is needed in https://github.com/JuliaWeb/HTTP.jl/issues/179
+        filename_part = match(r"filename\s*=\s*(.*)", content_disp)
+        if filename_part != nothing
+            filename = filename_part[1]
+            quoted_filename = match(r"\"(.*)\"", filename)
+            if quoted_filename != nothing
+                # It was in quotes, so it will be double escaped
+                filename = unescape_string(quoted_filename[1])
+            end
+            return filename
+        end
+    end
+    return nothing
+end
+
+function try_get_filename_from_remote_path(target)
+    target == "" && return nothing
+    filename = basename(target)
+    if filename == ""
+        try_get_filename_from_remote_path(dirname(target))
+    else
+        filename
+    end
+end
+
+
+determine_file(::Nothing, resp) = determine_file(tempdir(), resp)
+# ^ We want to the filename if possible because extension is useful for FileIO.jl
+
+function determine_file(path, resp)
+    # get the name
+    name = if isdir(path)
+        # got to to workout what file to put there
+        filename = something(
+                        try_get_filename_from_headers(resp.headers),
+                        try_get_filename_from_remote_path(resp.request.target),
+                        basename(tempname()) # fallback, basically a random string
+                    )
+        joinpath(path, filename)
+    else
+        # It is a file, we are done.
+        path
+    end
+
+    # get the extension, if we are going to save it in encoded form.
+    if header(resp, "Content-Encoding") == "gzip"
+        name *= ".gz"
+    end
+    name
+end
+
+"""
+    download(url, [local_path])
+
+Similar to `Base.download` this downloads a file, returning the filename.
+If the `local_path`:
+ - is not provided, then it is saved in a temporary directory
+ - if part to a directory is provided then it is saved into that directory
+ - otherwise the local path is uses as the filename to save to.
+
+When saving into a directory, the filename is determined (where possible),
+from the rules of the HTTP.
+"""
+function download(url::AbstractString, local_path=nothing)
+    local file
+    HTTP.open("GET", url) do stream
+        resp = startread(stream)
+        file = determine_file(local_path, resp)
+        @show file
+        @show resp
+        total_bytes = parse(Float64, getkv(resp.headers, "Content-Length", "NaN"))
+        downloaded_bytes = 0
+        start_time = now()
+        prev_time = now()
+
+        function report_callback()
+            prev_time = now()
+            taken_time = (prev_time - start_time).value / 1000 # in seconds
+            average_speed = downloaded_bytes / taken_time
+            remaining_bytes = total_bytes - downloaded_bytes
+            remaining_time = remaining_bytes/average_speed
+            completion_progress = downloaded_bytes/total_bytes
+        
+            @info("Downloading",
+                  source=url,
+                  dest = file,
+                  progress = completion_progress,
+                  taken_time,
+                  remaining_time,
+                  average_speed,
+                  downloaded_bytes,
+                  remaining_bytes,
+                  total_bytes,
+            )
+        end
+
+        open(file, "w") do fh
+            while(!eof(stream))
+                downloaded_bytes += write(fh, readavailable(stream))
+                if now() - prev_time > Millisecond(500)
+                    report_callback()
+                end
+            end
+        end
+        report_callback()
+    end
+    file
+end

--- a/src/download.jl
+++ b/src/download.jl
@@ -72,7 +72,7 @@ function determine_file(path, resp)
 end
 
 """
-    download(url, [local_path], [headers]; update_period=0.5, kw...)
+    download(url, [local_path], [headers]; update_period=5, kw...)
 
 Similar to `Base.download` this downloads a file, returning the filename.
 If the `local_path`:
@@ -88,17 +88,17 @@ from the rules of the HTTP.
  - `headers` specifies headers to be used for the HTTP GET request
  - any additional keyword args (`kw...`) are passed on to the HTTP request.
 """
-function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=0.5; kw...)
+function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=5, kw...)
     @debug 1 "downloading $url"
     local file
-    HTTP.open("GET", url, headers; kw..) do stream
+    HTTP.open("GET", url, headers; kw...) do stream
         resp = startread(stream)
         file = determine_file(local_path, resp)
         total_bytes = parse(Float64, getkv(resp.headers, "Content-Length", "NaN"))
         downloaded_bytes = 0
         start_time = now()
         prev_time = now()
-
+        
         function report_callback()
             prev_time = now()
             taken_time = (prev_time - start_time).value / 1000 # in seconds
@@ -117,7 +117,7 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
                   downloaded_bytes,
                   remaining_bytes,
                   total_bytes,
-            )
+                 )
         end
 
         Base.open(file, "w") do fh
@@ -129,6 +129,8 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
             end
         end
         report_callback()
+        
     end
     file
 end
+

--- a/src/download.jl
+++ b/src/download.jl
@@ -72,7 +72,7 @@ function determine_file(path, resp)
 end
 
 """
-    download(url, [local_path], [headers]; update_period=5, pretty_print=true, kw...)
+    download(url, [local_path], [headers]; update_period=1, kw...)
 
 Similar to `Base.download` this downloads a file, returning the filename.
 If the `local_path`:
@@ -85,22 +85,14 @@ from the rules of the HTTP.
 
  - `update_period` controls how often (in seconds) to report the progress.
     - set to `Inf` to disable reporting
- - `pretty_print` controls if the progress reports should be use human-friendly units.
  - `headers` specifies headers to be used for the HTTP GET request
  - any additional keyword args (`kw...`) are passed on to the HTTP request.
 """
-function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=5, pretty_print=true, kw...)
-    if pretty_print
-        format_progress(x) = "$(round(100x, digits=2))%"
-        format_bytes(x) = Base.format_bytes(x)
-        format_seconds(x) = "$(round(Int, x)) s"
-        format_bytes_per_second(x) = format_bytes(x) * "/s"
-    else
-        format_progress(x) = x
-        format_bytes(x) = x
-        format_seconds(x) = x
-        format_bytes_per_second(x) = x
-    end
+function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=1, kw...)
+    format_progress(x) = "$(round(100x, digits=2))%"
+    format_bytes(x) = x==Inf ? "∞ B" : Base.format_bytes(x)
+    format_seconds(x) = "$(round(x; digits=2)) s"
+    format_bytes_per_second(x) = format_bytes(x) * "/s"
 
 
     @debug 1 "downloading $url"
@@ -125,12 +117,12 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
                   source=url,
                   dest = file,
                   progress = completion_progress |> format_progress,
-                  taken_time |> format_seconds,
-                  remaining_time |> format_seconds,
-                  average_speed |> format_bytes_per_second,
-                  downloaded_bytes |> format_bytes,
-                  remaining_bytes |> format_bytes,
-                  total_bytes |> format_bytes,
+                  time_taken = taken_time |> format_seconds,
+                  time_remaining = remaining_time |> format_seconds,
+                  average_speed = average_speed |> format_bytes_per_second,
+                  downloaded = downloaded_bytes |> format_bytes,
+                  remaining = remaining_bytes |> format_bytes,
+                  total = total_bytes |> format_bytes,
                  )
         end
 

--- a/src/download.jl
+++ b/src/download.jl
@@ -72,7 +72,7 @@ function determine_file(path, resp)
 end
 
 """
-    download(url, [local_path]; update_period=0.5)
+    download(url, [local_path], [headers]; update_period=0.5, kw...)
 
 Similar to `Base.download` this downloads a file, returning the filename.
 If the `local_path`:
@@ -85,12 +85,13 @@ from the rules of the HTTP.
 
  - `update_period` controls how often (in seconds) to report the progress.
     - set to `Inf` to disable reporting
-
+ - `headers` specifies headers to be used for the HTTP GET request
+ - any additional keyword args (`kw...`) are passed on to the HTTP request.
 """
-function download(url::AbstractString, local_path=nothing; update_period=0.5)
+function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=0.5; kw...)
     @debug 1 "downloading $url"
     local file
-    HTTP.open("GET", url) do stream
+    HTTP.open("GET", url, headers; kw..) do stream
         resp = startread(stream)
         file = determine_file(local_path, resp)
         total_bytes = parse(Float64, getkv(resp.headers, "Content-Length", "NaN"))

--- a/test/download.jl
+++ b/test/download.jl
@@ -1,0 +1,39 @@
+include("compat.jl")
+using HTTP
+
+@testset "HTTP.download" begin
+    @testset "Content-Disposition" begin
+        invalid_content_disposition_fn = HTTP.download(
+            "http://test.greenbytes.de/tech/tc2231/attonlyquoted.asis")
+        @test isfile(invalid_content_disposition_fn)
+        @test basename(invilid_content_disposition_fn) == "attonlyquoted.asis" # just last part  of name
+
+        content_disposition_fn = HTTP.download(
+            "http://test.greenbytes.de/tech/tc2231/attwithasciifilenamepdf.asis")
+        @test isfile(content_disposition_fn)
+        @test basename(content_disposition_fn) == "foo.pdf"
+
+        escaped_content_disposition_fn = HTTP.download(
+            "http://test.greenbytes.de/tech/tc2231/attwithasciifnescapedquote.asis")
+        @test isfile(escaped_content_disposition_fn)
+        @test basename(escaped_content_disposition_fn) == "\"quoting\" tested.html"
+    end
+
+    @testset "Provided Filename" begin
+        provided_filename = tempname()
+        returned_filename = HTTP.download(
+            "http://test.greenbytes.de/tech/tc2231/attwithasciifilenamepdf.asis",
+            provided_filename
+        )
+        @test provided_filename == returned_filename
+        @test isfile(provided_filename)
+
+
+    end
+
+    @testset "Content-Encoding" begin
+        zip_content_encoding_fn = HTTP.download("https://httpbin.org/gzip")
+        @test isfile(gzip_content_encoding_fn)
+        @test last(splitext(gzip_content_encoding_fn)) == ".gz"
+    end
+end

--- a/test/download.jl
+++ b/test/download.jl
@@ -6,10 +6,12 @@ using HTTP
         invalid_content_disposition_fn = HTTP.download(
             "http://test.greenbytes.de/tech/tc2231/attonlyquoted.asis")
         @test isfile(invalid_content_disposition_fn)
-        @test basename(invilid_content_disposition_fn) == "attonlyquoted.asis" # just last part  of name
+        @test basename(invalid_content_disposition_fn) == "attonlyquoted.asis" # just last part  of name
+
+
 
         content_disposition_fn = HTTP.download(
-            "http://test.greenbytes.de/tech/tc2231/attwithasciifilenamepdf.asis")
+            "http://test.greenbytes.de/tech/tc2231/inlwithasciifilenamepdf.asis")
         @test isfile(content_disposition_fn)
         @test basename(content_disposition_fn) == "foo.pdf"
 
@@ -22,7 +24,7 @@ using HTTP
     @testset "Provided Filename" begin
         provided_filename = tempname()
         returned_filename = HTTP.download(
-            "http://test.greenbytes.de/tech/tc2231/attwithasciifilenamepdf.asis",
+            "http://test.greenbytes.de/tech/tc2231/inlwithasciifilenamepdf.asis",
             provided_filename
         )
         @test provided_filename == returned_filename
@@ -32,7 +34,7 @@ using HTTP
     end
 
     @testset "Content-Encoding" begin
-        zip_content_encoding_fn = HTTP.download("https://httpbin.org/gzip")
+        gzip_content_encoding_fn = HTTP.download("https://httpbin.org/gzip")
         @test isfile(gzip_content_encoding_fn)
         @test last(splitext(gzip_content_encoding_fn)) == ".gz"
     end

--- a/test/download.jl
+++ b/test/download.jl
@@ -1,4 +1,3 @@
-include("compat.jl")
 using HTTP
 
 @testset "HTTP.download" begin

--- a/test/download.jl
+++ b/test/download.jl
@@ -14,10 +14,12 @@ using HTTP
         @test isfile(content_disposition_fn)
         @test basename(content_disposition_fn) == "foo.pdf"
 
-        escaped_content_disposition_fn = HTTP.download(
-            "http://test.greenbytes.de/tech/tc2231/attwithasciifnescapedquote.asis")
-        @test isfile(escaped_content_disposition_fn)
-        @test basename(escaped_content_disposition_fn) == "\"quoting\" tested.html"
+        if Sys.isunix() # Don't try this on windows, quotes are not allowed in windows filenames.
+            escaped_content_disposition_fn = HTTP.download(
+                "http://test.greenbytes.de/tech/tc2231/attwithasciifnescapedquote.asis")
+            @test isfile(escaped_content_disposition_fn)
+            @test basename(escaped_content_disposition_fn) == "\"quoting\" tested.html"
+        end
     end
 
     @testset "Provided Filename" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,10 +18,10 @@ using HTTP
     # println("running WebSockets.jl tests..."); include("WebSockets.jl");
     println("running messages.jl tests..."); include("messages.jl");
     
-    println("running download.jl tests...)"; include("download.jl");
+    println("running download.jl tests..."); include("download.jl");
 
-    println("running handlers.jl tests..."); include("handlers.jl")
-    println("running server.jl tests..."); include("server.jl")
+    println("running handlers.jl tests..."); include("handlers.jl");
+    println("running server.jl tests..."); include("server.jl");
 
     println("running async.jl tests..."); include("async.jl");
 end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,8 @@ using HTTP
     println("running loopback.jl tests..."); include("loopback.jl");
     # println("running WebSockets.jl tests..."); include("WebSockets.jl");
     println("running messages.jl tests..."); include("messages.jl");
+    
+    println("running download.jl tests...)"; include("download.jl");
 
     println("running handlers.jl tests..."); include("handlers.jl")
     println("running server.jl tests..."); include("server.jl")


### PR DESCRIPTION
rather than deleting it as in #271  
this replace it with a new and better version.

It is very verbose, but I think the 0.7 way of handling that is to tell your logger to be quieter.
Also to tell your logger to display a progress bar instead, that should be possible with the new system.


Locally this was working when I had it as a separate package but it is screwing up now that I've merge it in and I'm at a lose as to why.

```
ERROR: DNSError: , unknown node or service (EAI_NONAME)
```