### PR TITLE
removing @error in catch block

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -354,7 +354,6 @@ function handle_transaction(f, t::Transaction; final_transaction::Bool=false)
         closeread(http)
         closewrite(http)
     catch e
-        @error "error handling request" exception=(e, stacktrace(catch_backtrace()))
         if isopen(http) && !iswritable(http)
             http.message.response.status = 500
             startwrite(http)


### PR DESCRIPTION
Following #419 I did a fair bit more testing and it still occasionally throws a IOStream, stream unusable error (see 1st comment in #419; this is also with `reuse_limit=0`). Removing this error line seems to fix the problem.