### PR TITLE
Fix tests for HTTP v0.9.0.

### DIFF
--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -163,6 +163,5 @@ end
 content_type(f::Form) = "Content-Type" =>
                         "multipart/form-data; boundary=$(f.boundary)"
 
-# To be deprecated in HTTP@0.9
-# @deprecate post(url, f::Form; kw...) post(url, [], f; kw...)
-post(url, f::Form; kw...) = post(url, Header[], f; kw...)
+# Deprecation can be removed in HTTP 0.10.0 (or 1.0.0).
+@deprecate post(url, f::Form; kw...) post(url, [], f; kw...)


### PR DESCRIPTION
HTTP.post(uri, body) was supposed to be deprecated for 0.9.0,
but now that deprecations are silent by default it can be
deprecated now in 0.9.1. Also rewrites the tests for this
such that they don't start to fail again with HTTP 0.10.0
(or 1.0.0).