### PR TITLE
Allow passing in a custom boundary to HTTP.Form

### DIFF
--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -53,9 +53,8 @@ function Base.read(f::Form, n::Integer)
     return result
 end
 
-function Form(d)
+function Form(d; boundary=string(rand(UInt128), base=16))
     @require eltype(d) <: Pair
-    boundary = string(rand(UInt128), base=16)
     data = IO[]
     io = IOBuffer()
     len = length(d)


### PR DESCRIPTION
This one is also motivated by BrokenRecord. If you want your HTTP request body to be deterministic, you need to be able to set the multipart boundary yourself.