### PR TITLE
Scale the time we sleep when checking for request timeout. Otherwise,…

### DIFF
--- a/src/TimeoutRequest.jl
+++ b/src/TimeoutRequest.jl
@@ -23,7 +23,7 @@ function request(::Type{TimeoutLayer{Next}}, io::IO, req, body;
             @debug 1 "💥  Read inactive > $(readtimeout)s: $io"
             break
         end
-        sleep(8 + rand() * 4)
+        sleep(readtimeout / 10)
     end
 
     try


### PR DESCRIPTION
… if a user tried to pass readtimeout < 8 seconds, we would be sleeping longer than that anyway