### PR TITLE
Never generate empty filename for download

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.8.17"
+version = "0.8.18"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/download.jl
+++ b/src/download.jl
@@ -29,7 +29,7 @@ function try_get_filename_from_headers(resp)
                 # It was in quotes, so it will be double escaped
                 filename = unescape_string(quoted_filename[1])
             end
-            return filename
+            return filename == "" ? nothing : filename
         end
     end
     return nothing


### PR DESCRIPTION
Ran into a strange error when I was trying `HTTP.download`, it tried to save the file to `/tmp/`, which obviously is not a valid path for a file. Found out that the Content-Disposition header listed an empty filename which is... odd.

```jl
julia> using HTTP

julia> resp = HTTP.get("https://pretalx.com/media/juliacon2020/images/9A8DCP/logo_kafyqWH.png");

julia> println(HTTP.header(resp, "Content-Disposition"))
attachment; filename=""
```

I could add this to the test suite but I'm afraid of the URL not being very permanent. Thoughts on that?