### PR TITLE
Cosmetic changes

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -2,9 +2,6 @@ module HTTP
 
 export startwrite, startread, closewrite, closeread
 
-using MbedTLS
-import MbedTLS: SSLContext
-
 const DEBUG_LEVEL = 0
 
 Base.@deprecate escape escapeuri
@@ -344,9 +341,9 @@ open(f::Function, method::String, url, headers=Header[]; kw...)::Response =
 """
     HTTP.openraw(method, url, [, headers])::Tuple{TCPSocket, Response, ByteView}
 
-Open a raw socket that is unmanaged by HTTP.jl. Useful for doing HTTP upgrades to other protocols.
-Any bytes of the body read from the socket when reading headers, is returned as excess bytes in the
-last tuple argument.
+Open a raw socket that is unmanaged by HTTP.jl. Useful for doing HTTP upgrades
+to other protocols.  Any bytes of the body read from the socket when reading
+headers, is returned as excess bytes in the last tuple argument.
 
 Example of a WebSocket upgrade:
 ```julia

--- a/test/server.jl
+++ b/test/server.jl
@@ -33,10 +33,10 @@ port = 8087 # rand(8000:8999)
 
 # echo response
 handler = (http) -> begin
-    request::Request = http.message
+    request::HTTP.Request = http.message
     request.body = read(http)
     closeread(http)
-    request.response::Response = Response(request.body)
+    request.response::HTTP.Response = HTTP.Response(request.body)
     request.response.request = request
     startwrite(http)
     write(http, request.response.body)
@@ -123,10 +123,10 @@ println(client)
 @test occursin("Body of Request", client)
 
 hello = (http) -> begin
-    request::Request = http.message
+    request::HTTP.Request = http.message
     request.body = read(http)
     closeread(http)
-    request.response::Response = Response("Hello")
+    request.response::HTTP.Response = HTTP.Response("Hello")
     request.response.request = request
     startwrite(http)
     write(http, request.response.body)
@@ -169,10 +169,10 @@ end
 # test automatic forwarding of non-sensitive headers
 # this is a server that will "echo" whatever headers were sent to it
 t1 = @async HTTP.listen("127.0.0.1", 8090) do http
-    request::Request = http.message
+    request::HTTP.Request = http.message
     request.body = read(http)
     closeread(http)
-    request.response::Response = Response(200, req.headers)
+    request.response::HTTP.Response = HTTP.Response(200, request.headers)
     request.response.request = request
     startwrite(http)
     write(http, request.response.body)


### PR DESCRIPTION
Remove redundant `using MbedTLS` from toplevel `src/HTTP.jl`

Servers.jl:
 - Line-wrap some docstrings and code
 - More examples in docstrings.
 - Some refinement of wording and punctuation in docstrings.
 - Avoid bringing unwanted symbols in from MbedTLS (`encrypt` etc).
 - Rename `Server2` -> `Server` and fix type params.
 - Call `@async check_readtimeout` rather than having `@async while` inside that function.

test/server.jl
 - Qualify type names to allow test to run stand-alone.