### PR TITLE
Fix invalid Access-Control-Allow-Methods

### DIFF
--- a/docs/examples/cors_server.jl
+++ b/docs/examples/cors_server.jl
@@ -22,11 +22,11 @@ function getNextId()
     return id
 end
 
-#CORS headers that show what kinds of complex requests are allowed to API
+# CORS headers that show what kinds of complex requests are allowed to API
 headers = [
     "Access-Control-Allow-Origin" => "*",
     "Access-Control-Allow-Headers" => "*",
-    "Access-Control-Allow-Methods" => "POST;GET;OPTIONS"
+    "Access-Control-Allow-Methods" => "POST, GET, OPTIONS"
 ]
 
 #= 


### PR DESCRIPTION
I copied the code from the example and got 
```
Cannot parse Access-Control-Allow-Methods response header field in preflight response.
```
in Chrome. According to the [Mozilla Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods), the methods should be separated by comma's instead of semicolons. Also, I've added spaces for readability, which is also allowed according to aforementioned documentation.

The newline at the end of the file was, interestingly enough, added by the GitHub web interface.