### PR TITLE
fix websocket connection for Firefox

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -65,7 +65,7 @@ function check_upgrade(http)
                                 "$(http.message)"))
     end
 
-    if !(headercontains(http, "Connection", "upgrade") ||
+    if !(hasheader(http, "Connection", "upgrade") ||
          hasheader(http, "Connection", "keep-alive, upgrade"))
         throw(WebSocketError(0, "Expected \"Connection: upgrade\"!\n" *
                                 "$(http.message)"))

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -53,7 +53,8 @@ end
 function is_upgrade(r::HTTP.Message)
     ((r isa HTTP.Request && r.method == "GET") ||
      (r isa HTTP.Response && r.status == 101)) &&
-    HTTP.headercontains(r, "Connection", "upgrade") &&
+    (HTTP.hasheader(r, "Connection", "upgrade") ||
+     HTTP.hasheader(r, "Connection", "keep-alive, upgrade")) &&
     HTTP.hasheader(r, "Upgrade", "websocket")
 end
 
@@ -64,7 +65,8 @@ function check_upgrade(http)
                                 "$(http.message)"))
     end
 
-    if !headercontains(http, "Connection", "upgrade")
+    if !(headercontains(http, "Connection", "upgrade") ||
+         hasheader(http, "Connection", "keep-alive, upgrade"))
         throw(WebSocketError(0, "Expected \"Connection: upgrade\"!\n" *
                                 "$(http.message)"))
     end


### PR DESCRIPTION
This follows the example in WebSockets.jl to get websocket connections working for Firefox (see this code snippet:
https://github.com/JuliaWeb/WebSockets.jl/blob/64dfe1d4513335031246d562ec4be3102f182101/src/HT TP.jl#L244 )

This is working for me locally, but I'm new to Julia development, and I think I have messed up dependencies, so someone should probably give this a quick check before merging.

Thanks!