### PR TITLE
Improve streaming interface. Reduce allocation and buffering.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,23 +3,13 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
 deps = ["Libdl", "Pkg", "SHA", "Test"]
-git-tree-sha1 = "b530fbeb6f41ab5a83fbe3db1fcbe879334bcd2d"
+git-tree-sha1 = "9930c1a6cd49d9fcd7218df6be417e6ae4f1468a"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.4.2"
-
-[[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ae262fa91da6a74e8937add6b613f58cd56cdad4"
-uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.1.0"
+version = "0.5.2"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-
-[[DelimitedFiles]]
-deps = ["Mmap"]
-uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
 deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
@@ -59,10 +49,10 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["BinaryProvider", "Compat", "Libdl", "Pkg", "Sockets"]
-git-tree-sha1 = "17d5a81dbb1e682d4ff707c01f0afe5948068fa6"
+deps = ["BinaryProvider", "Libdl", "Pkg", "Random", "Sockets", "Test"]
+git-tree-sha1 = "4b890362c0c2fdb14a575ce927f1f4eeac6dda9f"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "0.6.0"
+version = "0.6.4"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -89,20 +79,8 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[SharedArrays]]
-deps = ["Distributed", "Mmap", "Random", "Serialization"]
-uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
-
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
-uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-
-[[Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
-uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,10 +17,11 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 MbedTLS = "v0.6.0"
 
 [extras]
+BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [targets]
-test = ["Test", "JSON", "XMLDict", "Distributed"]
+test = ["Test", "JSON", "XMLDict", "Distributed", "BufferedStreams"]

--- a/src/DebugRequest.jl
+++ b/src/DebugRequest.jl
@@ -2,7 +2,6 @@ module DebugRequest
 
 import ..Layer, ..request
 using ..IOExtras
-import ..ConnectionPool: ByteView, byteview
 
 const live_mode = true
 

--- a/src/IODebug.jl
+++ b/src/IODebug.jl
@@ -10,7 +10,6 @@ import ..debug_header
 
     logwrite(iod::IODebug, f, x) = show_io_debug(stdout, "➡️ ", f, x)
     logread(iod::IODebug, f, x) = show_io_debug(stdout, "⬅️ ", f, x)
-    logunread(iod::IODebug, f, x) = show_io_debug(stdout, "♻️ ", f, x)
 
 else
 
@@ -23,7 +22,6 @@ else
 
     logwrite(iod::IODebug, f, x) = push!(iod.log, ("➡️ ", f, x))
     logread(iod::IODebug, f, x) = push!(iod.log, ("⬅️ ", f, x))
-    logunread(iod::IODebug, f, x) = push!(iod.log, ("♻️ ", f, x))
 
 end
  
@@ -57,9 +55,13 @@ Base.readavailable(iod::IODebug) =
     (r = readavailable(iod.io);
      logread(iod, :readavailable, String(copy(r))); r)
 
-IOExtras.unread!(iod::IODebug, bytes) =
-    (logunread(iod, :unread!, String(copy(bytes)));
-     unread!(iod.io, bytes))
+Base.readuntil(iod::IODebug, f) =
+    (r = readuntil(iod.io, f);
+     logread(iod, :readuntil, String(copy(r))); r)
+
+Base.readuntil(iod::IODebug, f, h) =
+    (r = readuntil(iod.io, f, h);
+     logread(iod, :readuntil, String(copy(r))); r)
 
 Base.eof(iod::IODebug) = eof(iod.io)
 Base.close(iod::IODebug) = close(iod.io)

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -1,6 +1,5 @@
 """
 This module defines extensions to the `Base.IO` interface to support:
- - an `unread!` function for pushing excess bytes back into a stream,
  - `startwrite`, `closewrite`, `startread` and `closeread` for streams
     with transactional semantics.
 """
@@ -9,8 +8,7 @@ module IOExtras
 using ..Sockets
 using MbedTLS: MbedException
 
-export bytes, ByteView, CodeUnits, IOError, isioerror,
-       unread!,
+export bytes, ByteView, nobytes, CodeUnits, IOError, isioerror,
        startwrite, closewrite, startread, closeread,
        tcpsocket, localport, peerport
 
@@ -56,42 +54,6 @@ end
 Base.show(io::IO, e::IOError) = print(io, "IOError(", e.e, " ", e.message, ")\n")
 
 
-"""
-    unread!(::IO, bytes)
-
-Push bytes back into a connection (to be returned by the next read).
-"""
-function unread!(io::IOBuffer, bytes)
-    l = length(bytes)
-    if l == 0
-        return
-    end
-
-    @assert bytes == io.data[io.ptr - l:io.ptr-1]
-
-    if io.seekable
-        seek(io, io.ptr - (l + 1))
-        return
-    end
-
-    println("WARNING: Can't unread! non-seekable IOBuffer")
-    println("         Discarding $(length(bytes)) bytes!")
-    @assert false
-    return
-end
-
-
-function unread!(io, bytes)
-    if length(bytes) == 0
-        return
-    end
-    println("WARNING: No unread! method for $(typeof(io))!")
-    println("         Discarding $(length(bytes)) bytes!")
-    return
-end
-
-
-
 _doc = """
     startwrite(::IO)
     closewrite(::IO)
@@ -125,46 +87,25 @@ peerport(io) = try !isopen(tcpsocket(io)) ? 0 :
                    0
                end
 
-end
-
 
 const ByteView = typeof(view(UInt8[], 1:0))
-
-const readuntil_block_size = 4096
+const nobytes = view(UInt8[], 1:0)
 
 """
 Read from an `IO` stream until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
-function Base.readuntil(io::IO,
-                        find_delimiter::Function #= Vector{UInt8} -> Int =#
-                       )::ByteView
+function Base.readuntil(buf::IOBuffer,
+                    find_delimiter::Function #= Vector{UInt8} -> Int =#
+                   )::ByteView
 
-    # Fast path, buffer already contains delimiter...
-    if !eof(io)
-        bytes = read(io, readuntil_block_size)
-        if (l = find_delimiter(bytes)) > 0
-            if l < length(bytes)
-                unread!(io, view(bytes, l+1:length(bytes)))
-            end
-            return view(bytes, 1:l)
-        end
-
-        # Otherwise, wait for delimiter...
-        buf = Vector{UInt8}(bytes)
-        while !eof(io)
-            bytes = read(io, readuntil_block_size)
-            append!(buf, bytes)
-            if (l = find_delimiter(buf)) > 0
-                if l < length(buf)
-                    n = length(buf) - l
-                    bl = length(bytes)
-                    unread!(io, view(bytes, 1+bl-n:bl))
-                end
-                return view(buf, 1:l)
-            end
-        end
+    l = find_delimiter(view(buf.data, buf.ptr:buf.size))
+    if l == 0
+        return nobytes
     end
+    bytes = view(buf.data, buf.ptr:buf.ptr + l - 1)
+    buf.ptr += l
+    return bytes
+end
 
-    throw(EOFError())
 end

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -130,6 +130,7 @@ end
 
 const ByteView = typeof(view(UInt8[], 1:0))
 
+const readuntil_block_size = 4096
 
 """
 Read from an `IO` stream until `find_delimiter(bytes)` returns non-zero.
@@ -141,7 +142,7 @@ function Base.readuntil(io::IO,
 
     # Fast path, buffer already contains delimiter...
     if !eof(io)
-        bytes = readavailable(io)
+        bytes = read(io, readuntil_block_size)
         if (l = find_delimiter(bytes)) > 0
             if l < length(bytes)
                 unread!(io, view(bytes, l+1:length(bytes)))
@@ -152,7 +153,7 @@ function Base.readuntil(io::IO,
         # Otherwise, wait for delimiter...
         buf = Vector{UInt8}(bytes)
         while !eof(io)
-            bytes = readavailable(io)
+            bytes = read(io, readuntil_block_size)
             append!(buf, bytes)
             if (l = find_delimiter(buf)) > 0
                 if l < length(buf)

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -495,7 +495,7 @@ Read chunk-size from an `IO` stream.
 After the final zero size chunk, read trailers into a `Message` struct.
 """
 function readchunksize(io::IO, message::Message)::Int
-    n = parse_chunk_size(readuntil(io, find_end_of_line))
+    n = parse_chunk_size(readuntil(io, find_end_of_chunk_size))
     if n == 0
         bytes = readuntil(io, find_end_of_trailer)
         if bytes[2] != UInt8('\n')

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -199,7 +199,6 @@ end
     if !headerscomplete(http.message)
         startread(http)
     end
-    # FIXME was: @require headerscomplete(http.message)
 
     # Find length of next chunk
     if http.ntoread == unknown_length && http.readchunked

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -8,10 +8,9 @@ import ..HTTP
 using ..Sockets
 using ..IOExtras
 using ..Messages
-import ..ByteView
 import ..Messages: header, hasheader, setheader,
                    writeheaders, writestartline
-import ..ConnectionPool: getrawstream, nobytes, ByteView
+import ..ConnectionPool: getrawstream
 import ..@require, ..precondition_error
 import ..@ensure, ..postcondition_error
 import ..@debug, ..DEBUG_LEVEL
@@ -228,12 +227,12 @@ end
     @ensure http.ntoread >= 0
 end
 
-function Base.readavailable(http::Stream, n::Int=typemax(Int))::ByteView
+function Base.readavailable(http::Stream, n::Int=typemax(Int))
 
     ntr = ntoread(http)
 
     if ntr == 0
-        return nobytes
+        return UInt8[]
     end
 
     n2 = min(n, ntr + nextra(http)) # Try to read (and ignore) trailing CRLF

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -193,11 +193,10 @@ end
 
 @inline function ntoread(http::Stream)
 
-    @require headerscomplete(http.message)
-    # FIXME ?
-    #if !headerscomplete(http.message)
-    #    startread(http)
-    #end
+    if !headerscomplete(http.message)
+        startread(http)
+    end
+    # FIXME was: @require headerscomplete(http.message)
 
     # Find length of next chunk
     if http.ntoread == unknown_length && http.readchunked

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 JSON
 XMLDict
+BufferedStreams

--- a/test/loopback.jl
+++ b/test/loopback.jl
@@ -35,6 +35,7 @@ end
 Base.eof(lb::Loopback) = eof(lb.io)
 Base.bytesavailable(lb::Loopback) = bytesavailable(lb.io)
 Base.readavailable(lb::Loopback) = readavailable(lb.io)
+Base.unsafe_read(lb::Loopback, p::Ptr, n::Integer) = unsafe_read(lb.io, p, n)
 Base.close(lb::Loopback) = (close(lb.io); close(lb.buf))
 Base.isopen(lb::Loopback) = isopen(lb.io)
 


### PR DESCRIPTION
These changes:
 - Improve the streaming interface (see #337, #339) by implementing more of the Base `IO` interface for `HTTP.Stream`: `close`, `unsafe_read`, `read(io, UInt8)`, `read(io, n)`, `.readbytes!` etc.
 - Change the internal read implementation to use `unsafe_read` (rather than `readavailable`) where possible to reduce allocation and buffering.
 - Replace `Connection.excess::ByteView` with `Connection.buffer::IOBuffer` and remove `IOExtras.unread`. The `buffer` is used to read headers and chunk sizes (who's byte-length can't be determined in advance).

The previous `ByteView` / `unread!` scheme avoided copying data between buffers by twiddling views into the buffer returned by `readavailable`. However, using `readavailable` implies allocating a new buffer on every MbedTLS read. With these changes, the method `Base.readuntil(t::Transaction, f::Function)` reads small blocks of bytes into an `IOBuffer` until the end of the header is found.

https://github.com/JuliaWeb/HTTP.jl/blob/a77beb6dde496a65c49917d9e3480862c9d5384f/src/ConnectionPool.jl#L220-L230

 The `IOBuffer` remains allocated for the lifetime of the `Connection`. The excess bytes after the header are consumed by the next call to one of the `read*` methods. After that, the `read*` methods are passed directly to the underlying `MbedTLS.Context`.

Consider an audio streaming example:
```julia
samples = Vector{UInt8}(undef, 16384)
HTTP.open("GET", url) do http
    while !eof(http)
        n = readbytes!(http, samples)
        play_audio_samples(samples, n)
    end
end
```

The `readbytes!` call will occasionally result in an internal read to `Connection.buffer::IOBuffer` to read HTTP headers or HTTP chunk size. However, most of the time the `ccall` to `mbedtls_ssl_read` will now be reading bytes directly into the `samples` buffer.

Needs Tests