### PR TITLE
Make MbedException an HTTP.IOError

### DIFF
--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -7,6 +7,7 @@ This module defines extensions to the `Base.IO` interface to support:
 module IOExtras
 
 using ..Sockets
+using MbedTLS: MbedException
 
 export bytes, ByteView, CodeUnits, IOError, isioerror,
        unread!,
@@ -38,6 +39,7 @@ isioerror(e) = false
 isioerror(::Base.EOFError) = true
 isioerror(::Base.IOError) = true
 isioerror(e::ArgumentError) = e.msg == "stream is closed or unusable"
+isioerror(::MbedException) = true
 
 
 """


### PR DESCRIPTION
![screenshot 2018-09-19 13 07 05](https://user-images.githubusercontent.com/3131001/45772414-3b487080-bc0d-11e8-8092-431a6d2e9291.png)

I think we're running into transient MbedExceptions and Sam said this makes sense to add.