### PR TITLE
can't unread! `buf`

### DIFF
--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -158,12 +158,14 @@ function Base.readuntil(io::IO,
         # Otherwise, wait for delimiter...
         buf = Vector{UInt8}(bytes)
         while !eof(io)
-            append!(buf, readavailable(io))
-            if (l = find_delimiter(buf)) > 0
-                if l < length(buf)
-                    unread!(io, view(buf, l+1:length(buf)))
+            bl = length(buf)
+            bytes = readavailable(io)
+            append!(buf, bytes)
+            if (l = find_delimiter(bytes)) > 0
+                if l < length(bytes)
+                    unread!(io, view(bytes, l+1:length(bytes)))
                 end
-                return view(buf, 1:l)
+                return view(buf, 1:bl+l)
             end
         end
     end


### PR DESCRIPTION
When a `readuntil` spans multiple chunks, calling `unread!` on the view of `buf` fails with a `BoundsError` because the CRLF at the end of the chunk isn't present in `buf`.  Instead, the original result of the `readavailable` should be used in the `unread!`.