### PR TITLE
Remove newline between field_name_isequal and it docstring

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -307,7 +307,6 @@ Base.getindex(m::Message, k) = header(m, k)
 [HTTP `field-name`s](https://tools.ietf.org/html/rfc7230#section-3.2)
 are ASCII-only and case-insensitive.
 """
-
 field_name_isequal(a, b) = ascii_lc_isequal(a, b)
 
 """


### PR DESCRIPTION
This throws up a deprecation warning in julia 0.7

```
┌ Warning: Deprecated syntax `multiple line breaks between doc string and object` at /home/wheel/oxinabox/.julia/packages/HTTP/mwR9J/src/Messages.jl:311.
│ Use `at most one line break` instead.
└ @ ~/.julia/packages/HTTP/mwR9J/src/Messages.jl:311
```