### PR TITLE
Fix #511. The change from getaddrinfo to getalladdrinfo had an unexpe…

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -610,7 +610,7 @@ function getconnection(::Type{TCPSocket},
     @debug 2 "TCP connect: $host:$p..."
 
     if connect_timeout == 0
-        tcp = Sockets.connect(Sockets.getalladdrinfo(host)[1], p)
+        tcp = Sockets.connect(host == "localhost" ? ip"127.0.0.1" : Sockets.getalladdrinfo(host)[1], p)
         keepalive && keepalive!(tcp)
         return tcp
     end


### PR DESCRIPTION
…cted breaking change in that when the host was 'localhost', it tried to use the ipv6 address instead of ipv4. This broke mainly testing scenarios where a local server was started on 0.0.0.0 and thus the client couldn't connect.
