### PR TITLE
Round number of bytes to integer before Base.format_bytes

### DIFF
--- a/src/download.jl
+++ b/src/download.jl
@@ -91,7 +91,7 @@ from the rules of the HTTP.
 """
 function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=1, kw...)
     format_progress(x) = round(x, digits=4)
-    format_bytes(x) = !isfinite(x) ? "∞ B" : Base.format_bytes(round(x))
+    format_bytes(x) = !isfinite(x) ? "∞ B" : Base.format_bytes(round(Int, x))
     format_seconds(x) = "$(round(x; digits=2)) s"
     format_bytes_per_second(x) = format_bytes(x) * "/s"
 

--- a/src/download.jl
+++ b/src/download.jl
@@ -91,7 +91,7 @@ from the rules of the HTTP.
 """
 function download(url::AbstractString, local_path=nothing, headers=Header[]; update_period=1, kw...)
     format_progress(x) = round(x, digits=4)
-    format_bytes(x) = !isfinite(x) ? "∞ B" : Base.format_bytes(x)
+    format_bytes(x) = !isfinite(x) ? "∞ B" : Base.format_bytes(round(x))
     format_seconds(x) = "$(round(x; digits=2)) s"
     format_bytes_per_second(x) = format_bytes(x) * "/s"
 


### PR DESCRIPTION
I got this intimidating error today:
```
julia> HTTP.download("https://gist.githubusercontent.com/fonsp/6155554a8519ad6d191a6c3ddf764dcc/raw/34108a39580173572ac7232c0020232a932bd3b6/hw4 some solutions.jl")
┌ Error: Exception while generating log record in module HTTP at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:119
│   exception =
│    InexactError: Int64(196.42857142857142)
│    Stacktrace:
│     [1] Int64 at ./float.jl:710 [inlined]
│     [2] format_bytes(::Float64) at ./timing.jl:99
│     [3] format_bytes at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:94 [inlined]
│     [4] format_bytes_per_second at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:96 [inlined]
│     [5] |>(::Float64, ::HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}) at ./operators.jl:834
│     [6] macro expansion at ./logging.jl:332 [inlined]
│     [7] (::HTTP.var"#report_callback#27"{Float64,Dates.DateTime,String,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}})() at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:119
│     [8] (::HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}})(::HTTP.Streams.Stream{HTTP.Messages.Response,HTTP.ConnectionPool.Transaction{MbedTLS.SSLContext}}) at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:143
│     [9] macro expansion at /home/fons/.julia/packages/HTTP/atT5q/src/StreamRequest.jl:70 [inlined]
│     [10] macro expansion at ./task.jl:332 [inlined]
│     [11] request(::Type{HTTP.StreamRequest.StreamLayer{Union{}}}, ::HTTP.ConnectionPool.Transaction{MbedTLS.SSLContext}, ::HTTP.Messages.Request, ::Nothing; reached_redirect_limit::Bool, response_stream::Nothing, iofunction::HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}, verbose::Int64, kw::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/StreamRequest.jl:57
│     [12] request(::Type{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}, ::HTTP.URIs.URI, ::HTTP.Messages.Request, ::Nothing; proxy::Nothing, socket_type::Type{T} where T, reuse_limit::Int64, kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Bool}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/ConnectionRequest.jl:89
│     [13] request(::Type{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}, ::HTTP.URIs.URI, ::Vararg{Any,N} where N; kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Bool}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/ExceptionRequest.jl:19
│     [14] (::Base.var"#56#58"{Base.var"#56#57#59"{ExponentialBackOff,HTTP.RetryRequest.var"#2#3"{Bool,HTTP.Messages.Request},typeof(HTTP.request)}})(::Type{T} where T, ::Vararg{Any,N} where N; kwargs::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Bool}}}) at ./error.jl:288
│     [15] #request#1 at /home/fons/.julia/packages/HTTP/atT5q/src/RetryRequest.jl:44 [inlined]
│     [16] request(::Type{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; http_version::VersionNumber, target::String, parent::Nothing, iofunction::Function, kw::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:reached_redirect_limit,),Tuple{Bool}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/MessageRequest.jl:51
│     [17] request(::Type{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:reached_redirect_limit, :iofunction),Tuple{Bool,HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/BasicAuthRequest.jl:28
│     [18] request(::Type{HTTP.RedirectRequest.RedirectLayer{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; redirect_limit::Int64, forwardheaders::Bool, kw::Base.Iterators.Pairs{Symbol,HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Tuple{Symbol},NamedTuple{(:iofunction,),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/RedirectRequest.jl:24
│     [19] request(::String, ::String, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; headers::Array{Pair{SubString{String},SubString{String}},1}, body::Nothing, query::Nothing, kw::Base.Iterators.Pairs{Symbol,HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Tuple{Symbol},NamedTuple{(:iofunction,),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/HTTP.jl:314
│     [20] #open#6 at /home/fons/.julia/packages/HTTP/atT5q/src/HTTP.jl:348 [inlined]
│     [21] open at /home/fons/.julia/packages/HTTP/atT5q/src/HTTP.jl:348 [inlined]
│     [22] #download#19 at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:101 [inlined]
│     [23] download at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:93 [inlined] (repeats 2 times)
│     [24] top-level scope at REPL[3]:1
│     [25] eval(::Module, ::Any) at ./boot.jl:331
│     [26] eval_user_input(::Any, ::REPL.REPLBackend) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:134
│     [27] repl_backend_loop(::REPL.REPLBackend) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:195
│     [28] start_repl_backend(::REPL.REPLBackend, ::Any) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:180
│     [29] run_repl(::REPL.AbstractREPL, ::Any; backend_on_current_task::Bool) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:292
│     [30] run_repl(::REPL.AbstractREPL, ::Any) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:288
│     [31] (::Base.var"#806#808"{Bool,Bool,Bool,Bool})(::Module) at ./client.jl:399
│     [32] #invokelatest#1 at ./essentials.jl:710 [inlined]
│     [33] invokelatest at ./essentials.jl:709 [inlined]
│     [34] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./client.jl:383
│     [35] exec_options(::Base.JLOptions) at ./client.jl:313
│     [36] _start() at ./client.jl:506
└ @ HTTP ~/.julia/packages/HTTP/atT5q/src/download.jl:119
ERROR: HTTP.ExceptionRequest.StatusError(400, "GET", "/fonsp/6155554a8519ad6d191a6c3ddf764dcc/raw/34108a39580173572ac7232c0020232a932bd3b6/hw4 some solutions.jl", HTTP.Messages.Response:
"""
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 11
content-type: text/plain; charset=utf-8

""")
Stacktrace:
 [1] request(::Type{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}, ::HTTP.URIs.URI, ::Vararg{Any,N} where N; kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Bool}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/ExceptionRequest.jl:22
 [2] (::Base.var"#56#58"{Base.var"#56#57#59"{ExponentialBackOff,HTTP.RetryRequest.var"#2#3"{Bool,HTTP.Messages.Request},typeof(HTTP.request)}})(::Type{T} where T, ::Vararg{Any,N} where N; kwargs::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Bool}}}) at ./error.jl:288
 [3] #request#1 at /home/fons/.julia/packages/HTTP/atT5q/src/RetryRequest.jl:44 [inlined]
 [4] request(::Type{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; http_version::VersionNumber, target::String, parent::Nothing, iofunction::Function, kw::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:reached_redirect_limit,),Tuple{Bool}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/MessageRequest.jl:51
 [5] request(::Type{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:reached_redirect_limit, :iofunction),Tuple{Bool,HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/BasicAuthRequest.jl:28
 [6] request(::Type{HTTP.RedirectRequest.RedirectLayer{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; redirect_limit::Int64, forwardheaders::Bool, kw::Base.Iterators.Pairs{Symbol,HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Tuple{Symbol},NamedTuple{(:iofunction,),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/RedirectRequest.jl:24
 [7] request(::String, ::String, ::Array{Pair{SubString{String},SubString{String}},1}, ::Nothing; headers::Array{Pair{SubString{String},SubString{String}},1}, body::Nothing, query::Nothing, kw::Base.Iterators.Pairs{Symbol,HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}},Tuple{Symbol},NamedTuple{(:iofunction,),Tuple{HTTP.var"#20#26"{Int64,String,Nothing,HTTP.var"#format_progress#22",HTTP.var"#format_bytes#23",HTTP.var"#format_seconds#24",HTTP.var"#format_bytes_per_second#25"{HTTP.var"#format_bytes#23"}}}}}) at /home/fons/.julia/packages/HTTP/atT5q/src/HTTP.jl:314
 [8] #open#6 at /home/fons/.julia/packages/HTTP/atT5q/src/HTTP.jl:348 [inlined]
 [9] open at /home/fons/.julia/packages/HTTP/atT5q/src/HTTP.jl:348 [inlined]
 [10] #download#19 at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:101 [inlined]
 [11] download at /home/fons/.julia/packages/HTTP/atT5q/src/download.jl:93 [inlined] (repeats 2 times)
 [12] top-level scope at REPL[3]:1
```