### PR TITLE
Document connect_timeout and set it to the nonzero minimum of itself and readtimeout

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -640,7 +640,7 @@ function getconnection(::Type{TCPSocket},
                        host::AbstractString,
                        port::AbstractString;
                        keepalive::Bool=false,
-                       connecttimeout::Int=0,
+                       connect_timeout::Int=0,
                        readtimeout::Int=0,
                        kw...)::TCPSocket
 
@@ -648,9 +648,9 @@ function getconnection(::Type{TCPSocket},
 
     @debug 2 "TCP connect: $host:$p..."
 
-    timeouts = filter(!iszero, [connecttimeout, readtimeout])
-    connecttimeout = isempty(timeouts) ? 0 : minimum(timeouts)
-    if connecttimeout == 0
+    timeouts = filter(!iszero, [connect_timeout, readtimeout])
+    connect_timeout = isempty(timeouts) ? 0 : minimum(timeouts)
+    if connect_timeout == 0
         tcp = Sockets.connect(host == "localhost" ? ip"127.0.0.1" : Sockets.getalladdrinfo(host)[1], p)
         keepalive && keepalive!(tcp)
         return tcp
@@ -661,7 +661,7 @@ function getconnection(::Type{TCPSocket},
 
     timeout = Ref{Bool}(false)
     @async begin
-        sleep(connecttimeout)
+        sleep(connect_timeout)
         if tcp.status == Base.StatusConnecting
             timeout[] = true
             tcp.status = Base.StatusClosing

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -648,8 +648,7 @@ function getconnection(::Type{TCPSocket},
 
     @debug 2 "TCP connect: $host:$p..."
 
-    timeouts = filter(!iszero, [connect_timeout, readtimeout])
-    connect_timeout = isempty(timeouts) ? 0 : minimum(timeouts)
+    connect_timeout = connect_timeout == 0 && readtimeout > 0 ? readtimeout : connect_timeout
     if connect_timeout == 0
         tcp = Sockets.connect(host == "localhost" ? ip"127.0.0.1" : Sockets.getalladdrinfo(host)[1], p)
         keepalive && keepalive!(tcp)

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -97,7 +97,7 @@ Streaming options
 Connection Pool options
 
  - `connect_timeout = 0`, close the connection after this many seconds if it
-   is still attempting to connect. Use `connectiontimeout = 0` to disable.
+   is still attempting to connect. Use `connect_timeout = 0` to disable.
  - `connection_limit = 8`, number of concurrent connections to each host:port.
  - `pipeline_limit = 16`, number of concurrent requests per connection.
  - `reuse_limit = nolimit`, number of times a connection is reused after the
@@ -561,7 +561,6 @@ function stack(;redirect=true,
                 retry=true,
                 status_exception=true,
                 readtimeout=0,
-                connect_timeout=0,
                 detect_content_type=false,
                 verbose=0,
                 kw...)

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -561,7 +561,7 @@ function stack(;redirect=true,
                 retry=true,
                 status_exception=true,
                 readtimeout=0,
-                connecttimeout=0,
+                connect_timeout=0,
                 detect_content_type=false,
                 verbose=0,
                 kw...)

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -96,7 +96,7 @@ Streaming options
 
 Connection Pool options
 
- - `connectiontimeout = 0`, close the connection after this many seconds if it
+ - `connect_timeout = 0`, close the connection after this many seconds if it
    is still attempting to connect. Use `connectiontimeout = 0` to disable.
  - `connection_limit = 8`, number of concurrent connections to each host:port.
  - `pipeline_limit = 16`, number of concurrent requests per connection.

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -96,6 +96,8 @@ Streaming options
 
 Connection Pool options
 
+ - `connectiontimeout = 0`, close the connection after this many seconds if it
+   is still attempting to connect. Use `connectiontimeout = 0` to disable.
  - `connection_limit = 8`, number of concurrent connections to each host:port.
  - `pipeline_limit = 16`, number of concurrent requests per connection.
  - `reuse_limit = nolimit`, number of times a connection is reused after the
@@ -559,6 +561,7 @@ function stack(;redirect=true,
                 retry=true,
                 status_exception=true,
                 readtimeout=0,
+                connecttimeout=0,
                 detect_content_type=false,
                 verbose=0,
                 kw...)


### PR DESCRIPTION
This is to make it the same format as `readtimeout`.

Also changes `connecttimeout` to be the nonzero minimum of `connecttimeout` and `readtimeout` if either is set.

This is to get around connections hanging even if `readtimeout` is set. For example, this occurs if you try to connect to the EC2 metadata IP from outside AWS.

I'm not sure of a great way to add a test for this. This works, for example:

```julia
@test_throws Exception HTTP.get("http://169.254.169.254/latest/meta-data/iam/info"; connectiontimeout=1, retry=false)
```

But I'd obviously prefer to avoid trying to hit the EC2 metadata service.