### PR TITLE
Fix docs for `request`

### DIFF
--- a/docs/src/public_interface.md
+++ b/docs/src/public_interface.md
@@ -3,7 +3,7 @@
 ## Requests
 
 ```@docs
-HTTP.request(::String,::HTTP.URIs.URI,::Array{Pair{SubString{String},SubString{String}},1},::Any)
+HTTP.request
 HTTP.open
 HTTP.get
 HTTP.put


### PR DESCRIPTION
0.8.6 and #443 changed the method signature the docs for `request` were
associated with and thus removed the docs for `request`. All links that
point to `request` were broken as well.

I simply pointed the docs to `HTTP.request` w/o any signature which
appears to work fine.