### PR TITLE
Fix cookies=true

### DIFF
--- a/src/CookieRequest.jl
+++ b/src/CookieRequest.jl
@@ -20,15 +20,17 @@ export CookieLayer
 
 function request(::Type{CookieLayer{Next}},
                  method::String, url::URI, headers, body;
-                 cookies::Dict{String, String}=Dict{String, String}(),
+                 cookies::Union{Bool, Dict{String, String}}=Dict{String, String}(),
                  cookiejar::Dict{String, Set{Cookie}}=default_cookiejar,
                  kw...) where Next
 
     hostcookies = get!(cookiejar, url.host, Set{Cookie}())
 
     cookiestosend = getcookies(hostcookies, url)
-    for (name, value) in cookies
-        push!(cookiestosend, Cookie(name, value))
+    if !(cookies isa Bool)
+        for (name, value) in cookies
+            push!(cookiestosend, Cookie(name, value))
+        end
     end
     if !isempty(cookiestosend)
         setkv(headers, "Cookie", string(getkv(headers, "Cookie", ""), cookiestosend))


### PR DESCRIPTION
Fixing a bug where passing `cookies=true` would result in a TypeError.

v0.8.0 introduced a bug introduced during the resolution of #360 where unless a populated `Dict` was passed to the `cookies` keyword the CookieLayer would either be disabled (empty `Dict`) or a TypeError would occur (passing `true`)

This allows passing `cookies = true` again by allowing a `Union{Bool, Dict{String, String}}` and branching when `cookies` is a `Bool`.

I'm not entirely sure why `cookies` is checked for emptiness here:
https://github.com/JuliaWeb/HTTP.jl/blob/0d007944f25339e16725b147d63b122559cac47e/src/HTTP.jl#L618
Removing this could allow some edge cases where it is programmatically generated but might be empty while cookie handling is still desired. (This change is not in this PR yet)
