### PR TITLE
Add a method to `escapeuri` for `NamedTuple`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.8.15"
+version = "0.8.16"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -318,6 +318,7 @@ escapeuri(v::Symbol) = escapeuri(string(v))
 escapeuri(key, value) = string(escapeuri(key), "=", escapeuri(value))
 escapeuri(key, values::Vector) = escapeuri(key => v for v in values)
 escapeuri(query) = join((escapeuri(k, v) for (k,v) in query), "&")
+escapeuri(nt::NamedTuple) = escapeuri(pairs(nt))
 
 decodeplus(q) = replace(q, '+' => ' ')
 

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -485,6 +485,9 @@ urltests = URLTest[
         @test HTTP.queryparams(HTTP.URI("http://www.example.com/path/foo+bar/path?query+name=query+value")) ==
             Dict("query name" => "query value")
         @test HTTP.queryparams(HTTP.escapeuri(Dict("a+b" => "c d+e"))) == Dict("a+b" => "c d+e")
+
+        # Issue 540
+        @test HTTP.escapeuri((a=1, b=2)) == "a=1&b=2"
     end
 
     @testset "Normalize URI paths" begin


### PR DESCRIPTION
Closes #540 

Turns out it was a pretty easy fix...