### PR TITLE
Exclude Content-Length from AWS4 signing

### DIFF
--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -111,6 +111,11 @@ function sign_aws4!(method::String,
         if k == "x-amz-security-token" && !token_in_signature
             continue
         end
+        # In Amazon's examples, they exclude Content-Length from signing. This does not
+        # appear to be addressed in the documentation, so we'll just mimic the example.
+        if k == "content-length"
+            continue
+        end
         if !haskey(normalized_headers, k)
             normalized_headers[k] = Vector{String}()
             push!(unique_header_keys, k)

--- a/test/aws4.jl
+++ b/test/aws4.jl
@@ -6,11 +6,11 @@ using HTTP.AWS4AuthRequest: sign_aws4!
 
 # Based on https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
 
-function test_sign!(method, headers, params; opts...)
+function test_sign!(method, headers, params, body=""; opts...)
     sign_aws4!(method,
                URI("https://example.amazonaws.com/" * params),
                headers,
-               UInt8[];
+               Vector{UInt8}(body);
                timestamp=DateTime(2015, 8, 30, 12, 36),
                aws_service="service",
                aws_region="us-east-1",
@@ -65,41 +65,51 @@ const required_headers = ["Authorization", "host", "x-amz-date"]
     end
 
     yesheaders = [
-        ("get-header-key-duplicate", "",
+        ("get-header-key-duplicate", "", "",
          Headers(["My-Header1" => "value2",
                   "My-Header1" => "value2",
                   "My-Header1" => "value1"]),
          "host;my-header1;x-amz-date",
          "c9d5ea9f3f72853aea855b47ea873832890dbdd183b4468f858259531a5138ea"),
-        ("get-header-value-multiline", "",
+        ("get-header-value-multiline", "", "",
          Headers(["My-Header1" => "value1\n  value2\n    value3"]),
          "host;my-header1;x-amz-date",
          "ba17b383a53190154eb5fa66a1b836cc297cc0a3d70a5d00705980573d8ff790"),
-        ("get-header-value-order", "",
+        ("get-header-value-order", "", "",
          Headers(["My-Header1" => "value4",
                   "My-Header1" => "value1",
                   "My-Header1" => "value3",
                   "My-Header1" => "value2"]),
          "host;my-header1;x-amz-date",
          "08c7e5a9acfcfeb3ab6b2185e75ce8b1deb5e634ec47601a50643f830c755c01"),
-        ("get-header-value-trim", "",
+        ("get-header-value-trim", "", "",
          Headers(["My-Header1" => " value1",
                   "My-Header2" => " \"a   b   c\""]),
          "host;my-header1;my-header2;x-amz-date",
          "acc3ed3afb60bb290fc8d2dd0098b9911fcaa05412b367055dee359757a9c736"),
-        ("post-header-key-sort", "",
+        ("post-header-key-sort", "", "",
          Headers(["My-Header1" => "value1"]),
          "host;my-header1;x-amz-date",
          "c5410059b04c1ee005303aed430f6e6645f61f4dc9e1461ec8f8916fdf18852c"),
-        ("post-header-value-case", "",
+        ("post-header-value-case", "", "",
          Headers(["My-Header1" => "VALUE1"]),
          "host;my-header1;x-amz-date",
          "cdbc9802e29d2942e5e10b5bccfdd67c5f22c7c4e8ae67b53629efa58b974b7d"),
+        ("post-x-www-form-urlencoded", "", "Param1=value1",
+         Headers(["Content-Type" => "application/x-www-form-urlencoded",
+                  "Content-Length" => "13"]),
+         "content-type;host;x-amz-date",
+         "ff11897932ad3f4e8b18135d722051e5ac45fc38421b1da7b9d196a0fe09473a"),
+        ("post-x-www-form-urlencoded-parameters", "", "Param1=value1",
+         Headers(["Content-Type" => "application/x-www-form-urlencoded; charset=utf8",
+                  "Content-Length" => "13"]),
+         "content-type;host;x-amz-date",
+         "1a72ec8f64bd914b0e42e42607c7fbce7fb2c7465f63e3092b3b0d39fa77a6fe"),
     ]
-    @testset "$name" for (name, p, h, sh, sig) in yesheaders
+    @testset "$name" for (name, p, body, h, sh, sig) in yesheaders
         hh = sort(map(first, h))
         m = startswith(name, "get") ? "GET" : "POST"
-        test_sign!(m, h, p)
+        test_sign!(m, h, p, body)
         @test header_keys(h) == sort(vcat(required_headers, hh))
         d = Dict(h) # collapses duplicates but we don't care here
         @test d["x-amz-date"] == "20150830T123600Z"


### PR DESCRIPTION
This is done in Amazon's examples but does not appear to be addressed in the documentation, so we'll just follow suit with the example.