### PR TITLE
Interface for adding custom layers to the HTTP stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /docs/Manifest.toml
 /Manifest.toml
 /test/coverage/Manifest.toml
+.idea/*

--- a/README.md
+++ b/README.md
@@ -110,6 +110,58 @@ x = UInt8[0x48, 0x65, 0x6c, 0x6c, 0x6f]
 Hello
 ```
 
+## Custom HTTP Layer Examples
+#####Notes:
+- There is no enforcement of a "well-defined" stack, you can insert a layer anywhere in the stack even if it logically
+does not make sense
+- When creating a custom layer, you need to create a `request()`, see below for an example
+- Custom layers is only implemented with the "low-level" `request()` calls, not the "convenience" functions such as
+`HTTP.get()`, `HTTP.put()`, etc.
+
+```julia
+julia> module TestRequest
+               import HTTP: Layer, request, Response
+
+               abstract type TestLayer{Next <: Layer} <: Layer{Next} end
+               export TestLayer, request
+
+               function request(::Type{TestLayer{Next}}, io::IO, req, body; kw...)::Response where Next
+                       println("Insert your custom layer logic here!")
+                       return request(Next, io, req, body; kw...)
+               end
+       end
+
+julia> using HTTP
+julia> using ..TestRequest
+
+julia> custom_stack = insert(stack(), StreamLayer, TestLayer)
+
+julia> result = request(custom_stack, "GET", "https://httpbin.org/ip")
+
+Insert your custom layer logic here!
+HTTP.Messages.Response:
+"""
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: *
+Content-Type: application/json
+Date: Fri, 30 Aug 2019 14:13:17 GMT
+Referrer-Policy: no-referrer-when-downgrade
+Server: nginx
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+Content-Length: 45
+Connection: keep-alive
+
+{
+  "origin": "--Redacted--"
+}
+"""
+
+julia> 
+```
+
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://JuliaWeb.github.io/HTTP.jl/dev
 

--- a/src/AWS4AuthRequest.jl
+++ b/src/AWS4AuthRequest.jl
@@ -18,7 +18,7 @@ Add a [AWS Signature Version 4](http://docs.aws.amazon.com/general/latest/gr/sig
 Credentials are read from environment variables `AWS_ACCESS_KEY_ID`,
 `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
 """
-abstract type AWS4AuthLayer{Next <: Layer} <: Layer end
+abstract type AWS4AuthLayer{Next <: Layer} <: Layer{Next} end
 export AWS4AuthLayer
 
 function request(::Type{AWS4AuthLayer{Next}},

--- a/src/BasicAuthRequest.jl
+++ b/src/BasicAuthRequest.jl
@@ -12,7 +12,7 @@ import ..@debug, ..DEBUG_LEVEL
 
 Add `Authorization: Basic` header using credentials from url userinfo.
 """
-abstract type BasicAuthLayer{Next <: Layer} <: Layer end
+abstract type BasicAuthLayer{Next <: Layer} <: Layer{Next} end
 export BasicAuthLayer
 
 function request(::Type{BasicAuthLayer{Next}},

--- a/src/CanonicalizeRequest.jl
+++ b/src/CanonicalizeRequest.jl
@@ -9,7 +9,7 @@ using ..Strings: tocameldash
 
 Rewrite request and response headers in Canonical-Camel-Dash-Format.
 """
-abstract type CanonicalizeLayer{Next <: Layer} <: Layer end
+abstract type CanonicalizeLayer{Next <: Layer} <: Layer{Next} end
 export CanonicalizeLayer
 
 function request(::Type{CanonicalizeLayer{Next}},

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -19,7 +19,7 @@ Otherwise leave it open so that it can be reused.
 `IO` related exceptions from `Base` are wrapped in `HTTP.IOError`.
 See [`isioerror`](@ref).
 """
-abstract type ConnectionPoolLayer{Next <: Layer} <: Layer end
+abstract type ConnectionPoolLayer{Next <: Layer} <: Layer{Next} end
 export ConnectionPoolLayer
 
 function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;

--- a/src/ContentTypeRequest.jl
+++ b/src/ContentTypeRequest.jl
@@ -9,7 +9,7 @@ using ..Messages
 import ..MessageRequest: bodylength, bodybytes
 import ..@debug, ..DEBUG_LEVEL
 
-abstract type ContentTypeDetectionLayer{Next <: Layer} <: Layer end
+abstract type ContentTypeDetectionLayer{Next <: Layer} <: Layer{Next} end
 export ContentTypeDetectionLayer
 
 function request(::Type{ContentTypeDetectionLayer{Next}},

--- a/src/CookieRequest.jl
+++ b/src/CookieRequest.jl
@@ -15,7 +15,7 @@ const default_cookiejar = Dict{String, Set{Cookie}}()
 Add locally stored Cookies to the request headers.
 Store new Cookies found in the response headers.
 """
-abstract type CookieLayer{Next <: Layer} <: Layer end
+abstract type CookieLayer{Next <: Layer} <: Layer{Next} end
 export CookieLayer
 
 function request(::Type{CookieLayer{Next}},

--- a/src/DebugRequest.jl
+++ b/src/DebugRequest.jl
@@ -12,7 +12,7 @@ include("IODebug.jl")
 
 Wrap the `IO` stream in an `IODebug` stream and print Message data.
 """
-abstract type DebugLayer{Next <:Layer} <: Layer end
+abstract type DebugLayer{Next <:Layer} <: Layer{Next} end
 export DebugLayer
 
 function request(::Type{DebugLayer{Next}}, io::IO, req, body; kw...) where Next

--- a/src/ExceptionRequest.jl
+++ b/src/ExceptionRequest.jl
@@ -11,7 +11,7 @@ using ..Messages: iserror
 
 Throw a `StatusError` if the request returns an error response status.
 """
-abstract type ExceptionLayer{Next <: Layer} <: Layer end
+abstract type ExceptionLayer{Next <: Layer} <: Layer{Next} end
 export ExceptionLayer
 
 function request(::Type{ExceptionLayer{Next}}, a...; kw...) where Next

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -1,6 +1,9 @@
 module HTTP
 
-export startwrite, startread, closewrite, closeread
+export startwrite, startread, closewrite, closeread, stack, insert, AWS4AuthLayer, 
+    BasicAuthLayer, CanonicalizeLayer, ConnectionPoolLayer, ContentTypeDetectionLayer,
+    DebugLayer, ExceptionLayer, MessageLayer, RedirectLayer, RetryLayer, StreamLayer, 
+    TimeoutLayer
 
 const DEBUG_LEVEL = Ref(0)
 
@@ -23,6 +26,62 @@ include("ConnectionPool.jl")
 include("Messages.jl")                 ;using .Messages
 include("cookies.jl")                  ;using .Cookies
 include("Streams.jl")                  ;using .Streams
+include("layers.jl")                   ;using .Layers
+
+"""
+## Request Execution Stack
+
+The Request Execution Stack is separated into composable layers.
+
+Each layer is defined by a nested type `Layer{Next}` where the `Next`
+parameter defines the next layer in the stack.
+The `request` method for each layer takes a `Layer{Next}` type as
+its first argument and dispatches the request to the next layer
+using `request(Next, ...)`.
+
+The example below defines three layers and three stacks each with
+a different combination of layers.
+
+
+```julia
+abstract type Layer end
+abstract type Layer1{Next <: Layer} <: Layer end
+abstract type Layer2{Next <: Layer} <: Layer end
+abstract type Layer3 <: Layer end
+
+request(::Type{Layer1{Next}}, data) where Next = "L1", request(Next, data)
+request(::Type{Layer2{Next}}, data) where Next = "L2", request(Next, data)
+request(::Type{Layer3}, data) = "L3", data
+
+const stack1 = Layer1{Layer2{Layer3}}
+const stack2 = Layer2{Layer1{Layer3}}
+const stack3 = Layer1{Layer3}
+```
+
+```julia
+julia> request(stack1, "foo")
+("L1", ("L2", ("L3", "foo")))
+
+julia> request(stack2, "bar")
+("L2", ("L1", ("L3", "bar")))
+
+julia> request(stack3, "boo")
+("L1", ("L3", "boo"))
+```
+
+This stack definition pattern gives the user flexibility in how layers are
+combined but still allows Julia to do whole-stack compile time optimisations.
+
+e.g. the `request(stack1, "foo")` call above is optimised down to a single
+function:
+```julia
+julia> code_typed(request, (Type{stack1}, String))[1].first
+CodeInfo(:(begin
+    return (Core.tuple)("L1", (Core.tuple)("L2", (Core.tuple)("L3", data)))
+end))
+```
+"""
+const nobody = UInt8[]
 
 """
 
@@ -297,22 +356,17 @@ HTTP.open("POST", "http://music.com/play") do io
 end
 ```
 """
-request(method::String, url::URI, headers::Headers, body; kw...)::Response =
-    request(HTTP.stack(;kw...), method, url, headers, body; kw...)
-#FIXME consider @nospecialize for `body` ? (other places? in ConnectionPool?)
-
-
-const nobody = UInt8[]
-
-function request(method, url, h=Header[], b=nobody;
-                 headers=h, body=b, query=nothing, kw...)::Response
-
+function request(stack::Type{<:Layer}, method, url, h=Header[], b=nobody;
+                headers=h, body=b, query=nothing, kw...)::Response
     uri = URI(url)
     if query !== nothing
         uri = merge(uri, query=query)
     end
-    return request(string(method), uri, mkheaders(headers), body; kw...)
+
+    return request(stack, string(method), uri, mkheaders(headers), body; kw...)
 end
+
+request(a...; kw...)::Response = return request(HTTP.stack(;kw...), a...; kw...)
 
 """
     HTTP.open(method, url, [,headers]) do io
@@ -416,61 +470,6 @@ Shorthand for `HTTP.request("DELETE", ...)`. See [`HTTP.request`](@ref).
 """
 delete(a...; kw...) = request("DELETE", a...; kw...)
 
-"""
-
-## Request Execution Stack
-
-The Request Execution Stack is separated into composable layers.
-
-Each layer is defined by a nested type `Layer{Next}` where the `Next`
-parameter defines the next layer in the stack.
-The `request` method for each layer takes a `Layer{Next}` type as
-its first argument and dispatches the request to the next layer
-using `request(Next, ...)`.
-
-The example below defines three layers and three stacks each with
-a different combination of layers.
-
-
-```julia
-abstract type Layer end
-abstract type Layer1{Next <: Layer} <: Layer end
-abstract type Layer2{Next <: Layer} <: Layer end
-abstract type Layer3 <: Layer end
-
-request(::Type{Layer1{Next}}, data) where Next = "L1", request(Next, data)
-request(::Type{Layer2{Next}}, data) where Next = "L2", request(Next, data)
-request(::Type{Layer3}, data) = "L3", data
-
-const stack1 = Layer1{Layer2{Layer3}}
-const stack2 = Layer2{Layer1{Layer3}}
-const stack3 = Layer1{Layer3}
-```
-
-```julia
-julia> request(stack1, "foo")
-("L1", ("L2", ("L3", "foo")))
-
-julia> request(stack2, "bar")
-("L2", ("L1", ("L3", "bar")))
-
-julia> request(stack3, "boo")
-("L1", ("L3", "boo"))
-```
-
-This stack definition pattern gives the user flexibility in how layers are
-combined but still allows Julia to do whole-stack compile time optimisations.
-
-e.g. the `request(stack1, "foo")` call above is optimised down to a single
-function:
-```julia
-julia> code_typed(request, (Type{stack1}, String))[1].first
-CodeInfo(:(begin
-    return (Core.tuple)("L1", (Core.tuple)("L2", (Core.tuple)("L3", data)))
-end))
-```
-"""
-abstract type Layer end
 include("RedirectRequest.jl");          using .RedirectRequest
 include("BasicAuthRequest.jl");         using .BasicAuthRequest
 include("AWS4AuthRequest.jl");          using .AWS4AuthRequest
@@ -485,6 +484,7 @@ include("ConnectionRequest.jl");        using .ConnectionRequest
 include("DebugRequest.jl");             using .DebugRequest
 include("StreamRequest.jl");            using .StreamRequest
 include("ContentTypeRequest.jl");       using .ContentTypeDetection
+include("exceptions.jl")
 
 """
 The `stack()` function returns the default HTTP Layer-stack type.
@@ -626,12 +626,11 @@ function stack(;redirect=true,
     (verbose >= 3 ||
      DEBUG_LEVEL[] >= 3   ? DebugLayer                : NoLayer){
     (readtimeout > 0      ? TimeoutLayer              : NoLayer){
-                            StreamLayer
+                            StreamLayer{Union{}}
     }}}}}}}}}}}}
 end
 
 include("download.jl")
-
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
 include("Handlers.jl")                 ;using .Handlers; using .Handlers: serve
 include("WebSockets.jl")               ;using .WebSockets

--- a/src/MessageRequest.jl
+++ b/src/MessageRequest.jl
@@ -16,7 +16,7 @@ import ..Form
 
 Construct a [`Request`](@ref) object and set mandatory headers.
 """
-struct MessageLayer{Next <: Layer} <: Layer end
+struct MessageLayer{Next <: Layer} <: Layer{Next} end
 export MessageLayer
 
 function request(::Type{MessageLayer{Next}},

--- a/src/RedirectRequest.jl
+++ b/src/RedirectRequest.jl
@@ -12,7 +12,7 @@ import ..@debug, ..DEBUG_LEVEL
 
 Redirects the request in the case of 3xx response status.
 """
-abstract type RedirectLayer{Next <: Layer} <: Layer end
+abstract type RedirectLayer{Next <: Layer} <: Layer{Next} end
 export RedirectLayer
 
 function request(::Type{RedirectLayer{Next}},

--- a/src/RetryRequest.jl
+++ b/src/RetryRequest.jl
@@ -21,7 +21,7 @@ Methods of `isrecoverable(e)` define which exception types lead to a retry.
 e.g. `HTTP.IOError`, `Sockets.DNSError`, `Base.EOFError` and `HTTP.StatusError`
 (if status is ``5xx`).
 """
-abstract type RetryLayer{Next <: Layer} <: Layer end
+abstract type RetryLayer{Next <: Layer} <: Layer{Next} end
 export RetryLayer
 
 function request(::Type{RetryLayer{Next}}, url, req, body;

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -19,14 +19,14 @@ immediately so that the transmission can be aborted if the `Response` status
 indicates that the server does not wish to receive the message body.
 [RFC7230 6.5](https://tools.ietf.org/html/rfc7230#section-6.5).
 """
-abstract type StreamLayer <: Layer end
+abstract type StreamLayer{Next <: Layer} <: Layer{Next} end
 export StreamLayer
 
-function request(::Type{StreamLayer}, io::IO, request::Request, body;
+function request(::Type{StreamLayer{Next}}, io::IO, request::Request, body;
                  response_stream=nothing,
                  iofunction=nothing,
                  verbose::Int=0,
-                 kw...)::Response
+                 kw...)::Response where Next
 
     verbose == 1 && printlncompact(request)
 

--- a/src/TimeoutRequest.jl
+++ b/src/TimeoutRequest.jl
@@ -9,7 +9,7 @@ import ..@debug, ..DEBUG_LEVEL
 
 Close `IO` if no data has been received for `timeout` seconds.
 """
-abstract type TimeoutLayer{Next <: Layer} <: Layer end
+abstract type TimeoutLayer{Next <: Layer} <: Layer{Next} end
 export TimeoutLayer
 
 function request(::Type{TimeoutLayer{Next}}, io::IO, req, body;

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -145,7 +145,6 @@ URI(str::AbstractString) = parse_uri_reference(str)
 Base.parse(::Type{URI}, str::AbstractString) = parse_uri_reference(str)
 
 function ensurevalid(uri::URI)
-
     # https://tools.ietf.org/html/rfc3986#section-3.1
     # ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     if !(uri.scheme === absent ||

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,0 +1,7 @@
+struct LayerNotFoundException <: Exception
+	var::String
+end
+
+function Base.showerror(io::IO, e::LayerNotFoundException)
+	println(io, typeof(e), ": ", e.var)
+end

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -1,0 +1,58 @@
+module Layers
+export Layer, next, top_layer, insert
+
+include("exceptions.jl")
+
+abstract type Layer{Next} end
+
+"""
+    next(::Type{S}) where {T, S<:Layer{T}}
+
+Return the next `Layer` in the stack
+
+Example:
+stack = MessageLayer{ConnectionPoolLayer{StreamLayer{Union{}}}
+next(stack)  # ConnectionPoolLayer{StreamLayer{Union{}}}
+"""
+next(::Type{S}) where {T, S<:Layer{T}} = return T
+
+"""
+    top_layer(::Type{T}) where T <: Layer
+
+Return the parametric type of the top most `Layer` in the stack
+
+Example:
+stack = MessageLayer{ConnectionPoolLayer{StreamLayer{Union{}}}
+top_layer(stack)  # MessageLayer
+"""
+top_layer(::Type{T}) where T <: Layer = return T.name.wrapper
+top_layer(::Type{Union{}}) = return Union{}
+
+"""
+    insert(stack::Type{<:Layer}, layer_before::Type{<:Layer}, custom_layer::Type{<:Layer})
+
+Insert your `custom_layer` in-front of the `layer_before`
+
+Example:
+stack = MessageLayer{ConnectionPoolLayer{StreamLayer{Union{}}}
+result = insert(stack, MessageLayer, TestLayer)  # TestLayer{MessageLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}
+"""
+function insert(stack::Type{<:Layer}, layer_before::Type{<:Layer}, custom_layer::Type{<:Layer})
+    new_stack = Union
+    head_layer = top_layer(stack)
+    rest_stack = stack
+
+    while true
+        if head_layer === layer_before
+            return new_stack{custom_layer{rest_stack}}
+        else
+            head_layer === Union{} && break
+            new_stack = new_stack{head_layer{T}} where T
+            rest_stack = next(rest_stack)
+            head_layer = top_layer(rest_stack)
+        end
+    end
+    throw(LayerNotFoundException("$layer_before not found in $stack"))
+end
+
+end

--- a/test/TestRequest.jl
+++ b/test/TestRequest.jl
@@ -1,0 +1,10 @@
+module TestRequest
+	import HTTP: Layer, request, Response
+
+	abstract type TestLayer{Next <: Layer} <: Layer{Next} end
+	export TestLayer, request
+
+	function request(::Type{TestLayer{Next}}, io::IO, req, body; kw...)::Response where Next
+		return request(Next, io, req, body; kw...)
+	end
+end

--- a/test/ascii.jl
+++ b/test/ascii.jl
@@ -1,5 +1,3 @@
-using HTTP
-
 @testset "HTTP.ascii" begin
 
     lc = HTTP.Messages.ascii_lc

--- a/test/client.jl
+++ b/test/client.jl
@@ -1,8 +1,19 @@
 using HTTP, Test, JSON
+include("resources/TestRequest.jl")
+using ..TestRequest
+
 
 @testset "HTTP.Client" begin
 
 status(r) = r.status
+@testset "Custom HTTP Stack" begin
+   @testset "Low-level Request" begin
+        custom_stack = insert(stack(), StreamLayer, TestLayer)
+        result = request(custom_stack, "GET", "https://httpbin.org/ip")
+
+        @test status(result) == 200
+    end
+end
 
 for sch in ("http", "https")
     println("running $sch client tests...")
@@ -238,5 +249,4 @@ end
         end
     end
 end
-
 end # @testset "HTTP.Client"

--- a/test/insert_layers.jl
+++ b/test/insert_layers.jl
@@ -1,0 +1,40 @@
+include("resources/TestRequest.jl")
+include("../src/exceptions.jl")
+
+using ..TestRequest
+
+@testset "HTTP Stack Inserting" begin
+    @testset "Insert - Beginning" begin
+        expected = TestLayer{RedirectLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}
+        result = insert(stack(), RedirectLayer, TestLayer)
+
+        @test expected == result
+    end
+
+    @testset "Insert - Middle" begin
+        expected = RedirectLayer{MessageLayer{RetryLayer{TestLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}
+        result = insert(stack(), ExceptionLayer, TestLayer)
+
+        @test expected == result
+    end
+
+    @testset "Insert - End" begin
+        expected = RedirectLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{TestLayer{Union{}}}}}}}}
+        result = insert(stack(), Union{}, TestLayer)
+
+        @test expected == result
+    end
+
+    @testset "Insert - Non-existant layer" begin
+        @test_throws HTTP.Layers.LayerNotFoundException insert(stack(), AWS4AuthLayer, TestLayer)
+    end
+
+    @testset "Insert - Multiple Same layer" begin
+        test_stack = insert(stack(), RetryLayer, ExceptionLayer)
+
+        expected = RedirectLayer{MessageLayer{TestLayer{ExceptionLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}
+        result = insert(test_stack, ExceptionLayer, TestLayer)
+
+        @test expected == result
+    end
+end

--- a/test/resources/TestRequest.jl
+++ b/test/resources/TestRequest.jl
@@ -1,0 +1,10 @@
+module TestRequest
+	import HTTP: Layer, request, Response
+
+	abstract type TestLayer{Next <: Layer} <: Layer{Next} end
+	export TestLayer, request
+
+	function request(::Type{TestLayer{Next}}, io::IO, req, body; kw...)::Response where Next
+		return request(Next, io, req, body; kw...)
+	end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,13 @@ addprocs(5)
 
 using Test
 using HTTP
+using JSON
 
 @testset "HTTP" begin
     for f in ["ascii.jl",
               "issue_288.jl",
               "utils.jl",
+              "client.jl",
               "sniff.jl",
               "uri.jl",
               "url.jl",
@@ -19,7 +21,8 @@ using HTTP
               "handlers.jl",
               "server.jl",
               "async.jl",
-              "aws4.jl"]
+              "aws4.jl",
+              "insert_layers.jl"]
 
         println("Running $f tests...")
         include(f)


### PR DESCRIPTION
Problem
---
`HTTP.stack` defines the layers in its stack in a specific order. If you currently want to insert custom layers at a specific point you must completely reconstruct the stack and ensure that all pre-processing is handled as well.

Solution
---
Create a custom layer (see `README.md` for an example), `insert()` and create your `request()`.

Notes
---
- Resolves #389 
- Allows for the removal of `AWS4AuthRequest.jl` from this package and move it into `AWSCore.jl`