### PR TITLE
Eliminate type-piracy in `string`

### DIFF
--- a/src/CookieRequest.jl
+++ b/src/CookieRequest.jl
@@ -38,7 +38,7 @@ function request(::Type{CookieLayer{Next}},
         end
     end
     if !isempty(cookiestosend)
-        setkv(headers, "Cookie", string(getkv(headers, "Cookie", ""), cookiestosend))
+        setkv(headers, "Cookie", stringify(getkv(headers, "Cookie", ""), cookiestosend))
     end
 
     res = request(Next, method, url, headers, body; kw...)

--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -30,7 +30,7 @@
 
 module Cookies
 
-export Cookie, cookies
+export Cookie, cookies, stringify
 
 import Base: ==
 using ..Dates
@@ -119,7 +119,7 @@ function Base.String(c::Cookie, isrequest::Bool=true)
     return String(take!(io))
 end
 
-function Base.string(cookiestring::String, cookies::Vector{Cookie}, isrequest::Bool=true)
+function stringify(cookiestring::String, cookies::Vector{Cookie}, isrequest::Bool=true)
     io = IOBuffer()
     !isempty(cookiestring) && write(io, cookiestring, cookiestring[end] == ';' ? "" : ";")
     len = length(cookies)

--- a/test/cookies.jl
+++ b/test/cookies.jl
@@ -46,7 +46,7 @@
                    HTTP.Cookie("cookie-2", "v\$2"),
                    HTTP.Cookie("cookie-3", "v\$3"),
                   ]
-        @test string("", cookies) == "cookie-1=v\$1; cookie-2=v\$2; cookie-3=v\$3"
+        @test HTTP.stringify("", cookies) == "cookie-1=v\$1; cookie-2=v\$2; cookie-3=v\$3"
     end
 
     @testset "readsetcookies" begin


### PR DESCRIPTION
Overriding behavior for a particular eltype of a container is piracy against the container. I have no particular attachment to this particular solution; perhaps you want to define a `CookieRequest` struct and then overload `Base.show`? Anyway, this seemed like the easiest approach, but I do not know how this package interacts with a wider ecosystem so this change could, for all I know, be breaking.

Deleting this method (or replacing it with a private one) eliminates approximately 250 method invalidations, mostly from `Base.show_unquoted` which rampantly calls `string(::String, args...)`. It's a small enough effect that it's a little difficult to measure, but this change seems to shave about 5% off TTFP.
