### PR TITLE
Only print -4077 error when verbose

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -290,7 +290,7 @@ function listenloop(f, server, tcpisvalid, connection_count,
                 handle_connection(f, conn, server, reuse_limit, readtimeout)
                 # verbose && @info "Closed ($count):  $conn"
             catch e
-                if e isa Base.IOError && e.code == -54
+                if e isa Base.IOError && (e.code == -54 || e.code == -4077)
                     verbose && @warn "connection reset by peer (ECONNRESET)"
                 else
                     @error exception=(e, stacktrace(catch_backtrace()))


### PR DESCRIPTION
Pluto uses HTTP.jl, and it prints the following error message very often:

![image](https://user-images.githubusercontent.com/6933510/99802840-af0d9d00-2b38-11eb-8622-3fceaec617fd.png)

I have not investigated this error thoroughly (little HTTP knowledge), but my observations are:
- It happens when firefox navigates away from a HTTP.jl-served page that has an open WS connection. It does not happen on Chrome, it does not happen on pages with no WS connection.
- **The error can safely be ignored**.
- The error always has the `-4077` code.

I am submitting this PR because:
- Many Pluto users are confused by this error. It makes Pluto look unstable, and users often post this error in unrelated bug reports.
- There is no way for a package using HTTP.jl to prevent this error from printing.
- The existing code suggests that a similar situation occurs with the `-54` error. I am assuming that this `-4077` error is similar, but might not have been found before because the WS part of HTTP.jl is less commonly used.

What do you think?