### PR TITLE
Fix #520 memory leak from server

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -473,9 +473,12 @@ end
 
 
 function release(c::Connection)
-    pod = getpod(POOL, hashconn(c))
-    @debug 2 "returning connection to pod: $c"
-    put!(pod.conns, c)
+    h = hashconn(c)
+    if haskey(POOL.conns, h)
+        pod = getpod(POOL, h)
+        @debug 2 "returning connection to pod: $c"
+        put!(pod.conns, c)
+    end
     return
 end
 


### PR DESCRIPTION
With the recent refactoring of ConnectionPool.jl to be thread-safe, we
moved to the use of Channels internally to manage the "pool", which is
more of a holding pen for Connections that have finished reading/writing
and can be reused. This works fine and well for client code, but the
server code isn't architected to use or need the connection pooling; it
manages the lifetime of the connection itself as long as it stays open.
The problem was that `closeread`/`closewrite` are still called in the
server handling code to manage the connection transactions and
underlying socket state; both `closeread` and `closewrite` "release" a
connection back to the pool, which internally did a `put!` to the
connection pool. The issue is that there aren't any `take!`-ers for
those connection pool channels, and they're declared with `Inf` size, so
they just continued to grow and grow as connections were released.

The fix I've submitted for now is that when a connection is released
back to the connection pool, we first check if we've seen that type of
connection before; if not, we'll skip storing it for re-use. This works
because client code always tries to _get_ a connection to reuse before
making a new one, whereas the server code only ever releases connections
via use of `closeread`/`closewrite`. So from the pool's perspective, if
it hasn't ever seen this type of connection before, it decides to ignore
the release.