### PR TITLE
Fix #261

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -74,7 +74,8 @@ function IOExtras.startwrite(http::Stream)
     m = messagetowrite(http)
     if !hasheader(m, "Content-Length") &&
        !hasheader(m, "Transfer-Encoding") &&
-       !hasheader(m, "Upgrade")
+       !hasheader(m, "Upgrade") &&
+        (m isa Request || bodylength(m) > 0)
         http.writechunked = true
         setheader(m, "Transfer-Encoding" => "chunked")
     else


### PR DESCRIPTION
Ensure that the server does not return a Transfer-Encoding: chunked
header for messages that have no body (i.e. HEAD responses, 204 and
304).

See https://github.com/JuliaWeb/HTTP.jl/issues/261#issuecomment-400529685