### PR TITLE
WIP/RFC: added parser for multipart form with updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -499,7 +499,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 ││   │ request(StreamLayer,               ::IO,  ::Request, body) │           │
 ││   └──────────────┬───────────────────┬─────────────────────────┘         │ │
 │└──────────────────┼────────║──────────┼───────────────║─────────────────────┘
-│                   │        ║          │               ║                   │  
+│                   │        ║          │               ║                   │
 │┌──────────────────▼───────────────┐   │  ┌──────────────────────────────────┐
 ││ HTTP.Request                     │   │  │ HTTP.Response                  │ │
 ││                                  │   │  │                                  │
@@ -523,7 +523,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 ││ writestartline(::IO, ::Request)  │ │  ║ │ parse_status_line(bytes, ::Req') │
 ││ writeheaders(::IO, ::Request)    │ │  ║ │ parse_header_field(bytes, ::Req')│
 │└──────────────────────────────────┘ │  ║ └──────────────────────────────────┘
-│                            ║        │  ║                                     
+│                            ║        │  ║
 │┌───────────────────────────║────────┼──║────────────────────────────────────┐
 └▶ HTTP.ConnectionPool       ║        │  ║                                    │
  │                     ┌──────────────▼────────┐ ┌───────────────────────┐    │
@@ -543,7 +543,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
  │                           ║           ║       │ Base.TCPSocket <:IO   │    │
  │                           ║           ║       └───────────────────────┘    │
  └───────────────────────────║───────────║────────────────────────────────────┘
-                             ║           ║                                     
+                             ║           ║
  ┌───────────────────────────║───────────║──────────────┐  ┏━━━━━━━━━━━━━━━━━━┓
  │ HTTP Server               ▼                          │  ┃ data flow: ════▶ ┃
  │                        Request     Response          │  ┃ reference: ────▶ ┃
@@ -585,6 +585,7 @@ end
 include("download.jl")
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
 include("Handlers.jl")                 ;using .Handlers; using .Handlers: serve
+include("parsemultipart.jl")
 include("WebSockets.jl")               ;using .WebSockets
 
 import .ConnectionPool: Transaction, Connection

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -133,7 +133,7 @@ end
 
 function Base.show(io::IO, m::Multipart{T}) where {T}
     items = ["data=::$T", "contenttype=\"$(m.contenttype)\"", "contenttransferencoding=\"$(m.contenttransferencoding)\")"]
-    isnothing(m.filename) || pushfirst!(items, "filename=\"$(m.filename)\"")
+    m.filename === nothing || pushfirst!(items, "filename=\"$(m.filename)\"")
     print(io, "HTTP.Multipart($(join(items, ", ")))")
 end
 
@@ -146,7 +146,7 @@ Base.reset(m::Multipart{T}) where {T} = reset(m.data)
 Base.seekstart(m::Multipart{T}) where {T} = seekstart(m.data)
 
 function writemultipartheader(io::IOBuffer, i::Multipart)
-    if isnothing(i.filename)
+    if i.filename === nothing
         write(io, "\r\n")
     else
         write(io, "; filename=\"$(i.filename)\"\r\n")

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -83,8 +83,8 @@ function writemultipartheader(io::IOBuffer, i::IOStream)
     write(io, "; filename=\"$(basename(i.name[7:end-1]))\"\r\n")
     write(io, "Content-Type: $(HTTP.sniff(i))\r\n\r\n")
     return
-    end
-    function writemultipartheader(io::IOBuffer, i::IO)
+end
+function writemultipartheader(io::IOBuffer, i::IO)
     write(io, "\r\n\r\n")
     return
 end
@@ -97,15 +97,45 @@ key-value pair of a Dict passed to an http request, like `HTTP.post(url; body=Di
 The `data` argument must be an `IO` type such as `IOStream`, or `IOBuffer`.
 The `content_type` and `content_transfer_encoding` arguments allow the manual setting of these multipart headers. `Content-Type` will default to the result
 of the `HTTP.sniff(data)` mimetype detection algorithm, whereas `Content-Transfer-Encoding` will be left out if not specified.
+
+Filename SHOULD be included when the Multipart represents the contents of a file
+[RFC7578 4.2](https://tools.ietf.org/html/rfc7578#section-4.2)
+
+Content-Disposition set to "form-data" MUST be included with each Multipart.
+An additional "name" parameter MUST be included
+An optional "filename" parameter SHOULD be included if the contents of a file are sent
+This will be formatted such as:
+  Content-Disposition: form-data; name="user"; filename="myfile.txt"
+[RFC7578 4.2](https://tools.ietf.org/html/rfc7578#section-4.2)
+
+Content-Type for each Multipart is optional, but SHOULD be included if the contents
+of a file are sent.
+[RFC7578 4.4](https://tools.ietf.org/html/rfc7578#section-4.4)
+
+Content-Transfer-Encoding for each Multipart is deprecated
+[RFC7578 4.7](https://tools.ietf.org/html/rfc7578#section-4.7)
+
+Other Content- header fields MUST be ignored
+[RFC7578 4.8](https://tools.ietf.org/html/rfc7578#section-4.8)
 """
 mutable struct Multipart{T <: IO} <: IO
-    filename::String
+    filename::Union{String, Nothing}
     data::T
     contenttype::String
     contenttransferencoding::String
+    name::String
 end
-Multipart(f::String, data::T, ct="", cte="") where {T} = Multipart(f, data, ct, cte)
-Base.show(io::IO, m::Multipart{T}) where {T} = print(io, "HTTP.Multipart(filename=\"$(m.filename)\", data=::$T, contenttype=\"$(m.contenttype)\", contenttransferencoding=\"$(m.contenttransferencoding)\")")
+
+function Multipart(f::Union{AbstractString, Nothing}, data::T, ct::AbstractString="", cte::AbstractString="", name::AbstractString="") where {T<:IO}
+    f = f !== nothing ? String(f) : nothing
+    return Multipart{T}(f, data, String(ct), String(cte), String(name))
+end
+
+function Base.show(io::IO, m::Multipart{T}) where {T}
+    items = ["data=::$T", "contenttype=\"$(m.contenttype)\"", "contenttransferencoding=\"$(m.contenttransferencoding)\")"]
+    isnothing(m.filename) || pushfirst!(items, "filename=\"$(m.filename)\"")
+    print(io, "HTTP.Multipart($(join(items, ", ")))")
+end
 
 Base.bytesavailable(m::Multipart{T}) where {T} = isa(m.data, IOStream) ? filesize(m.data) - position(m.data) : bytesavailable(m.data)
 Base.eof(m::Multipart{T}) where {T} = eof(m.data)
@@ -113,9 +143,14 @@ Base.read(m::Multipart{T}, n::Integer) where {T} = read(m.data, n)
 Base.read(m::Multipart{T}) where {T} = read(m.data)
 Base.mark(m::Multipart{T}) where {T} = mark(m.data)
 Base.reset(m::Multipart{T}) where {T} = reset(m.data)
+Base.seekstart(m::Multipart{T}) where {T} = seekstart(m.data)
 
 function writemultipartheader(io::IOBuffer, i::Multipart)
-    write(io, "; filename=\"$(i.filename)\"\r\n")
+    if isnothing(i.filename)
+        write(io, "\r\n")
+    else
+        write(io, "; filename=\"$(i.filename)\"\r\n")
+    end
     contenttype = i.contenttype == "" ? HTTP.sniff(i.data) : i.contenttype
     write(io, "Content-Type: $(contenttype)\r\n")
     write(io, i.contenttransferencoding == "" ? "\r\n" : "Content-Transfer-Encoding: $(i.contenttransferencoding)\r\n\r\n")

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -1,0 +1,269 @@
+const CR_BYTE = 0x0d # \r
+const LF_BYTE = 0x0a # \n
+const DASH_BYTE = 0x2d # -
+const HTAB_BYTE = 0x09 # \t
+const SPACE_BYTE = 0x20
+const RETURN_BYTES = [CR_BYTE, LF_BYTE]
+
+"""
+    find_multipart_boundary(bytes, boundaryDelimiter; start::Int=1)
+
+Find the first and last index of the next boundary delimiting a part, and if
+the discovered boundary is the terminating boundary.
+"""
+function find_multipart_boundary(bytes::AbstractVector{UInt8}, boundaryDelimiter::AbstractVector{UInt8}; start::Int=1)
+    # The boundary delimiter line is prepended with two '-' characters
+    # The boundary delimiter line starts on a new line, so must be preceded by a \r\n.
+    # The boundary delimiter line ends with \r\n, and can have "optional linear whitespace" between
+    # the end of the boundary delimiter, and the \r\n.
+    # The last boundary delimiter line has an additional '--' at the end of the boundary delimiter
+    # [RFC2046 5.1.1](https://tools.ietf.org/html/rfc2046#section-5.1.1)
+
+    i = start
+    end_index = i+length(boundaryDelimiter)-1
+    while end_index <= length(bytes)
+        if bytes[i:end_index] == boundaryDelimiter
+            # boundary delimiter line start on a new line ...
+            if i > 1
+                (i == 2 || bytes[i-2] != CR_BYTE || bytes[i-1] != LF_BYTE) && error("boundary delimiter found, but it was not the start of a line")
+                # the CRLF preceding the boundary delimiter is "conceptually attached
+                # to the boundary", so account for this with the index
+                i-=2
+            end
+
+            # need to check if there are enough characters for the CRLF or for two dashes
+            end_index < length(bytes)-1 || error("boundary delimiter found, but did not end with new line")
+
+            is_terminating_delimiter = bytes[end_index+1] == DASH_BYTE && bytes[end_index+2] == DASH_BYTE
+            is_terminating_delimiter && (end_index+=2)
+
+            # ... there can be arbitrary SP and HTAB space between the boundary delimiter ...
+            while (end_index < length(bytes) && (bytes[end_index+1] in [HTAB_BYTE, SPACE_BYTE])) end_index+=1 end
+            # ... and ends with a new line
+            (end_index < length(bytes)-1) && bytes[end_index+1] == CR_BYTE && bytes[end_index+2] == LF_BYTE || error("boundary delimiter found, but did not end with new line")
+            end_index += 2
+
+            return (is_terminating_delimiter, i, end_index)
+        end
+
+        i += 1
+        end_index += 1
+    end
+
+    error("boundary delimiter not found")
+end
+
+"""
+    find_multipart_boundaries(bytes, boundary; start=1)
+
+Find the start and end indexes of all the parts of the multipart object.  Ultimately this method is
+looking for the data between the boundary delimiters in the byte array.  A vector containing all
+the start/end pairs is returned.
+"""
+function find_multipart_boundaries(bytes::AbstractVector{UInt8}, boundary::AbstractVector{UInt8}; start=1)
+    idxs = []
+    while true
+        (is_terminating_delimiter, i, end_index) = find_multipart_boundary(bytes, boundary; start = start)
+        push!(idxs, (i, end_index))
+        is_terminating_delimiter && break
+        start = end_index + 1
+    end
+    return idxs
+end
+
+"""
+    find_header_boundary(bytes)
+
+Find the end of the multipart header in the byte array.  Returns a Tuple with the
+start index(1) and the end index. Headers are separated from the body by CRLFCRLF.
+
+[RFC2046 5.1](https://tools.ietf.org/html/rfc2046#section-5.1)
+[RFC822 3.1](https://tools.ietf.org/html/rfc822#section-3.1)
+"""
+function find_header_boundary(bytes::AbstractVector{UInt8})
+    delimiter = UInt8[CR_BYTE, LF_BYTE, CR_BYTE, LF_BYTE]
+    length(delimiter) > length(bytes) && (return nothing)
+
+    l = length(bytes) - length(delimiter) + 1
+    i = 1
+    end_index = length(delimiter)
+    while (i <= l)
+        bytes[i:end_index] == delimiter && (return (1, end_index))
+        i += 1
+        end_index += 1
+    end
+    error("no delimiter found separating header from multipart body")
+end
+
+"""
+    content_disposition_tokenize(str)
+
+Tokenize the "arguments" for the Content-Disposition delcaration.  A vector of
+strings is returned that contains each token and separator found in the source
+string. Tokens are separated by either an equal sign(=) or a semi-colon(;) and
+may be quoted or escaped with a backslash(\\). All tokens returned are stripped
+of whitespace at the beginning and end of the string, quotes are retained.
+"""
+function content_disposition_tokenize(str)
+    retval = Vector{SubString}()
+    start = 1
+    quotes = false
+    escaped = false
+
+    for offset in eachindex(str)
+        if escaped == false
+            if quotes == true && str[offset] == '"'
+                quotes = false
+            elseif str[offset] == '\\'
+                escaped = true
+            elseif str[offset] == '"'
+                quotes = true
+            elseif quotes == false && (str[offset] == ';' || str[offset] == '=')
+                prev = prevind(str, offset)
+                if prev > start
+                    push!(retval, strip(SubString(str, start, prev)))
+                end
+                push!(retval, SubString(str, offset, offset))
+                start = nextind(str, offset)
+            end
+        else
+            escaped = false
+        end
+    end
+
+    if start != lastindex(str)
+        push!(retval, strip(SubString(str, start)))
+    end
+
+    return retval
+end
+
+"""
+    content_disposition_extract(str)
+
+Extract all the flags and key/value arguments from the Content-Disposition
+line.  The result is returned as an array of tuples.
+
+In the case of a flag the first value of the tuple is false the second value
+is the flag and the third value is nothing.
+
+In the case of a key/value argument the first value is true, the second is the
+key, and the third is the value (or nothing if no value was specified).
+"""
+function content_disposition_extract(str)
+    retval = Vector{Tuple{Bool, SubString, Union{SubString,Nothing}}}()
+    tokens = content_disposition_tokenize(str)
+    total  = length(tokens)
+
+    function strip_quotes(val)
+        if val[1] == '"' && val[end] == '"'
+            SubString(val, 2, lastindex(val) - 1)
+        else
+            val
+        end
+    end
+
+    i = 1
+    while i < total
+        if tokens[i] != ';'
+            pair  = (i + 1 <= total && tokens[i + 1] == "=")
+            key   = strip_quotes(tokens[i])
+            value = (pair && i + 2 <= total && tokens[i + 2] != ";" ? strip_quotes(tokens[i + 2]) : nothing)
+
+            push!(retval, (pair, key, value))
+
+            if pair
+                i += 3
+            else
+                i += 1
+            end
+        else
+            i += 1
+        end
+    end
+    return retval
+end
+
+"""
+    parse_multipart_chunk(chunk)
+
+Parse a single multi-part chunk into a Multipart object.  This will decode
+the header and extract the contents from the byte array.
+"""
+function parse_multipart_chunk(chunk)
+    (startIndex, end_index) = find_header_boundary(chunk)
+
+    headers = String(view(chunk, startIndex:end_index))
+    content = view(chunk, end_index+1:lastindex(chunk))
+
+    disposition = match(r"(?i)Content-Disposition: form-data(.*)\r\n", headers)
+
+    if isnothing(disposition)
+        @warn "Content disposition is not specified dropping the chunk."
+        return # Specifying content disposition is mandatory
+    end
+
+    name = nothing
+    filename = nothing
+
+    for (pair, key, value) in content_disposition_extract(disposition[1])
+        if pair && key == "name"
+            name = value
+        elseif pair && key == "filename"
+            filename = value
+        end
+    end
+
+    isnothing(name) && return
+
+    match_contenttype = match(r"(?i)Content-Type: (\S*[^;\s])", headers)
+    contenttype = !isnothing(match_contenttype) ? match_contenttype[1] : "text/plain" # if content_type is not specified, the default text/plain is assumed
+
+    return Multipart(filename, IOBuffer(content), contenttype, "", name)
+end
+
+"""
+    parse_multipart_body(body, boundary)::Vector{Multipart}
+
+Parse the multipart body received from the client breaking it into the various
+chunks which are returned as an array of Multipart objects.
+"""
+function parse_multipart_body(body::AbstractVector{UInt8}, boundary::AbstractString)::Vector{Multipart}
+    multiparts = Multipart[]
+    idxs = find_multipart_boundaries(body, IOBuffer("--$(boundary)").data)
+    length(idxs) > 1 || (return multiparts)
+
+    for i in 1:length(idxs)-1
+        chunk = view(body, idxs[i][2]+1:idxs[i+1][1]-1)
+        push!(multiparts, parse_multipart_chunk(chunk))
+    end
+    return multiparts
+end
+
+
+"""
+    parse_multipart_form(req::Request)::Vector{Multipart}
+
+Parse the full mutipart form submission from the client returning and
+array of Multipart objects containing all the data.
+
+The order of the multipart form data in the request should be preserved.
+[RFC7578 5.2](https://tools.ietf.org/html/rfc7578#section-5.2).
+
+The boundary delimiter MUST NOT appear inside any of the encapsulated parts. Note
+that the boundary delimiter does not need to have '-' characters, but a line using
+the boundary delimiter will start with '--' and end in \r\n.
+[RFC2046 5.1](https://tools.ietf.org/html/rfc2046#section-5.1.1)
+"""
+function parse_multipart_form(req::Request)::Vector{Multipart}
+    # parse boundary from Content-Type
+    m = match(r"multipart/form-data; boundary=(.*)$", req["Content-Type"])
+    isnothing(m) && return nothing
+
+    boundary_delimiter = m[1]
+
+    # [RFC2046 5.1.1](https://tools.ietf.org/html/rfc2046#section-5.1.1)
+    length(boundary_delimiter) > 70 && error("boundary delimiter must not be greater than 70 characters")
+
+    return parse_multipart_body(payload(req), boundary_delimiter)
+end

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -198,7 +198,7 @@ function parse_multipart_chunk(chunk)
 
     disposition = match(r"(?i)Content-Disposition: form-data(.*)\r\n", headers)
 
-    if isnothing(disposition)
+    if disposition === nothing
         @warn "Content disposition is not specified dropping the chunk."
         return # Specifying content disposition is mandatory
     end
@@ -214,10 +214,10 @@ function parse_multipart_chunk(chunk)
         end
     end
 
-    isnothing(name) && return
+    name === nothing && return
 
     match_contenttype = match(r"(?i)Content-Type: (\S*[^;\s])", headers)
-    contenttype = !isnothing(match_contenttype) ? match_contenttype[1] : "text/plain" # if content_type is not specified, the default text/plain is assumed
+    contenttype = match_contenttype !== nothing ? match_contenttype[1] : "text/plain" # if content_type is not specified, the default text/plain is assumed
 
     return Multipart(filename, IOBuffer(content), contenttype, "", name)
 end
@@ -258,7 +258,7 @@ the boundary delimiter will start with '--' and end in \r\n.
 function parse_multipart_form(req::Request)::Vector{Multipart}
     # parse boundary from Content-Type
     m = match(r"multipart/form-data; boundary=(.*)$", req["Content-Type"])
-    isnothing(m) && return nothing
+    m === nothing && return nothing
 
     boundary_delimiter = m[1]
 

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -230,7 +230,7 @@ chunks which are returned as an array of Multipart objects.
 """
 function parse_multipart_body(body::AbstractVector{UInt8}, boundary::AbstractString)::Vector{Multipart}
     multiparts = Multipart[]
-    idxs = find_multipart_boundaries(body, IOBuffer("--$(boundary)").data)
+    idxs = find_multipart_boundaries(body, Vector{UInt8}("--$(boundary)"))
     length(idxs) > 1 || (return multiparts)
 
     for i in 1:length(idxs)-1

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -263,7 +263,7 @@ that the boundary delimiter does not need to have '-' characters, but a line usi
 the boundary delimiter will start with '--' and end in \r\n.
 [RFC2046 5.1](https://tools.ietf.org/html/rfc2046#section-5.1.1)
 """
-function parse_multipart_form(req::Request)::Vector{Multipart}
+function parse_multipart_form(req::Request)::Union{Vector{Multipart}, Nothing}
     # parse boundary from Content-Type
     m = match(r"multipart/form-data; boundary=(.*)$", req["Content-Type"])
     m === nothing && return nothing

--- a/test/multipart.jl
+++ b/test/multipart.jl
@@ -24,7 +24,7 @@
     @testset "HTTP.Multipart ensure show() works correctly" begin
         # testing that there is no error in printing when nothing is set for filename
         str = sprint(show, (HTTP.Multipart(nothing, IOBuffer("some data"), "plain/text", "", "testname")))
-        @test findfirst("contenttype=\"plain/text\"", str) != nothing
+        @test findfirst("contenttype=\"plain/text\"", str) !== nothing
     end
     @testset "HTTP.Multipart test constructor" begin
         @test_nowarn HTTP.Multipart(nothing, IOBuffer("some data"), "plain/text", "", "testname")

--- a/test/multipart.jl
+++ b/test/multipart.jl
@@ -21,4 +21,13 @@
             @test_throws MethodError HTTP.post(uri, body)
         end
     end
+    @testset "HTTP.Multipart ensure show() works correctly" begin
+        # testing that there is no error in printing when nothing is set for filename
+        str = sprint(show, (HTTP.Multipart(nothing, IOBuffer("some data"), "plain/text", "", "testname")))
+        @test findfirst("contenttype=\"plain/text\"", str) != nothing
+    end
+    @testset "HTTP.Multipart test constructor" begin
+        @test_nowarn HTTP.Multipart(nothing, IOBuffer("some data"), "plain/text", "", "testname")
+        @test_throws MethodError HTTP.Multipart(nothing, "some data", "plain/text", "", "testname")
+    end
 end

--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -1,0 +1,126 @@
+using Test
+using HTTP
+
+
+function generate_test_body()
+    IOBuffer("----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue\"; filename=\"multipart.txt\"\r\nContent-Type: text/plain\r\n\r\nnot much to say\n\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key1\"\r\n\r\n1\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key2\"\r\n\r\nkey the second\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue2\"; filename=\"multipart-leading-newline.txt\"\r\nContent-Type: text/plain\r\n\r\n\nfile with leading newline\n\r\n----------------------------918073721150061572809433--\r\n").data
+end
+
+
+function generate_test_request()
+    headers = [
+        "User-Agent" => "PostmanRuntime/7.15.2",
+        "Accept" => "*/*",
+        "Cache-Control" => "no-cache",
+        "Postman-Token" => "288c2481-1837-4ba9-add3-f23d380fa440",
+        "Host" => "localhost:8888",
+        "Accept-Encoding" => "gzip, deflate",
+        "Accept-Encoding" => "gzip, deflate",
+        "Content-Type" => "multipart/form-data; boundary=--------------------------918073721150061572809433",
+        "Content-Length" => "657",
+        "Connection" => "keep-alive",
+    ]
+
+    HTTP.Request("POST", "/", headers, generate_test_body())
+end
+
+
+@testset "parse multipart form-data" begin
+    @testset "find_multipart_boundary" begin
+        request = generate_test_request()
+
+        # NOTE: this is the start of a "boundary delimiter line" and has two leading
+        # '-' characters prepended to the boundary delimiter from Content-Type header
+        delimiter = IOBuffer("----------------------------918073721150061572809433").data
+        body = generate_test_body()
+        # length of the delimiter, CRLF, and -1 for the end index to be the LF character
+        endIndexOffset = length(delimiter) + 2 - 1
+
+        (isTerminatingDelimiter, startIndex, endIndex) = HTTP.find_multipart_boundary(body, delimiter)
+        @test !isTerminatingDelimiter
+        @test 1 == startIndex
+        @test (startIndex + endIndexOffset) == endIndex
+
+        # the remaining "boundary delimiter lines" will have a CRLF preceding them
+        endIndexOffset += 2
+
+        (isTerminatingDelimiter, startIndex, endIndex) = HTTP.find_multipart_boundary(body, delimiter, start = startIndex + 1)
+        @test !isTerminatingDelimiter
+        @test 175 == startIndex
+        @test (startIndex + endIndexOffset) == endIndex
+
+        (isTerminatingDelimiter, startIndex, endIndex) = HTTP.find_multipart_boundary(body, delimiter, start = startIndex + 3)
+        @test !isTerminatingDelimiter
+        @test 279 == startIndex
+        @test (startIndex + endIndexOffset) == endIndex
+
+        (isTerminatingDelimiter, startIndex, endIndex) = HTTP.find_multipart_boundary(body, delimiter, start = startIndex + 3)
+        @test !isTerminatingDelimiter
+        @test 396 == startIndex
+        @test (startIndex + endIndexOffset) == endIndex
+
+        (isTerminatingDelimiter, startIndex, endIndex) = HTTP.find_multipart_boundary(body, delimiter, start = startIndex + 3)
+        @test isTerminatingDelimiter
+        @test 600 == startIndex
+        # +2 because of the two additional '--' characters
+        @test (startIndex + endIndexOffset + 2) == endIndex
+    end
+
+
+    @testset "parse_multipart_form" begin
+        multiparts = HTTP.parse_multipart_form(generate_test_request())
+        @test 4 == length(multiparts)
+
+        @test "multipart.txt" === multiparts[1].filename
+        @test "namevalue" === multiparts[1].name
+        @test "text/plain" === multiparts[1].contenttype
+        @test "not much to say\n" === String(read(multiparts[1].data))
+
+        @test isnothing(multiparts[2].filename)
+        @test "key1" === multiparts[2].name
+        @test "text/plain" === multiparts[2].contenttype
+        @test "1" === String(read(multiparts[2].data))
+
+        @test isnothing(multiparts[3].filename)
+        @test "key2" === multiparts[3].name
+        @test "text/plain" === multiparts[3].contenttype
+        @test "key the second" === String(read(multiparts[3].data))
+
+        @test "multipart-leading-newline.txt" === multiparts[4].filename
+        @test "namevalue2" === multiparts[4].name
+        @test "text/plain" === multiparts[4].contenttype
+        @test "\nfile with leading newline\n" === String(read(multiparts[4].data))
+    end
+end
+
+@testset "content_disposition_extract($(v[1])" for v in (
+        ("; filename=abc.txt ; name = xyz", "xyz", "abc.txt"),
+        ("; name=abc ; filename = xyz", "abc", "xyz"),
+        ("""; mno;filename="abc";name=xyz""", "xyz", "abc"),
+        (""";filename="abc";mno;name=xyz""", "xyz", "abc"),
+        (""";filename=   "abc"   ;mno;name=xyz""", "xyz", "abc"),
+        ("; filename=abc.txt ; name = xyz ;", "xyz", "abc.txt"),
+        ("; filename=abc.txt ; name = xyz;", "xyz", "abc.txt"),
+        ("; filename=abc.txt ; name = xyz ; mno", "xyz", "abc.txt"),
+        ("; filename=abc.txt ; name = xyz ; mno ;", "xyz", "abc.txt"),
+        (";name=\"ab\\\"cdef\"","ab\\\"cdef", nothing),
+        (";filename=abc\\;xyz", nothing, "abc\\;xyz"),
+        (";filename=\\\"abc;name=xyz", "xyz", "\\\"abc"),
+        (";name=xyz;filename=;mno", "xyz", nothing),
+        (";name=\"xy;z\";filename=;mno", "xy;z", nothing),
+        (";name=\"x=z\";filename=bbb", "x=z", "bbb")
+        )
+    name = nothing
+    filename = nothing
+
+    for (pair, key, value) in HTTP.content_disposition_extract(v[1])
+        if pair && key == "name"
+            name = value
+        elseif pair && key == "filename"
+            filename = value
+        end
+    end
+
+    @test name == v[2]
+    @test filename == v[3]
+end

--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -3,7 +3,7 @@ using HTTP
 
 
 function generate_test_body()
-    IOBuffer("----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue\"; filename=\"multipart.txt\"\r\nContent-Type: text/plain\r\n\r\nnot much to say\n\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key1\"\r\n\r\n1\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key2\"\r\n\r\nkey the second\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue2\"; filename=\"multipart-leading-newline.txt\"\r\nContent-Type: text/plain\r\n\r\n\nfile with leading newline\n\r\n----------------------------918073721150061572809433--\r\n").data
+    Vector{UInt8}("----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue\"; filename=\"multipart.txt\"\r\nContent-Type: text/plain\r\n\r\nnot much to say\n\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key1\"\r\n\r\n1\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key2\"\r\n\r\nkey the second\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue2\"; filename=\"multipart-leading-newline.txt\"\r\nContent-Type: text/plain\r\n\r\n\nfile with leading newline\n\r\n----------------------------918073721150061572809433--\r\n")
 end
 
 
@@ -31,7 +31,7 @@ end
 
         # NOTE: this is the start of a "boundary delimiter line" and has two leading
         # '-' characters prepended to the boundary delimiter from Content-Type header
-        delimiter = IOBuffer("----------------------------918073721150061572809433").data
+        delimiter = Vector{UInt8}("----------------------------918073721150061572809433")
         body = generate_test_body()
         # length of the delimiter, CRLF, and -1 for the end index to be the LF character
         endIndexOffset = length(delimiter) + 2 - 1

--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -24,6 +24,21 @@ function generate_test_request()
     HTTP.Request("POST", "/", headers, generate_test_body())
 end
 
+function generate_non_multi_test_request()
+    headers = [
+        "User-Agent" => "PostmanRuntime/7.15.2",
+        "Accept" => "*/*",
+        "Cache-Control" => "no-cache",
+        "Postman-Token" => "288c2481-1837-4ba9-add3-f23d380fa440",
+        "Host" => "localhost:8888",
+        "Accept-Encoding" => "gzip, deflate",
+        "Accept-Encoding" => "gzip, deflate",
+        "Content-Length" => "657",
+        "Connection" => "keep-alive",
+    ]
+
+    HTTP.Request("POST", "/", headers, Vector{UInt8}())
+end
 
 @testset "parse multipart form-data" begin
     @testset "find_multipart_boundary" begin
@@ -68,6 +83,8 @@ end
 
 
     @testset "parse_multipart_form" begin
+        @test HTTP.parse_multipart_form(generate_non_multi_test_request()) === nothing
+        
         multiparts = HTTP.parse_multipart_form(generate_test_request())
         @test 4 == length(multiparts)
 

--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -76,12 +76,12 @@ end
         @test "text/plain" === multiparts[1].contenttype
         @test "not much to say\n" === String(read(multiparts[1].data))
 
-        @test isnothing(multiparts[2].filename)
+        @test multiparts[2].filename === nothing
         @test "key1" === multiparts[2].name
         @test "text/plain" === multiparts[2].contenttype
         @test "1" === String(read(multiparts[2].data))
 
-        @test isnothing(multiparts[3].filename)
+        @test multiparts[3].filename === nothing
         @test "key2" === multiparts[3].name
         @test "text/plain" === multiparts[3].contenttype
         @test "key the second" === String(read(multiparts[3].data))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using JSON
               "utils.jl",
               "client.jl",
               "multipart.jl",
+              "parsemultipart.jl",
               "sniff.jl",
               "uri.jl",
               "url.jl",


### PR DESCRIPTION
This is basically the https://github.com/JuliaWeb/HTTP.jl/pull/427 pull request with changes asked for by @c42f here https://github.com/JuliaWeb/HTTP.jl/pull/427#pullrequestreview-275747560.

The biggest change where the processing of the arguments on the "Content-Disposition" command according to https://tools.ietf.org/html/rfc2183.  Basically to parse that line correctly I created a content_disposition_tokenize() method that would take the line:

`
Content-Disposition: form-data; name=abc ; filename=xyz.txt ; inline
`

And convert it to the list of SubString objects:

`
[ "name", "=","abc", ";", "filename", "=", "xyz.txt", ";", "inline" ]
`

Then a method content_disposition_extract() which parses that list into a tuple with a boolean indicating of the element is a key value pair, followed by the "key", then the "value" if present so the above line would be turned into:

`
[
    (true, "name", "abc"),
    (true, "filename", "xyz.txt"),
    (false, "inline", nothing)
]
`

Then the name and filename can be extracted.

This is the second attempt for this pull.  The first had a bad merge.  Now it seems to have worked correctly.