### PR TITLE
Catch getsslcontext errors in server listenloop

### DIFF
--- a/test/mwe.jl
+++ b/test/mwe.jl
@@ -15,12 +15,12 @@ end
         sleep(2)
         launch("https://127.0.0.1:8000/examples/mwe")
     end
-
+    dir = joinpath(dirname(pathof(HTTP)), "../test")
     HTTP.listen("127.0.0.1", 8000;
-                sslconfig = MbedTLS.SSLConfig(joinpath(dirname(@__FILE__), "resources/cert.pem"),
-                                              joinpath(dirname(@__FILE__), "resources/key.pem"))) do http
+                sslconfig = MbedTLS.SSLConfig(joinpath(dir, "resources/cert.pem"),
+                                              joinpath(dir, "resources/key.pem"))) do http
 
-        if HTTP.WebSockets.is_websocket_upgrade(http.message)
+        if HTTP.WebSockets.is_upgrade(http.message)
             HTTP.WebSockets.upgrade(http) do client
                 count = 1
                 while !eof(client);
@@ -32,7 +32,7 @@ end
             end
         else
             h = HTTP.Handlers.RequestHandlerFunction() do req::HTTP.Request
-                HTTP.Response(200,read(joinpath(dirname(@__FILE__),"resources/mwe.html"), String))
+                HTTP.Response(200,read(joinpath(dir, "resources/mwe.html"), String))
             end
             HTTP.Handlers.handle(h, http)
         end

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,6 +1,6 @@
 module test_server
 
-using HTTP, Sockets, Test
+using HTTP, Sockets, Test, MbedTLS
 
 function testget(url, m=1)
     r = []

--- a/test/server.jl
+++ b/test/server.jl
@@ -171,7 +171,7 @@ end
     dir = joinpath(dirname(pathof(HTTP)), "../test")
     sslconfig = MbedTLS.SSLConfig(joinpath(dir, "resources/cert.pem"), joinpath(dir, "resources/key.pem"))
     tsk = @async try
-        HTTP.listen("127.0.0.1", 8091; sslconfig = sslconfig, verbose=true) do http::HTTP.Stream
+        HTTP.listen("127.0.0.1", 8092; sslconfig = sslconfig, verbose=true) do http::HTTP.Stream
             while !eof(http)
                 println("body data: ", String(readavailable(http)))
             end
@@ -186,8 +186,8 @@ end
     clientoptions = (;
         require_ssl_verification = false,
     )
-    r = HTTP.request("GET", "https://127.0.0.1:8091"; clientoptions...)
-    @test_throws HTTP.IOError HTTP.request("GET", "http://127.0.0.1:8091"; clientoptions...)
+    r = HTTP.request("GET", "https://127.0.0.1:8092"; clientoptions...)
+    @test_throws HTTP.IOError HTTP.request("GET", "http://127.0.0.1:8092"; clientoptions...)
 
 end # @testset
 

--- a/test/server.jl
+++ b/test/server.jl
@@ -171,7 +171,7 @@ end
     dir = joinpath(dirname(pathof(HTTP)), "../test")
     sslconfig = MbedTLS.SSLConfig(joinpath(dir, "resources/cert.pem"), joinpath(dir, "resources/key.pem"))
     tsk = @async try
-        HTTP.listen("127.0.0.1", 8085; sslconfig = sslconfig, verbose=true) do http::HTTP.Stream
+        HTTP.listen("127.0.0.1", 8091; sslconfig = sslconfig, verbose=true) do http::HTTP.Stream
             while !eof(http)
                 println("body data: ", String(readavailable(http)))
             end
@@ -186,8 +186,8 @@ end
     clientoptions = (;
         require_ssl_verification = false,
     )
-    r = HTTP.request("GET", "https://127.0.0.1:8085"; clientoptions...)
-    @test_throws HTTP.IOError HTTP.request("GET", "http://127.0.0.1:8085"; clientoptions...)
+    r = HTTP.request("GET", "https://127.0.0.1:8091"; clientoptions...)
+    @test_throws HTTP.IOError HTTP.request("GET", "http://127.0.0.1:8091"; clientoptions...)
 
 end # @testset
 


### PR DESCRIPTION
Fixes #318. This is a bad bug. Basically, if you're running an ssl
server, any client who sends a non-perfect https request (like simply a
plain *http* request) would result in the server task throwing an error
and closing. This is partly because the thrown error isn't super
obvious, nested down a few calls in our overloaded
`Sockets.accept(::Server{SSLConfig})` method. The fix proposed here is
that we'll put a try-catch in the ssl handshaking code and if an error
is thrown, we return `nothing`; in the server `listenloop`, if the
accepted `io` is `nothing`, then we'll skip and try to accept the next
connection.