### PR TITLE
Fix for HTTPS proxy

### DIFF
--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -82,6 +82,9 @@ function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
 
     try
         if proxy !== nothing && target_url.scheme == "https"
+            target_url = URI(scheme=target_url.scheme,
+                             host=target_url.host,
+                             port=443)
             return tunnel_request(Next, io, target_url, req, body; kw...)
         end
 

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -82,9 +82,7 @@ function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
 
     try
         if proxy !== nothing && target_url.scheme == "https"
-            target_url = URI(scheme=target_url.scheme,
-                             host=target_url.host,
-                             port=443)
+            target_url = merge(target_url, port=443)
             return tunnel_request(Next, io, target_url, req, body; kw...)
         end
 


### PR DESCRIPTION
Instantiate a new `target_url` specifying the port (443) for https proxy.