### PR TITLE
Flush TCP connections during `closewrite()`

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -186,6 +186,23 @@ writebusy(t::Transaction) = @v1_3 lock(() -> t.writebusy, t.c.writelock) t.write
 readbusy(t::Transaction) = @v1_3 lock(() -> t.readbusy, t.c.readlock) t.readbusy
 
 """
+    flush(c::Connection)
+
+Flush a TCP buffer by toggling the Nagle algorithm off and on again for a socket.
+This forces the socket to send whatever data is within its buffer immediately,
+rather than waiting 10's of milliseconds for the buffer to fill more.
+"""
+function Base.flush(c::Connection)
+    sock = tcpsocket(c.io)
+
+    # I don't understand why uninitializd sockets can get here, but they can, so filter 'em out.
+    if sock.status ∉ (Base.StatusInit, Base.StatusUninit) && isopen(sock)
+        Sockets.nagle(sock, false)
+        Sockets.nagle(sock, true)
+    end
+end
+
+"""
 Is `c` currently in use or expecting a response to request already sent?
 """
 isbusy(c::Connection) = isopen(c) && (writebusy(c) || readbusy(c) ||
@@ -319,6 +336,7 @@ function IOExtras.closewrite(t::Transaction)
     finally
         @v1_3 unlock(t.c.writelock)
     end
+    flush(t.c)
     release(t.c)
 
     return

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -193,12 +193,15 @@ This forces the socket to send whatever data is within its buffer immediately,
 rather than waiting 10's of milliseconds for the buffer to fill more.
 """
 function Base.flush(c::Connection)
-    sock = tcpsocket(c.io)
-
-    # I don't understand why uninitializd sockets can get here, but they can, so filter 'em out.
-    if sock.status ∉ (Base.StatusInit, Base.StatusUninit) && isopen(sock)
-        Sockets.nagle(sock, false)
-        Sockets.nagle(sock, true)
+    # Flushing the TCP buffer requires support for `Sockets.nagle()`
+    # which was only added in Julia v1.3
+    @static if VERSION >= v"1.3"
+        sock = tcpsocket(c.io)
+        # I don't understand why uninitializd sockets can get here, but they can
+        if sock.status ∉ (Base.StatusInit, Base.StatusUninit) && isopen(sock)
+            Sockets.nagle(sock, false)
+            Sockets.nagle(sock, true)
+        end
     end
 end
 


### PR DESCRIPTION
TCP connections are generally (depending on kernel whimsy) governed by
the Nagle algorithm, which may not immediately transmit data but instead
wait for the TCP buffer to fill before spitting a packet out onto the
network.  This is due to the fact that the kernel does not necessarily
know when a "message" is complete and simply does its best to maximize
throughput (by decrease packet counts) while minimizing latency (by
transmitting quickly).  We can help the OS out a bit here by flushing
the TCP buffer when we're done with a message (e.g. in `closewrite()`)
which (on some kernels) reduces the minimum latency of a message from
~40ms to < 1ms.  We flush by toggling the Nagle algorithm off and then
on again on that particular socket, forcing the OS to transmit any
pieces of data that were queued to be sent out of that socket
immediately.