### PR TITLE
Update async error log message

### DIFF
--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -61,7 +61,10 @@ function request(::Type{StreamLayer}, io::IO, request::Request, body;
                           "Server likely closed the connection unexpectedly. " *
                           "Only an issue if unable to read the response and this error gets re-thrown. ",
                           exception=(write_error, catch_backtrace()))
-                    close(io)
+                    try
+                        close(io)
+                    catch e
+                    end
                 end
                 yield()
                 startread(http)

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -57,7 +57,9 @@ function request(::Type{StreamLayer}, io::IO, request::Request, body;
                     writebody(http, request, body)
                 catch e
                     write_error = e
-                    @warn("Error in @async writebody task",
+                    @info("Error in @async writebody task. " *
+                          "Server likely closed the connection unexpectedly. " *
+                          "Only an issue if unable to read the response and this error gets re-thrown. ",
                           exception=(write_error, catch_backtrace()))
                     close(io)
                 end


### PR DESCRIPTION
I've noticed a lot of confusion about this warning and what it means. The immediate assumption made is that something is wrong and needs fixing but usually the case is that everything is fine (other than the connection closing before expected) and continues normally.

Preferably we could remove this msg altogether and rely on the exception thrown if the read fails, but this at least de-escalates the urgency of this msg and adds a bit of extra info.

Some more context here: https://github.com/JuliaWeb/HTTP.jl/pull/285/files/f4e2516abcb0df0a24f11460c2f9a782af2e5f5f#r213862000