### PR TITLE
HTTP.serve should default to localhost

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -207,7 +207,7 @@ export serve, Handler, handle, RequestHandlerFunction, StreamHandlerFunction,
        RequestHandler, StreamHandler,
        Router, @register, register!
 
-using ..Messages, ..URIs, ..Streams, ..IOExtras, ..Servers
+using ..Messages, ..URIs, ..Streams, ..IOExtras, ..Servers, ..Sockets
 
 """
 HTTP.handle(handler::HTTP.RequestHandler, ::HTTP.Request) => HTTP.Response
@@ -334,7 +334,7 @@ e.g.
 """
 function serve end
 
-function serve(f, host, port=8081; stream::Bool=false, kw...)
+function serve(f, host=Sockets.localhost, port=8081; stream::Bool=false, kw...)
     handler = f isa Handler ? f : stream ? StreamHandlerFunction(f) : RequestHandlerFunction(f)
     return Servers.listen(x->handle(handler, x), host, port; kw...)
 end


### PR DESCRIPTION
According to the docs, the host in HTTP.serve should default to localhost.