### PR TITLE
Fixed WebSockets not accepting upgrade requests from Firefox

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -336,7 +336,7 @@ hasheader(m, k::AbstractString, v::AbstractString) =
 Does the header for `key` (interpreted as comma-separated list) contain `value` (both case-insensitive)?
 """
 headercontains(m, k::AbstractString, v::AbstractString) =
-    any(field_name_isequal.(strip.(split(header(m, k), ",")), lowercase(v)))
+    any(field_name_isequal.(strip.(split(header(m, k), ",")), v))
 
 """
     setheader(::Message, key => value)

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -60,7 +60,7 @@ module Messages
 export Message, Request, Response, HeaderSizeError,
        reset!, status, method, headers, uri, body,
        iserror, isredirect, ischunked, issafe, isidempotent,
-       header, hasheader, setheader, defaultheader, appendheader,
+       header, hasheader, headercontains, setheader, defaultheader, appendheader,
        mkheaders, readheaders, headerscomplete,
        readchunksize,
        writeheaders, writestartline,
@@ -329,6 +329,14 @@ Does header for `key` match `value` (both case-insensitive)?
 """
 hasheader(m, k::AbstractString, v::AbstractString) =
     field_name_isequal(header(m, k), lowercase(v))
+
+"""
+    headercontains(::Message, key, value) -> Bool
+
+Does the header for `key` (interpreted as comma-separated list) contain `value` (both case-insensitive)?
+"""
+headercontains(m, k::AbstractString, v::AbstractString) =
+    any(field_name_isequal.(strip.(split(header(m, k), ",")), lowercase(v)))
 
 """
     setheader(::Message, key => value)

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -6,7 +6,7 @@ import ..HTTP
 using ..IOExtras
 using ..Streams
 import ..ConnectionPool
-using HTTP: header
+using HTTP: header, headercontains
 import ..@debug, ..DEBUG_LEVEL, ..@require, ..precondition_error
 import ..string
 
@@ -53,7 +53,7 @@ end
 function is_upgrade(r::HTTP.Message)
     ((r isa HTTP.Request && r.method == "GET") ||
      (r isa HTTP.Response && r.status == 101)) &&
-    HTTP.hasheader(r, "Connection", "upgrade") &&
+    HTTP.headercontains(r, "Connection", "upgrade") &&
     HTTP.hasheader(r, "Upgrade", "websocket")
 end
 
@@ -64,7 +64,7 @@ function check_upgrade(http)
                                 "$(http.message)"))
     end
 
-    if !hasheader(http, "Connection", "upgrade")
+    if !headercontains(http, "Connection", "upgrade")
         throw(WebSocketError(0, "Expected \"Connection: upgrade\"!\n" *
                                 "$(http.message)"))
     end

--- a/test/messages.jl
+++ b/test/messages.jl
@@ -62,9 +62,17 @@ using JSON
 
     ah(req, "X" => "Z")
     @test header(req, "X") == "Y, Z"
+    @test hasheader(req, "X", "Y, Z")
+    @test headercontains(req, "X", "Y")
+    @test headercontains(req, "X", "Z")
+    @test !headercontains(req, "X", "more")
 
     ah(req, "X" => "more")
     @test header(req, "X") == "Y, Z, more"
+    @test hasheader(req, "X", "Y, Z, more")
+    @test headercontains(req, "X", "Y")
+    @test headercontains(req, "X", "Z")
+    @test headercontains(req, "X", "more")
 
     ah(req, "Set-Cookie" => "A")
     ah(req, "Set-Cookie" => "B")


### PR DESCRIPTION
Fixes issue #320.

In order to accept upgrade requests from Firefox, which not only sends "connection: upgrade", but "connection: keep-alive, upgrade", a new method `headercontains` was added.

`headercontains` works similar to `hasheader` but will interpret the header value as comma-separated list and test if the expected value is in that list, rather than considering it as a single string.

Looking forward to your feedback.