### PR TITLE
Fix some outdated Sockets methods calls

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -633,7 +633,7 @@ function getconnection(::Type{TCPSocket},
     end
 
     tcp = Sockets.TCPSocket()
-    Sockets.bind(tcp, Sockets.getaddrinfo(host), p)
+    Sockets.connect!(tcp, Sockets.getalladdrinfo(host)[1], p)
 
     timeout = Ref{Bool}(false)
     @async begin
@@ -646,7 +646,7 @@ function getconnection(::Type{TCPSocket},
         end
     end
     try
-        Base.wait_connected(tcp)
+        Sockets.wait_connected(tcp)
     catch e
         if timeout[]
             throw(ConnectTimeout(host, port))


### PR DESCRIPTION
Fixes #617. Looks like we had some pre-1.0 code that expected some
Sockets functions that used to live in Base.