### PR TITLE
Buffer headers before writing them out

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -82,7 +82,9 @@ function IOExtras.startwrite(http::Stream)
     else
         http.writechunked = ischunked(m)
     end
-    writeheaders(http.stream, m)
+    buf = IOBuffer()
+    writeheaders(buf, m)
+    write(http.stream, take!(buf))
 end
 
 function Base.unsafe_write(http::Stream, p::Ptr{UInt8}, n::UInt)


### PR DESCRIPTION
We're currently sending headers as one packet per header -
that's both inefficient and undesirable for sequencing. Instead
buffer those headers up and try to send them all at once.