### PR TITLE
Improve error logging display

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -293,7 +293,7 @@ function listenloop(f, server, tcpisvalid, connection_count,
                 if e isa Base.IOError && e.code == -54
                     verbose && @warn "connection reset by peer (ECONNRESET)"
                 else
-                    @error exception=(e, stacktrace(catch_backtrace()))
+                    @error "" exception=(e, stacktrace(catch_backtrace()))
                 end
             finally
                 connection_count[] -= 1


### PR DESCRIPTION
The `exception` argument to `@error` is currently treated as the error message, not as a keyword argument, because it is the first argument. Example:

![image](https://user-images.githubusercontent.com/6933510/99802578-39093600-2b38-11eb-8b17-e8576e1d2ea8.png)
