### PR TITLE
Change defaultheader to defaultheader! to clarify mutating function

### DIFF
--- a/docs/src/internal_interface.md
+++ b/docs/src/internal_interface.md
@@ -25,7 +25,7 @@ HTTP.Messages.isidempotent
 HTTP.Messages.header
 HTTP.Messages.hasheader
 HTTP.Messages.setheader
-HTTP.Messages.defaultheader
+HTTP.Messages.defaultheader!
 HTTP.Messages.appendheader
 HTTP.Messages.readheaders
 HTTP.MessageRequest.setuseragent!

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -45,7 +45,7 @@ function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
     end
 
     if io.sequence >= reuse_limit
-        defaultheader(req, "Connection" => "close")
+        defaultheader!(req, "Connection" => "close")
     end
 
     try

--- a/src/MessageRequest.jl
+++ b/src/MessageRequest.jl
@@ -25,9 +25,9 @@ function request(::Type{MessageLayer{Next}},
                  target=resource(url),
                  parent=nothing, iofunction=nothing, kw...) where Next
 
-    defaultheader(headers, "Host" => url.host)
+    defaultheader!(headers, "Host" => url.host)
     if isassigned(USER_AGENT)
-        defaultheader(headers, "User-Agent" => USER_AGENT[])
+        defaultheader!(headers, "User-Agent" => USER_AGENT[])
     end
 
     if !hasheader(headers, "Content-Length") &&

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -60,7 +60,7 @@ module Messages
 export Message, Request, Response, HeaderSizeError,
        reset!, status, method, headers, uri, body,
        iserror, isredirect, ischunked, issafe, isidempotent,
-       header, hasheader, headercontains, setheader, defaultheader, appendheader,
+       header, hasheader, headercontains, setheader, defaultheader!, appendheader,
        mkheaders, readheaders, headerscomplete,
        readchunksize,
        writeheaders, writestartline,
@@ -349,16 +349,17 @@ setheader(h::Headers, v::Pair) =
                field_name_isequal)
 
 """
-    defaultheader(::Message, key => value)
+    defaultheader!(::Message, key => value)
 
-Set header `value` for `key` if it is not already set.
+Set header `value` in message for `key` if it is not already set.
 """
-function defaultheader(m, v::Pair)
+function defaultheader!(m, v::Pair)
     if header(m, first(v)) == ""
         setheader(m, v)
     end
     return
 end
+Base.@deprecate defaultheader defaultheader!
 
 """
     appendheader(::Message, key => value)


### PR DESCRIPTION
As I was reading through the package, `defaultheader` being called without anything being done with its return value confused me momentarily until I read it and realized it was a mutating function. This is basically a documentation change to make the package a little easier to grok.

Since defaultheader is considered part of the internal interface, there really
isn't any deprecation necessary, but I included one just in case.