### PR TITLE
Close WebSockets with a status code

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -164,11 +164,15 @@ function Base.write(ws::WebSocket, x1, x2, xs...)
     return n
 end
 
-function IOExtras.closewrite(ws::WebSocket)
+function IOExtras.closewrite(ws::WebSocket; statuscode=nothing)
     @require !ws.txclosed
     opcode = WS_FINAL | WS_CLOSE
     @debug 1 "WebSocket ⬅️  $(WebSocketHeader(opcode, 0x00))"
-    write(ws.io, [opcode, 0x00])
+    if statuscode === nothing
+        write(ws.io, [opcode, 0x00])
+    else
+        wswrite(ws, opcode, reinterpret(UInt8, [hton(UInt16(statuscode))]))
+    end
     ws.txclosed = true
 end
 
@@ -210,9 +214,10 @@ function mask!(to, from, l, mask=rand(UInt8, 4))
     return mask
 end
 
-function Base.close(ws::WebSocket)
+function Base.close(ws::WebSocket; statuscode::Union{Int, Nothing}=nothing)
+    isopen(ws) || return
     if !ws.txclosed
-        closewrite(ws)
+        closewrite(ws; statuscode=statuscode)
     end
     while !eof(ws) # FIXME Timeout in case other end does not send CLOSE?
         readframe(ws)


### PR DESCRIPTION
@samoconnor's advice on https://github.com/JuliaWeb/MbedTLS.jl/issues/186#issuecomment-435547230 worked perfectly :slightly_smiling_face:. I also added a check for the connection still being open, since writing to a closed one throws an error.
Closes #347 