### PR TITLE
Fix @register for Pages.jl

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -394,13 +394,16 @@ gh(s::String) = isempty(s) ? Any : Val{Symbol(s)}
 gh(s::Symbol) = Val{s}
 
 function generate_gethandler(router, method, scheme, host, path, handler)
+    m = :(HTTP.Handlers.gh($method))
+    s = :(HTTP.Handlers.gh($scheme))
+    h = :(HTTP.Handlers.gh($host))
     vals = :(HTTP.Handlers.newsplitsegments(map(String, split($path, '/'; keepempty=false)))...)
     q = esc(quote
         $(router).routes[HTTP.Handlers.Route(string($method), string($scheme), string($host), string($path))] = $handler
         @eval function HTTP.Handlers.gethandler(r::$(Expr(:$, :(typeof($router)))),
-            ::(HTTP.Handlers.gh($method)),
-            ::(HTTP.Handlers.gh($scheme)),
-            ::(HTTP.Handlers.gh($host)),
+            ::$(Expr(:$, m)),
+            ::$(Expr(:$, s)),
+            ::$(Expr(:$, h)),
             $(Expr(:$, vals)),
             args...)
             return $(Expr(:$, handler)) isa HTTP.Handler ? $(Expr(:$, handler)) : HTTP.Handlers.RequestHandlerFunction($(Expr(:$, handler)))


### PR DESCRIPTION
Hi,

I am no good with macros so this issue was tough for me to track down.

I have a package [Pages.jl](https://github.com/EricForgy/Pages.jl) and decided to take a leap and try to update it in preparation of tagging a new release of HTTP.jl.

I immediately ran into problems. With HTTP.jl v0.7.1, I have this constructor:

```julia
function Endpoint(handler,method,route)
    HTTP.register!(router[],method,route,HTTP.HandlerFunction(handler))
    new(handler,method,route)
end
```

Without any warning, this function dies because HTTP.jl `master` no longer has a `HandleFunction`.

I modify the constructor to the following:

```julia
function Endpoint(handler,method,route)
    HTTP.register!(router[],method,route,HTTP.RequestHandlerFunction(handler))
    new(handler,method,route)
end
```

The code now runs, but I get a deprecation warning about `register!` and I should use `@register` instead, so I modify again to:

```julia
function Endpoint(handler,method,route)
    HTTP.@register(router[],method,route,HTTP.RequestHandlerFunction(handler))
    new(handler,method,route)
end
```

and I get a very unhelpful error message:

```julia
ERROR: UndefVarError: method not defined
```

Six very stressful hours later pulling what little hair I have left out, I finally came up with this PR that works with Pages.jl and still passes all tests.

To be honest, I don't fully understand why the old code didn't work nor why this new code works, but it does, so I say "ship it" 😂 

More seriously, please have a look 😊 

I am really hopeful we can tag a new release soon and happy to help iron out any blocking issues.