### PR TITLE
Fix: `no_proxy` works only with absolute domain name

### DIFF
--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -13,7 +13,7 @@ hasdotsuffix(s, suffix) = endswith(s, "." * suffix)
 
 function isnoproxy(host)
     for x in NO_PROXY
-        hasdotsuffix(host, x) || host == x) && return true
+        (hasdotsuffix(host, x) || (host == x)) && return true
     end
     return false
 end

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -13,7 +13,7 @@ hasdotsuffix(s, suffix) = endswith(s, "." * suffix)
 
 function isnoproxy(host)
     for x in NO_PROXY
-        hasdotsuffix(host, x) && return true
+        hasdotsuffix(host, x) || host == x) && return true
     end
     return false
 end


### PR DESCRIPTION
For eg: 
With `no_proxy=example.com` or `no_proxy=.example.com` set, currently, request `GET http://example.com` gets proxied 

