### PR TITLE
Updated stringify to take an AbstractString

### DIFF
--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -119,7 +119,7 @@ function Base.String(c::Cookie, isrequest::Bool=true)
     return String(take!(io))
 end
 
-function stringify(cookiestring::String, cookies::Vector{Cookie}, isrequest::Bool=true)
+function stringify(cookiestring::AbstractString, cookies::Vector{Cookie}, isrequest::Bool=true)
     io = IOBuffer()
     !isempty(cookiestring) && write(io, cookiestring, cookiestring[end] == ';' ? "" : ";")
     len = length(cookies)


### PR DESCRIPTION
This is to fix a Method Error that stringify(::SubString{String}, ::Array{Cookie, 1}) could not be found.  

This was happening when executing two HTTP.request("GET"; redirect=true) operations in a row with the same "cookiejar".  Both requests actually result in HTTP redirects with Set-Cookie headers spread all over the place.  The first worked fine, the second threw the Method Error.  So I'm not sure exactly *where* or *why* stringify is being called with a SubString rather than a String, I just know it apparently happens...somehow.

Changing the declaration to an AbstractString instead of a String makes everything happy again.