### PR TITLE
Streams: don't error when writing closing bytes

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -110,7 +110,9 @@ Write the final `0` chunk if needed.
 function closebody(http::Stream)
     if http.writechunked
         http.writechunked = false
-        write(http.stream, "0\r\n\r\n")
+        try
+            write(http.stream, "0\r\n\r\n")
+        catch end
     end
 end
 


### PR DESCRIPTION
A common error when using Firefox on localhost is:
```
┌ Error: error handling request
│   exception =
│    IOError: stream is closed or unusable
│    Stacktrace:
│     [1] check_open at ./stream.jl:328 [inlined]
│     [2] uv_write_async(::Sockets.TCPSocket, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:961
│     [3] uv_write(::Sockets.TCPSocket, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:924
│     [4] unsafe_write(::Sockets.TCPSocket, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:1007
│     [5] unsafe_write at /home/fons/.julia/packages/HTTP/GkPBm/src/ConnectionPool.jl:174 [inlined]
│     [6] macro expansion at ./gcutils.jl:91 [inlined]
│     [7] write at ./strings/io.jl:186 [inlined]
│     [8] closebody at /home/fons/.julia/packages/HTTP/GkPBm/src/Streams.jl:113 [inlined]
│     [9] closewrite(::HTTP.Streams.Stream{HTTP.Messages.Request,HTTP.ConnectionPool.Transaction{Sockets.TCPSocket}}) at /home/fons/.julia/packages/HTTP/GkPBm/src/Streams.jl:128
│     [10] (::HTTP.Servers.var"#13#14"{HTTP.Handlers.var"#4#5"{HTTP.Handlers.StreamHandlerFunction{Pluto.var"#71#75"}},HTTP.ConnectionPool.Transaction{Sockets.TCPSocket},HTTP.Streams.Stream{HTTP.Messages.Request,HTTP.ConnectionPool.Transaction{Sockets.TCPSocket}}})() at ./task.jl:333
└ @ HTTP.Servers ~/.julia/packages/HTTP/GkPBm/src/Servers.jl:373
```

Which led to [lots of confusing error messages when using Pluto.jl](https://github.com/fonsp/Pluto.jl/issues/123). I believe the error is due to Firefox closing the IO before receiving the bytes `0\r\n\r\n` when navigating to another page. 

This PR simply wraps the closing `write` call in a `try catch` block - I believe that this only affects the situation where a clean close is not possible, but both ends already know that the connection is closing. (I should point out that I am not familiar with the HTTP protocol!)