### PR TITLE
Add functions for setting default custom layers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.8.19"
+version = "0.8.20"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -1,9 +1,9 @@
 module HTTP
 
-export startwrite, startread, closewrite, closeread, stack, insert, AWS4AuthLayer,
-    BasicAuthLayer, CanonicalizeLayer, ConnectionPoolLayer, ContentTypeDetectionLayer,
-    DebugLayer, ExceptionLayer, MessageLayer, RedirectLayer, RetryLayer, StreamLayer,
-    TimeoutLayer
+export startwrite, startread, closewrite, closeread, stack, insert, insert_default!,
+    remove_default!, AWS4AuthLayer, BasicAuthLayer, CanonicalizeLayer, ConnectionPoolLayer,
+    ContentTypeDetectionLayer, DebugLayer, ExceptionLayer, MessageLayer, RedirectLayer,
+    RetryLayer, StreamLayer, TimeoutLayer
 
 const DEBUG_LEVEL = Ref(0)
 
@@ -566,7 +566,7 @@ function stack(;redirect=true,
 
     NoLayer = Union
 
-    (redirect             ? RedirectLayer             : NoLayer){
+    stack = (redirect     ? RedirectLayer             : NoLayer){
                             BasicAuthLayer{
     (detect_content_type  ? ContentTypeDetectionLayer : NoLayer){
     (cookies === true || (cookies isa AbstractDict && !isempty(cookies)) ?
@@ -582,6 +582,10 @@ function stack(;redirect=true,
     (readtimeout > 0      ? TimeoutLayer              : NoLayer){
                             StreamLayer{Union{}}
     }}}}}}}}}}}}
+
+    reduce(Layers.EXTRA_LAYERS; init=stack) do stack, (before, custom)
+        insert(stack, before, custom)
+    end
 end
 
 include("download.jl")

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -1,5 +1,7 @@
 module Layers
-export Layer, next, top_layer, insert
+export Layer, next, top_layer, insert, insert_default!, remove_default!
+
+const EXTRA_LAYERS = Set{Tuple{Union{UnionAll, Type{Union{}}}, UnionAll}}()
 
 include("exceptions.jl")
 
@@ -107,5 +109,11 @@ function insert(stack::Type{<:Layer}, layer_before::Type{<:Layer}, custom_layer:
     end
     throw(LayerNotFoundException("$layer_before not found in $stack"))
 end
+
+insert_default!(before::Type{<:Layer}, custom_layer::Type{<:Layer}) =
+    push!(EXTRA_LAYERS, (before, custom_layer))
+
+remove_default!(before::Type{<:Layer}, custom_layer::Type{<:Layer}) =
+    delete!(EXTRA_LAYERS, (before, custom_layer))
 
 end

--- a/test/insert_layers.jl
+++ b/test/insert_layers.jl
@@ -42,4 +42,14 @@ using ..TestRequest
         request(insert(stack(), Union{}, LastLayer), "GET", "https://httpbin.org/anything")
         @test TestRequest.FLAG[]
     end
+
+    @testset "Insert/remove default layers" begin
+        top = HTTP.top_layer(stack())
+        insert_default!(top, TestLayer)
+        @test HTTP.top_layer(stack()) <: TestLayer
+        remove_default!(top, TestLayer)
+        @test HTTP.top_layer(stack()) <: top
+        insert_default!(Union{}, TestLayer)
+        remove_default!(Union{}, TestLayer)
+    end
 end


### PR DESCRIPTION
Some motivation for this: [BrokenRecord.jl](https://github.com/JuliaTesting/BrokenRecord.jl) wants to add some behaviour to all calls to `HTTP.request`, which sounds like a good case for a custom layer, but since it is not in control of where `HTTP.request` is called, it can't insert a modified stack into all those calls. Instead, it uses Cassette to achieve something similar, and it works, but it can be horribly slow. With the ability to add default layers, BrokenRecord would no longer need Cassette and would be 500000x faster and more reliable.

Naming for these functions is open for discussion, I didn't think too hard about it.
I tried to keep the API similar to the existing `insert` function.
If something like this is actually wanted, I'll write some documentation for it.

- Running a test suite with currently released BrokenRecord: 143s 😴 
- Same test suite with new HTTP + BrokenRecord: 28s 🔥 