### PR TITLE
Amendment for #443

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -28,59 +28,6 @@ include("cookies.jl")                  ;using .Cookies
 include("Streams.jl")                  ;using .Streams
 include("layers.jl")                   ;using .Layers
 
-"""
-## Request Execution Stack
-
-The Request Execution Stack is separated into composable layers.
-
-Each layer is defined by a nested type `Layer{Next}` where the `Next`
-parameter defines the next layer in the stack.
-The `request` method for each layer takes a `Layer{Next}` type as
-its first argument and dispatches the request to the next layer
-using `request(Next, ...)`.
-
-The example below defines three layers and three stacks each with
-a different combination of layers.
-
-
-```julia
-abstract type Layer end
-abstract type Layer1{Next <: Layer} <: Layer end
-abstract type Layer2{Next <: Layer} <: Layer end
-abstract type Layer3 <: Layer end
-
-request(::Type{Layer1{Next}}, data) where Next = "L1", request(Next, data)
-request(::Type{Layer2{Next}}, data) where Next = "L2", request(Next, data)
-request(::Type{Layer3}, data) = "L3", data
-
-const stack1 = Layer1{Layer2{Layer3}}
-const stack2 = Layer2{Layer1{Layer3}}
-const stack3 = Layer1{Layer3}
-```
-
-```julia
-julia> request(stack1, "foo")
-("L1", ("L2", ("L3", "foo")))
-
-julia> request(stack2, "bar")
-("L2", ("L1", ("L3", "bar")))
-
-julia> request(stack3, "boo")
-("L1", ("L3", "boo"))
-```
-
-This stack definition pattern gives the user flexibility in how layers are
-combined but still allows Julia to do whole-stack compile time optimisations.
-
-e.g. the `request(stack1, "foo")` call above is optimised down to a single
-function:
-```julia
-julia> code_typed(request, (Type{stack1}, String))[1].first
-CodeInfo(:(begin
-    return (Core.tuple)("L1", (Core.tuple)("L2", (Core.tuple)("L3", data)))
-end))
-```
-"""
 const nobody = UInt8[]
 
 """

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,7 +1,7 @@
 struct LayerNotFoundException <: Exception
-	var::String
+    var::String
 end
 
 function Base.showerror(io::IO, e::LayerNotFoundException)
-	println(io, typeof(e), ": ", e.var)
+    println(io, typeof(e), ": ", e.var)
 end


### PR DESCRIPTION
Two comments came in after the merging of #443 which I had missed:

> Docstring should be attached to the Layer type in layers.jl
> https://github.com/JuliaWeb/HTTP.jl/pull/443#discussion_r321577984

> Should use spaces instead of tabs. Seems to be just with new files
> https://github.com/JuliaWeb/HTTP.jl/pull/443#discussion_r321578112

This CR addresses both of those concerns.