### PR TITLE
Added array of pair constructor for multipart Form. Removed escaping form values.

### DIFF
--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -53,7 +53,7 @@ function Base.read(f::Form, n::Integer)
     return result
 end
 
-function Form(d::Dict)
+function Form(d::Vector{Pair{String,T}}) where T<:Any
     boundary = string(rand(UInt128), base=16)
     data = IO[]
     io = IOBuffer()
@@ -69,13 +69,17 @@ function Form(d::Dict)
             io = IOBuffer()
         else
             write(io, "\r\n\r\n")
-            write(io, escapeuri(v))
+            write(io, v)
         end
         i == len && write(io, "\r\n--" * boundary * "--" * "\r\n")
     end
     seekstart(io)
     push!(data, io)
     return Form(data, 1, boundary)
+end
+
+function Form(d::Dict{String,T}) where T<:Any
+    return Form(collect(d))
 end
 
 function writemultipartheader(io::IOBuffer, i::IOStream)

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -53,7 +53,7 @@ function Base.read(f::Form, n::Integer)
     return result
 end
 
-function Form(d::Vector{Pair{String,T}}) where T<:Any
+function Form(d)
     boundary = string(rand(UInt128), base=16)
     data = IO[]
     io = IOBuffer()
@@ -76,10 +76,6 @@ function Form(d::Vector{Pair{String,T}}) where T<:Any
     seekstart(io)
     push!(data, io)
     return Form(data, 1, boundary)
-end
-
-function Form(d::Dict{String,T}) where T<:Any
-    return Form(collect(d))
 end
 
 function writemultipartheader(io::IOBuffer, i::IOStream)


### PR DESCRIPTION
Addresses #313. Keeps in place the existing `Dict` constructor for `Form` but adds a new one with an array of pairs to preserve multipart order. Also, removes escaping form values.

You can now create a form with either syntax:
```julia
HTTP.Form(["foo" => "FOO", "bar" => "BAR"])
# OR
HTTP.Form(Dict("foo" => "FOO", "bar" => "BAR"))
```