### PR TITLE
make download progress safer

### DIFF
--- a/src/download.jl
+++ b/src/download.jl
@@ -89,8 +89,8 @@ from the rules of the HTTP.
  - any additional keyword args (`kw...`) are passed on to the HTTP request.
 """
 function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=1, kw...)
-    format_progress(x) = "$(round(100x, digits=2))%"
-    format_bytes(x) = x==Inf ? "∞ B" : Base.format_bytes(x)
+    format_progress(x) = round(x, digits=4)
+    format_bytes(x) = !isfinite(x) ? "∞ B" : Base.format_bytes(x)
     format_seconds(x) = "$(round(x; digits=2)) s"
     format_bytes_per_second(x) = format_bytes(x) * "/s"
 


### PR DESCRIPTION
Under some circumstances, 
things like downloading `0.0` bytes in `0.0` seconds can occur,
which triggers it to try and print `NaN` speed. 
which is a problem

Also make progress a value between 0 and 1 as that is compat with how Juno does ProgressBars
https://github.com/JunoLab/Atom.jl/blob/857aa7c31e508789e434b5c2a4ba708f4f208565/src/progress.jl#L8-L25
