### PR TITLE
AWS4: Header changes and tests

### DIFF
--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -47,6 +47,7 @@ function sign_aws4!(method::String,
                     aws_access_key_id::String=ENV["AWS_ACCESS_KEY_ID"],
                     aws_secret_access_key::String=ENV["AWS_SECRET_ACCESS_KEY"],
                     aws_session_token::String=get(ENV, "AWS_SESSION_TOKEN", ""),
+                    include_md5=true,
                     kw...)
     if t !== nothing
         Base.depwarn("The `t` keyword argument to `sign_aws4!` is deprecated; use " *
@@ -78,7 +79,7 @@ function sign_aws4!(method::String,
     setkv(headers, "host", url.host)
     setkv(headers, "x-amz-content-sha256",  content_hash)
     setkv(headers, "x-amz-date",  datetime)
-    setkv(headers, "Content-MD5", base64encode(body_md5))
+    include_md5 && setkv(headers, "Content-MD5", base64encode(body_md5))
     if aws_session_token != ""
         setkv(headers, "x-amz-security-token", aws_session_token)
     end

--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -48,6 +48,7 @@ function sign_aws4!(method::String,
                     aws_secret_access_key::String=ENV["AWS_SECRET_ACCESS_KEY"],
                     aws_session_token::String=get(ENV, "AWS_SESSION_TOKEN", ""),
                     include_md5=true,
+                    include_sha256=true,
                     kw...)
     if t !== nothing
         Base.depwarn("The `t` keyword argument to `sign_aws4!` is deprecated; use " *
@@ -77,9 +78,13 @@ function sign_aws4!(method::String,
     # HTTP headers...
     rmkv(headers, "Authorization")
     setkv(headers, "host", url.host)
-    setkv(headers, "x-amz-content-sha256",  content_hash)
-    setkv(headers, "x-amz-date",  datetime)
+    setkv(headers, "x-amz-date", datetime)
     include_md5 && setkv(headers, "Content-MD5", base64encode(body_md5))
+    if (aws_service == "s3" && method == "PUT") || include_sha256
+        # This header is required for S3 PUT requests. See the documentation at
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+        setkv(headers, "x-amz-content-sha256", content_hash)
+    end
     if aws_session_token != ""
         setkv(headers, "x-amz-security-token", aws_session_token)
     end

--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -75,6 +75,7 @@ function sign_aws4!(method::String,
 
     # HTTP headers...
     rmkv(headers, "Authorization")
+    setkv(headers, "host", url.host)
     setkv(headers, "x-amz-content-sha256",  content_hash)
     setkv(headers, "x-amz-date",  datetime)
     setkv(headers, "Content-MD5", base64encode(body_md5))

--- a/test/aws4.jl
+++ b/test/aws4.jl
@@ -1,0 +1,44 @@
+using Dates
+using Test
+using HTTP
+using HTTP: Headers, URI
+using HTTP.AWS4AuthRequest: sign_aws4!
+
+# Based on https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
+
+@testset "AWS Signature Version 4" begin
+    # NOTE: These are the example credentials as specified in the AWS docs, they are not real
+    withenv("AWS_ACCESS_KEY_ID" => "AKIDEXAMPLE",
+            "AWS_SECRET_ACCESS_KEY" => "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY") do
+
+        cases = [
+            ("get-vanilla", "", "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"),
+            ("get-vanilla-empty-query-key", "?Param1=value1", "a67d582fa61cc504c4bae71f336f98b97f1ea3c7a6bfe1b6e45aec72011b9aeb"),
+            ("get-utf8", "ሴ", "8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85"),
+        ]
+        for (name, p, sig) in cases
+            @testset "$name" begin
+                headers = Headers([])
+                sign_aws4!("GET",
+                           URI("https://example.amazonaws.com/" * p),
+                           headers,
+                           UInt8[];
+                           timestamp=DateTime(2015, 8, 30, 12, 36),
+                           aws_service="service",
+                           aws_region="us-east-1",
+                           include_md5=false,
+                           include_sha256=false)
+                @test sort(map(first, headers)) == ["Authorization", "host", "x-amz-date"]
+                d = Dict(headers)
+                @test d["x-amz-date"] == "20150830T123600Z"
+                @test d["host"] == "example.amazonaws.com"
+                auth = string("AWS4-HMAC-SHA256 ",
+                              "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, ",
+                              "SignedHeaders=host;x-amz-date, ",
+                              "Signature=", sig)
+                @test d["Authorization"] == auth
+            end
+        end
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,8 @@ using HTTP
               "messages.jl",
               "handlers.jl",
               "server.jl",
-              "async.jl"]
+              "async.jl",
+              "aws4.jl"]
 
         println("Running $f tests...")
         include(f)


### PR DESCRIPTION
This PR consists of 4 related but functionally distinct commits:

* Include `host` unconditionally in the headers. This matches all of Amazon's examples, though it is not required.
* Make the `Content-MD5` header optional. This is recommended but not required, and omitting it aids in testing against Amazon's official test cases. The default here is to include it (no change in behavior).
* Make the `x-amz-content-sha256` header optional when it isn't required. It is only required for S3 PUT requests. The default here is to always include it (no change in behavior).
* Add a few basic tests that pass from Amazon's test suite. This is a first step toward #291.