### PR TITLE
Couple of fixes for various things and making cookie tracking on by default

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -555,7 +555,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 """
 function stack(;redirect=true,
                 aws_authorization=false,
-                cookies=true,
+                cookies=false,
                 canonicalize_headers=false,
                 retry=true,
                 status_exception=true,

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -555,7 +555,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 """
 function stack(;redirect=true,
                 aws_authorization=false,
-                cookies=false,
+                cookies=true,
                 canonicalize_headers=false,
                 retry=true,
                 status_exception=true,

--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -370,11 +370,11 @@ struct Router{sym} <: Handler
     segments::Dict{String, Val}
 end
 
-function Router(default::Union{Handler, Function, Nothing}=FourOhFour)
+function Router(default::Union{Handler, Function}=FourOhFour)
     # each router gets a unique symbol as a type parameter so that dispatching
     # requests always go to the correct router
     sym = gensym()
-    return Router{sym}(default, Dict{Route, String}(), Dict{String, Val}())
+    return Router{sym}(default isa Function ? RequestHandlerFunction(default) : default, Dict{Route, String}(), Dict{String, Val}())
 end
 
 const SCHEMES = Dict{String, Val}("http" => Val{:http}(), "https" => Val{:https}())

--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -231,7 +231,7 @@ end
 function pathmatch(cookie::Cookie, requestpath)
     requestpath == cookie.path && return true
     if startswith(requestpath, cookie.path)
-        if cookie.path[end] == '/'
+        if length(cookie.path) > 0 && cookie.path[end] == '/'
             return true # The "/any/" matches "/any/path" case.
         elseif length(requestpath) >= length(cookie.path) + 1 && requestpath[length(cookie.path)+1] == '/'
             return true # The "/any" matches "/any/path" case.


### PR DESCRIPTION
These are just a few small fixes. The biggest change is making `cookies=true` by default, which means we'll track cookies for users automatically. There was at least one case recently where a user was frustrated because it didn't seem like HTTP.jl could do "session management" like they were used to in python `requests`. We've made a couple of changes recently that make HTTP.jl act more and more like a friendlier client, so I think this makes sense.

cc-ing a couple people in case they have opinions on tracking cookies by default: @staticfloat , @StefanKarpinski , @oxinabox , @mattBrzezinski 