### PR TITLE
Check for headers correctly in download

### DIFF
--- a/src/download.jl
+++ b/src/download.jl
@@ -107,7 +107,6 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
         downloaded_bytes = 0
         start_time = now()
         prev_time = now()
-         
         
         function report_callback()
             prev_time = now()

--- a/src/download.jl
+++ b/src/download.jl
@@ -52,7 +52,7 @@ determine_file(::Nothing, resp) = determine_file(tempdir(), resp)
 function determine_file(path, resp)
     # get the name
     name = if isdir(path)
-        # We have been given a path too a directory
+        # we have been given a path to a directory
         # got to to workout what file to put there
         filename = something(
                         try_get_filename_from_headers(resp),

--- a/src/download.jl
+++ b/src/download.jl
@@ -100,11 +100,14 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
     local file
     HTTP.open("GET", url, headers; kw...) do stream
         resp = startread(stream)
+        eof(stream) && return  # don't do anything for streams we can't read (yet)
+        
         file = determine_file(local_path, resp)
         total_bytes = parse(Float64, header(resp, "Content-Length", "NaN"))
         downloaded_bytes = 0
         start_time = now()
         prev_time = now()
+         
         
         function report_callback()
             prev_time = now()

--- a/src/download.jl
+++ b/src/download.jl
@@ -52,6 +52,7 @@ determine_file(::Nothing, resp) = determine_file(tempdir(), resp)
 function determine_file(path, resp)
     # get the name
     name = if isdir(path)
+        # We have been given a path too a directory
         # got to to workout what file to put there
         filename = something(
                         try_get_filename_from_headers(resp),
@@ -60,7 +61,7 @@ function determine_file(path, resp)
                     )
         safer_joinpath(path, filename)
     else
-        # It is a file, we are done.
+        # We have been given a full filepath
         path
     end
 


### PR DESCRIPTION
There was a problem that @mschauer  found with

```
download("https://www.dropbox.com/s/uy6j8wru1nkqhw5/coal.csv?dl=1")
```
returning the wrong filename.
It was coming back with `"coal.csv?dl=1"`,
but the correct name according to headers is `"coal.csv"`.

I took a look in the headers and realized that they were casing all in lowercase.
Which is allowed, but the download  function was doing a case sensitive check on the list of headers,
rather than using the `header` function on the response.

This PR fixes that.

Could add a test based on the above, but seems a bit fragile.