### PR TITLE
Fix readtimeout for requests

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -165,9 +165,6 @@ getrawstream(t::Transaction) = t.c.io
 inactiveseconds(t::Transaction) = inactiveseconds(t.c)
 
 function inactiveseconds(c::Connection)::Float64
-    if isbusy(c)
-        return 0.0
-    end
     return time() - c.timestamp
 end
 
@@ -231,16 +228,17 @@ function Base.unsafe_read(t::Transaction, p::Ptr{UInt8}, n::UInt)
         p += nb
         n -= nb
         @debug 4 "↩️  read $nb-bytes from buffer."
+        t.c.timestamp = time()
     end
     if n > 0
         unsafe_read(t.c.io, p, n)
         @debug 4 "⬅️  read $n-bytes from $(typeof(t.c.io))"
+        t.c.timestamp = time()
     end
     return nothing
 end
 
 function read_to_buffer(t::Transaction, sizehint=4096)
-
     buf = t.c.buffer
 
     # Reset the buffer if it is empty.

--- a/test/client.jl
+++ b/test/client.jl
@@ -211,6 +211,10 @@ end
     @test status(HTTP.open(x -> x, :GET, "http://httpbin.org/ip")) == 200
 end
 
+@testset "readtimeout" begin
+    @test_throws HTTP.IOError HTTP.get("http://httpbin.org/delay/5"; readtimeout=1, retry=false)
+end
+
 @testset "Public entry point of HTTP.request and friends (e.g. issue #463)" begin
     headers = Dict("User-Agent" => "HTTP.jl")
     query = Dict("hello" => "world")


### PR DESCRIPTION
Should fix #571. There were a couple issues with the current
`readtimeout` and `TimeoutRequest` components. First, in the
`TimeoutRequest` layer, we were checking `inactiveseconds(io)` on the
`Transaction`, which returned 0 if the transaction was busy, which it
always would be in the middle of a request. Looking at uses of
`inactiveseconds`, it shouldn't be checking if the connection is busy or
not, so I removed that. The other places that were calling
`inactiveseconds` were already checking if the connection was busy or
not anyway.

The 2nd issue was that we weren't actually updating the connection
timestamp each time we read data for a response body. This would be
problematic for long-running downloads, because if if the request lasted
longer than the `readtimeout`, the connection would be closed, even
though we were still actively receiving data.

This should hopefully fix #571 since we'll now actually abort the
request if we reach the `readtimeout` instead of just sitting, waiting
indefinitely for lost packets of data to come. I will note that
currently `close(::SSLContext)` doesn't "interupt" the connection like
it does for `TcpSocket`, so the behavior is slightly different. But it's
a much larger (and scarier) project to overhaul the `SSLContext` `close`
behavior/semantics (but still needs to be done at some point). Hence
only the reliable test for `http` for now.