### PR TITLE
Fix code example in the docstring for `serve`. (#592)

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -332,7 +332,7 @@ end
 
 # pass in own server socket to control shutdown
 using Sockets
-server = Sockets.serve(Sockets.InetAddr(parse(IPAddr, host), port))
+server = Sockets.listen(Sockets.InetAddr(parse(IPAddr, host), port))
 @async HTTP.serve(f, host, port; server=server)
 # close server which will stop HTTP.serve
 close(server)


### PR DESCRIPTION
Replace incorrect call to Sockets.serve with a call to Sockets.listen in
the code example demonstrating how to start an HTTP server using a
server socket.

Closes #592 