### PR TITLE
Wrap UVError/IOError in getconnection with HTTP.IOError

### DIFF
--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -36,7 +36,12 @@ function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
     end
 
     IOType = ConnectionPool.Transaction{sockettype(url, socket_type)}
-    io = getconnection(IOType, url.host, url.port; reuse_limit=reuse_limit, kw...)
+    local io
+    try
+        io = getconnection(IOType, url.host, url.port; reuse_limit=reuse_limit, kw...)
+    catch e
+        rethrow(isioerror(e) ? IOError(e, "during request($url)") : e)
+    end
 
     try
         if proxy !== nothing && target_url.scheme == "https"


### PR DESCRIPTION
Fixes #295 

Is there a nice way to test this (e.g., generate a broken pipe)?