### PR TITLE
Let handle_connection and handle_transaction handle closing the under…

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -256,8 +256,7 @@ function listenloop(f, server, tcpisvalid, connection_count,
                     end
                 finally
                     connection_count[] -= 1
-                    close(io)
-                    verbose && @info "Closed ($count):  $conn"
+                    # handle_connection is in charge of closing the underlying io
                 end
             end
         catch e
@@ -288,7 +287,7 @@ function handle_connection(f, c::Connection, server, reuse_limit, readtimeout)
     try
         count = 0
         # if the connection socket or original server close, we stop taking requests
-        while isopen(c) && isopen(server)
+        while isopen(c) && isopen(server) && count <= reuse_limit
             handle_transaction(f, Transaction(c);
                                final_transaction=(count == reuse_limit))
             count += 1


### PR DESCRIPTION
…lying socket. Otherwise, the top level listenloop might close the socket if handle_connection returns, but connections are still being processed. This allows us to avoid calling handle_transaction if we're already over our reuse_limit. Previously, handle_transaction was immediately called after the previous request started to be handled asynchronously, which meant that even for reuse_limit=0, the connection would still call startread for a 2nd request once the 1st was starting to be handled. Should provide a proper fix for #405

cc: @tlienart 