### PR TITLE
Make DEBUG_LEVEL a Ref{Int} instead of an Int

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -667,7 +667,7 @@ function Base.show(io::IO, c::Connection)
         " ≣", c.pipeline_limit,
         length(c.excess) > 0 ? " $(length(c.excess))-byte excess" : "",
         nwaiting > 0 ? " $nwaiting bytes waiting" : "",
-        DEBUG_LEVEL > 1 && applicable(tcpsocket, c.io) ?
+        DEBUG_LEVEL[] > 1 && applicable(tcpsocket, c.io) ?
             " $(Base._fd(tcpsocket(c.io)))" : "")
 end
 

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -2,7 +2,7 @@ module HTTP
 
 export startwrite, startread, closewrite, closeread
 
-const DEBUG_LEVEL = 0
+const DEBUG_LEVEL = Ref(0)
 
 Base.@deprecate escape escapeuri
 Base.@deprecate URL URI
@@ -622,7 +622,7 @@ function stack(;redirect=true,
     (status_exception     ? ExceptionLayer            : NoLayer){
                             ConnectionPoolLayer{
     (verbose >= 3 ||
-     DEBUG_LEVEL >= 3     ? DebugLayer                : NoLayer){
+     DEBUG_LEVEL[] >= 3   ? DebugLayer                : NoLayer){
     (readtimeout > 0      ? TimeoutLayer              : NoLayer){
                             StreamLayer
     }}}}}}}}}}}}

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -3,23 +3,23 @@ taskid(t=current_task()) = string(hash(t) & 0xffff, base=16, pad=4)
 debug_header() = string("DEBUG: ", rpad(Dates.now(), 24), taskid(), " ")
 
 macro debug(n::Int, s)
-    DEBUG_LEVEL >= n ? :(println(debug_header(), $(esc(s)))) :
-                       :()
+    DEBUG_LEVEL[] >= n ? :(println(debug_header(), $(esc(s)))) :
+                         :()
 end
 
 macro debugshow(n::Int, s)
-    DEBUG_LEVEL >= n ? :(println(debug_header(),
-                                 $(sprint(Base.show_unquoted, s)), " = ",
-                                 sprint(io->show(io, "text/plain",
-                                                 begin value=$(esc(s)) end)))) :
-                       :()
+    DEBUG_LEVEL[] >= n ? :(println(debug_header(),
+                                   $(sprint(Base.show_unquoted, s)), " = ",
+                                   sprint(io->show(io, "text/plain",
+                                                   begin value=$(esc(s)) end)))) :
+                         :()
 
 end
 
 macro debugshort(n::Int, s)
-    DEBUG_LEVEL >= n ? :(println(debug_header(),
-                                 sprintcompact($(esc(s))))) :
-                       :()
+    DEBUG_LEVEL[] >= n ? :(println(debug_header(),
+                                   sprintcompact($(esc(s))))) :
+                         :()
 end
 
 sprintcompact(x) = sprint(show, x; context=:compact => true)
@@ -81,7 +81,7 @@ Throw `ArgumentError` if `postcondition` is false.
 """
 macro ensure(condition, msg = string(condition))
 
-    if DEBUG_LEVEL < 0
+    if DEBUG_LEVEL[] < 0
         return :()
     end
 


### PR DESCRIPTION
This is a quality of life improvement for local use. One can now simply write `HTTP.DEBUG_LEVEL[] = 2`, for example, to set the appropriate level.