### PR TITLE
Allow other string types in the cookie dictionary

### DIFF
--- a/src/CookieRequest.jl
+++ b/src/CookieRequest.jl
@@ -25,9 +25,9 @@ export CookieLayer
 
 function request(::Type{CookieLayer{Next}},
                  method::String, url::URI, headers, body;
-                 cookies::Union{Bool, Dict{String, String}}=Dict{String, String}(),
+                 cookies::Union{Bool, Dict{S1, S2}}=Dict{String, String}(),
                  cookiejar::Dict{String, Set{Cookie}}=default_cookiejar[Threads.threadid()],
-                 kw...) where Next
+                 kw...) where {Next, S1 <: AbstractString, S2 <: AbstractString}
 
     hostcookies = get!(cookiejar, url.host, Set{Cookie}())
 

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -157,8 +157,8 @@ AWS Authentication options
 
 Cookie options
 
- - `cookies::Union{Bool, Dict{String, String}} = false`, enable cookies, or alternatively,
-        pass a `Dict{String, String}` of name-value pairs to manually pass cookies
+ - `cookies::Union{Bool, Dict{AbstractString, AbstractString}} = false`, enable cookies, or alternatively,
+        pass a `Dict{AbstractString, AbstractString}` of name-value pairs to manually pass cookies
  - `cookiejar::Dict{String, Set{Cookie}}=default_cookiejar`,
 
 


### PR DESCRIPTION
Otherwise users have to convert their SubStrings to String, for example.