### PR TITLE
 Add option to exclude the session token from signing 

### DIFF
--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -60,6 +60,7 @@ function sign_aws4!(method::String,
                     aws_access_key_id::String=ENV["AWS_ACCESS_KEY_ID"],
                     aws_secret_access_key::String=ENV["AWS_SECRET_ACCESS_KEY"],
                     aws_session_token::String=get(ENV, "AWS_SESSION_TOKEN", ""),
+                    token_in_signature=true,
                     include_md5=true,
                     include_sha256=true,
                     kw...)
@@ -106,6 +107,10 @@ function sign_aws4!(method::String,
     unique_header_keys = Vector{String}()
     normalized_headers = Dict{String,Vector{String}}()
     for (k, v) in sort!([lowercase(k) => v for (k, v) in headers], by=first)
+        # Some services want the token included as part of the signature
+        if k == "x-amz-security-token" && !token_in_signature
+            continue
+        end
         if !haskey(normalized_headers, k)
             normalized_headers[k] = Vector{String}()
             push!(unique_header_keys, k)

--- a/test/aws4.jl
+++ b/test/aws4.jl
@@ -6,8 +6,8 @@ using HTTP.AWS4AuthRequest: sign_aws4!
 
 # Based on https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
 
-function test_get!(headers, params; opts...)
-    sign_aws4!("GET",
+function test_sign!(method, headers, params; opts...)
+    sign_aws4!(method,
                URI("https://example.amazonaws.com/" * params),
                headers,
                UInt8[];
@@ -51,9 +51,12 @@ const required_headers = ["Authorization", "host", "x-amz-date"]
         ("get-slashes", "example/", "9a624bd73a37c9a373b5312afbebe7a714a789de108f0bdfe846570885f57e84"),
         ("get-slash-pointless-dot", "./example", "ef75d96142cf21edca26f06005da7988e4f8dc83a165a80865db7089db637ec5"),
         ("get-space", "example space/", "652487583200325589f1fba4c7e578f72c47cb61beeca81406b39ddec1366741"),
+        ("post-vanilla", "", "5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b"),
+        ("post-vanilla-empty-query-value", "?Param1=value1", "28038455d6de14eafc1f9222cf5aa6f1a96197d7deb8263271d420d138af7f11"),
     ]
     @testset "$name" for (name, p, sig) in noheaders
-        headers = test_get!(Headers([]), p)
+        m = startswith(name, "get") ? "GET" : "POST"
+        headers = test_sign!(m, Headers([]), p)
         @test header_keys(headers) == required_headers
         d = Dict(headers)
         @test d["x-amz-date"] == "20150830T123600Z"
@@ -84,10 +87,19 @@ const required_headers = ["Authorization", "host", "x-amz-date"]
                   "My-Header2" => " \"a   b   c\""]),
          "host;my-header1;my-header2;x-amz-date",
          "acc3ed3afb60bb290fc8d2dd0098b9911fcaa05412b367055dee359757a9c736"),
+        ("post-header-key-sort", "",
+         Headers(["My-Header1" => "value1"]),
+         "host;my-header1;x-amz-date",
+         "c5410059b04c1ee005303aed430f6e6645f61f4dc9e1461ec8f8916fdf18852c"),
+        ("post-header-value-case", "",
+         Headers(["My-Header1" => "VALUE1"]),
+         "host;my-header1;x-amz-date",
+         "cdbc9802e29d2942e5e10b5bccfdd67c5f22c7c4e8ae67b53629efa58b974b7d"),
     ]
     @testset "$name" for (name, p, h, sh, sig) in yesheaders
         hh = sort(map(first, h))
-        test_get!(h, p)
+        m = startswith(name, "get") ? "GET" : "POST"
+        test_sign!(m, h, p)
         @test header_keys(h) == sort(vcat(required_headers, hh))
         d = Dict(h) # collapses duplicates but we don't care here
         @test d["x-amz-date"] == "20150830T123600Z"

--- a/test/aws4.jl
+++ b/test/aws4.jl
@@ -106,5 +106,30 @@ const required_headers = ["Authorization", "host", "x-amz-date"]
         @test d["host"] == "example.amazonaws.com"
         @test d["Authorization"] == test_auth_string(sh, sig)
     end
+    @testset "AWS Security Token Service" begin
+        # Not a real security token, provided by AWS as an example
+        token = string("AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwd",
+                       "QWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/k",
+                       "McGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7WZ0wq5VSXD",
+                       "vp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7ZD0u0iPPkUL64",
+                       "lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx3iSIlTJabIQwj2I",
+                       "CCR/oLxBA==")
+        @testset "Token included in signature" begin
+            sh = "host;x-amz-date;x-amz-security-token"
+            sig = "85d96828115b5dc0cfc3bd16ad9e210dd772bbebba041836c64533a82be05ead"
+            h = test_sign!("POST", Headers([]), "", aws_session_token=token)
+            d = Dict(h)
+            @test d["Authorization"] == test_auth_string(sh, sig)
+            @test haskey(d, "x-amz-security-token")
+        end
+        @testset "Token not included in signature" begin
+            sh = "host;x-amz-date"
+            sig = "5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b"
+            h = test_sign!("POST", Headers([]), "", aws_session_token=token, token_in_signature=false)
+            d = Dict(h)
+            @test d["Authorization"] == test_auth_string(sh, sig)
+            @test haskey(d, "x-amz-security-token")
+        end
+    end
 end
 


### PR DESCRIPTION
This PR consists of two commits, the first of which simply provides tests for AWS4 POST requests. The second adds an option to exclude the session token when calculating the signature. According to Amazon some services want it in the signature and some do not. The header is always included if the token is available, and it's included in signing by default, which means there's no change in default behavior.