### PR TITLE
Add verification of the boundary

### DIFF
--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -54,6 +54,10 @@ function Base.read(f::Form, n::Integer)
 end
 
 function Form(d; boundary=string(rand(UInt128), base=16))
+    # https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
+    bcharsnospace = raw"\w'\(\)\+,-\./:=\?"
+    boundary_re = Regex("^[$bcharsnospace ]{0,69}[$bcharsnospace]\$")
+    @require match(boundary_re, boundary) !== nothing
     @require eltype(d) <: Pair
     data = IO[]
     io = IOBuffer()

--- a/test/multipart.jl
+++ b/test/multipart.jl
@@ -30,4 +30,14 @@
         @test_nowarn HTTP.Multipart(nothing, IOBuffer("some data"), "plain/text", "", "testname")
         @test_throws MethodError HTTP.Multipart(nothing, "some data", "plain/text", "", "testname")
     end
+
+    @testset "Boundary" begin
+        @test HTTP.Form(Dict()) isa HTTP.Form
+        @test HTTP.Form(Dict(); boundary="a") isa HTTP.Form
+        @test HTTP.Form(Dict(); boundary=" Aa1'()+,-.:=?") isa HTTP.Form
+        @test HTTP.Form(Dict(); boundary='a'^70) isa HTTP.Form
+        @test_throws ArgumentError HTTP.Form(Dict(); boundary="")
+        @test_throws ArgumentError HTTP.Form(Dict(); boundary='a'^71)
+        @test_throws ArgumentError HTTP.Form(Dict(); boundary="a ")
+    end
 end


### PR DESCRIPTION
As specified here: https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html

```
boundary := 0*69<bchars> bcharsnospace 

bchars := bcharsnospace / " " 

bcharsnospace :=    DIGIT / ALPHA / "'" / "(" / ")" / "+"  / 
"_" 
               / "," / "-" / "." / "/" / ":" / "=" / "?" 
```