### PR TITLE
Fix #487. Clean up multi-threaded support w/ ConnectionPool and pipel…

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -5,7 +5,7 @@ export startwrite, startread, closewrite, closeread, stack, insert, AWS4AuthLaye
     DebugLayer, ExceptionLayer, MessageLayer, RedirectLayer, RetryLayer, StreamLayer,
     TimeoutLayer
 
-const DEBUG_LEVEL = Ref(0)
+const DEBUG_LEVEL = Ref(1)
 
 Base.@deprecate escape escapeuri
 Base.@deprecate URL URI

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -32,6 +32,7 @@ function request(::Type{StreamLayer{Next}}, io::IO, request::Request, body;
 
     response = request.response
     http = Stream(response, io)
+    println("streamlayer startwrite")
     startwrite(http)
 
     if verbose == 2
@@ -83,7 +84,7 @@ function request(::Type{StreamLayer{Next}}, io::IO, request::Request, body;
             rethrow(e)
         end
     end
-
+    println("streamrequest closewrite")
     closewrite(http)
     closeread(http)
 
@@ -105,6 +106,7 @@ function writebody(http::Stream, req::Request, body)
     req.txcount += 1
 
     if isidempotent(req)
+        println("writebody closewriter")
         closewrite(http)
     else
         @debug 2 "🔒  $(req.method) non-idempotent, " *

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -117,6 +117,7 @@ function IOExtras.closewrite(http::Stream{Response})
         return
     end
     closebody(http)
+    println("stream response closewrite")
     closewrite(http.stream)
 end
 
@@ -124,6 +125,7 @@ function IOExtras.closewrite(http::Stream{Request})
 
     if iswritable(http)
         closebody(http)
+        println("stream request closewrite")
         closewrite(http.stream)
     end
 

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -3,7 +3,7 @@ taskid(t=current_task()) = string(hash(t) & 0xffff, base=16, pad=4)
 debug_header() = string("DEBUG: ", rpad(Dates.now(), 24), taskid(), " ")
 
 macro debug(n::Int, s)
-    DEBUG_LEVEL[] >= n ? :(println($__source__, ": ", debug_header(), $(esc(s)))) :
+    DEBUG_LEVEL[] >= n ? :(println(debug_header(), $(esc(s)))) :
                          :()
 end
 

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -3,22 +3,7 @@ taskid(t=current_task()) = string(hash(t) & 0xffff, base=16, pad=4)
 debug_header() = string("DEBUG: ", rpad(Dates.now(), 24), taskid(), " ")
 
 macro debug(n::Int, s)
-    DEBUG_LEVEL[] >= n ? :(println(debug_header(), $(esc(s)))) :
-                         :()
-end
-
-macro debugshow(n::Int, s)
-    DEBUG_LEVEL[] >= n ? :(println(debug_header(),
-                                   $(sprint(Base.show_unquoted, s)), " = ",
-                                   sprint(io->show(io, "text/plain",
-                                                   begin value=$(esc(s)) end)))) :
-                         :()
-
-end
-
-macro debugshort(n::Int, s)
-    DEBUG_LEVEL[] >= n ? :(println(debug_header(),
-                                   sprintcompact($(esc(s))))) :
+    DEBUG_LEVEL[] >= n ? :(println($__source__, ": ", debug_header(), $(esc(s)))) :
                          :()
 end
 

--- a/test/async.jl
+++ b/test/async.jl
@@ -10,7 +10,7 @@ using MbedTLS: digest, MD_SHA256, MD_MD5
         [:verbose => 0, :reuse_limit => 50]
     ]
     protocols = ["http", "https"]
-
+    
     function dump_async_exception(e, st)
         buf = IOBuffer()
         write(buf, "==========\n@async exception:\n==========\n")
@@ -22,7 +22,6 @@ using MbedTLS: digest, MD_SHA256, MD_MD5
 
     function startASyncHTTP()
         @async HTTP.listen() do http
-            @show HTTP.Sockets.getsockname(http)
             startwrite(http)
             write(http, """
                 <html><head>

--- a/test/chunking.jl
+++ b/test/chunking.jl
@@ -15,7 +15,7 @@ using BufferedStreams
     split1 = 106
     split2 = 300
 
-    @async HTTP.listen("127.0.0.1", 8091) do http
+    t = @async HTTP.listen("127.0.0.1", 8091) do http
         startwrite(http)
         tcp = http.stream.c.io
 
@@ -32,6 +32,7 @@ using BufferedStreams
     end
 
     sleep(1)
+    @assert t.state == :runnable
 
     r = HTTP.get("http://127.0.0.1:8091")
 

--- a/test/client.jl
+++ b/test/client.jl
@@ -73,7 +73,15 @@ end
         @test status(r) == 200
 
         b = [JSON.parse(l) for l in eachline(io)]
-        @test a == b
+        @test all(zip(a, b)) do (x, y)
+            x["args"] == y["args"] &&
+            x["id"] == y["id"] &&
+            x["url"] == y["url"] &&
+            x["origin"] == y["origin"] &&
+            x["headers"]["Content-Length"] == y["headers"]["Content-Length"] &&
+            x["headers"]["Host"] == y["headers"]["Host"] &&
+            x["headers"]["User-Agent"] == y["headers"]["User-Agent"]
+        end
     end
 
     @testset "Client Body Posting - Vector{UTF8}, String, IOStream, IOBuffer, BufferStream" begin

--- a/test/client.jl
+++ b/test/client.jl
@@ -177,6 +177,7 @@ end
 
     @testset "openraw client method - $socket_protocol" for socket_protocol in ["wss", "ws"]
         # WebSockets require valid headers.
+        @show sch, socket_protocol
         headers = Dict(
             "Upgrade" => "websocket",
             "Connection" => "Upgrade",
@@ -203,7 +204,7 @@ end
         eof(socket)
         actualframe = read(socket, 7)
         @test expectedframe == actualframe
-
+        println("calling close")
         close(socket)
     end
 end


### PR DESCRIPTION
…ined request conditions.

@vtjnash, is it bad-practice to just have our `poolcondition = Threads.Condition()` and use its lock everywhere? Do we need a separate lock and only use the condition for notifying on closed connections? This seems to work in all my local testing.