### PR TITLE
Expand `Server` convenience type and use in `listen` and `listenloop`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,22 +5,24 @@ using Test
 using HTTP
 
 @testset "HTTP" begin
-    for f in ["ascii.jl",
-              "issue_288.jl",
-              "utils.jl",
-              "sniff.jl",
-              "uri.jl",
-              "url.jl",
-              "cookies.jl",
-              "parser.jl",
-              "loopback.jl",
-              "WebSockets.jl",
-              "messages.jl",
-              "handlers.jl",
-              "server.jl",
-              "async.jl",
-              "aws4.jl"]
-
+    for f in [
+        "ascii.jl",
+        "issue_288.jl",
+        "utils.jl",
+        "sniff.jl",
+        "uri.jl",
+        "url.jl",
+        "cookies.jl",
+        "parser.jl",
+        "loopback.jl",
+        "WebSockets.jl",
+        "messages.jl",
+        "handlers.jl",
+        "server.jl",
+        "async.jl",
+        "aws4.jl"
+        ]
+        
         println("Running $f tests...")
         include(f)
     end


### PR DESCRIPTION
In this PR, I expanded the definition of the convenience type `Server` to include all input to `listen`.

```julia
"Convenience object for passing around server details"
Base.@kwdef mutable struct Server{T <: Union{MbedTLS.SSLConfig, Nothing}}
    host::Union{IPAddr, String}=Sockets.localhost
    port::Integer=8081
    ssl::T=nothing
    tcpisvalid::Function=tcp->true
    server::Union{Base.IOServer, Nothing}=nothing
    reuseaddr::Bool=false
    connection_count::Ref{Int}=Ref(0)
    rate_limit::Union{Rational{Int}, Nothing}=nothing
    reuse_limit::Int=nolimit
    readtimeout::Int=60
    verbose::Bool=false
end
```

This will be helpful for some things / simplifications I want to do with WebSockets.jl.

I also exported `Server` from `Servers` so it can be conveniently accessed as

```julia
HTTP.Server()
```

instead of

```julia
HTTP.Servers.Server()
```

With this, we can do things like:

```julia
julia> HTTP.listen(f,HTTP.Server())
````

to kick up a quick server.

On the WebSockets.jl side, we have a similar convenience type: `ServerWS`. 

I'd like to add `Server` to `ServerWS` so we can have easy control of the HTTP server including a nice `Base.close(s::ServerWS)` method.

Generally speaking, I think having a more complete convenience type is... well... convenient 😊 

PS: The minor change to runtests.jl is to make it easier to comment out tests when debugging.