### PR TITLE
add keep_open option to prevent closing of socket

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -90,6 +90,8 @@ Streaming options
  - `response_stream = nothing`, a writeable `IO` stream or any `IO`-like
     type `T` for which `write(T, AbstractVector{UInt8})` is defined.
  - `verbose = 0`, set to `1` or `2` for extra message logging.
+ - `keep_open = false`, set to `true` to prevent the closing of the socket.
+   Use with `reuse_limit = 0` to prevent reuse of the socket.
 
 
 Connection Pool options

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -26,6 +26,7 @@ function request(::Type{StreamLayer}, io::IO, request::Request, body;
                  response_stream=nothing,
                  iofunction=nothing,
                  verbose::Int=0,
+                 keep_open::Bool=false,
                  kw...)::Response
 
     verbose == 1 && printlncompact(request)
@@ -78,8 +79,10 @@ function request(::Type{StreamLayer}, io::IO, request::Request, body;
         end
     end
 
-    closewrite(http)
-    closeread(http)
+    if !keep_open
+        closewrite(http)
+        closeread(http)
+    end
 
     verbose == 1 && printlncompact(response)
     verbose == 2 && println(response)


### PR DESCRIPTION
Hi!

I'm the author of DandelionWebSockets.jl. I previously used Requests to do the HTTP Upgrade to the WebSocket protocol, but since it's obsolete, I moved over to HTTP.jl. With this PR I create a way to get a socket that isn't closed by HTTP itself, so I can keep using it in my WebSockets package.

The `HTTP.open` method allows a user to get the stream via the `iofunction` supplied as a `do` function argument. However, `HTTP` closes the socket unconditionally after the supplied function returns. The `WebSockets.jl` package, as far as I understand, runs the entire WebSocket connection inside that supplied function. Unfortunately, that will not work for my package, as I maintain ownership of the socket myself.
This PR adds a `keep_open` argument to `HTTP.requests()`. If `keep_open = true` is supplied, then `HTTP.requests()` does not close the socket when `iofunction` returns. In my package, I can get the socket via a call to `HTTP.ConnectionPool.getrawstream()`, and save it for later use.

In the documentation comments, I mention that this should be used with `reuse_limit = 0`, to prevent reuse of the socket by `HTTP.ConnectionPool`. I'm not 100% sure this is appropriate, but seems reasonable. Please correct this if it is wrong. I'm generally not 100% sure this will work well with the connection pool, so if you don't like the PR, please reject it.

This was the least intrusive way I could think of to get what I needed. One could also imagine making a separate request method that immediately returns the socket along with the normal response, but that would add to your interface. I considered this less intrusive, especially since it's probably a highly specialized usecase.

Also a note on the test: I could add a test for `keep_open = false`, but with `keep_open = false` this particular requests takes a minute to time out. Running it once for `http` and once for `https` will add two full minutes to the test, for very little value.