### PR TITLE
allowed space after comma separator

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -335,7 +335,7 @@ hasheader(m, k::AbstractString, v::AbstractString) =
 Does the header for `key` (interpreted as comma-separated list) contain `value` (both case-insensitive)?
 """
 headercontains(m, k::AbstractString, v::AbstractString) =
-    any(field_name_isequal.(strip.(split(header(m, k), ",")), v))
+    any(field_name_isequal.(strip.(split(header(m, k), r", ?")), v))
 
 """
     setheader(::Message, key => value)


### PR DESCRIPTION
allowed one space after comma separator between HTTP header fields (resolve #373 and #370 ) 