### PR TITLE
Handle poorly-behaved callbacks more reliably

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -120,7 +120,10 @@ end
 
 Listen for HTTP connections and execute the `do` function for each request.
 
-The `do` function should be of the form `f(::HTTP.Stream)::Nothing`.
+The `do` function should be of the form `f(::HTTP.Stream)::Nothing`, and should
+at the minimum set a status via `setstatus()` and call `startwrite()` either
+explicitly or implicitly by writing out a response via `write()`.  Failure to
+do this will result in an HTTP 500 error being transmitted to the client.
 
 Optional keyword arguments:
  - `sslconfig=nothing`, Provide an `MbedTLS.SSLConfig` object to handle ssl


### PR DESCRIPTION
If `startwrite()` is never called during a server callback, the client
may be left waiting for a response and never get one.  This can cause
lockups and general misery, especially when connections are proxied
through an intermediary (such as `nginx`) with a finite connection
limit.

This PR detects a server callback that never calls `startwrite(http)`
and throws an error, triggering the HTTP 500 mechanism.  It also adds a
`closewrite(http)` onto that branch as without it, it appears that the
final chunk in the `Transfer-Encoding: Chunked` response may not appear.