### PR TITLE
Document Response and Request constructors

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -107,6 +107,9 @@ mutable struct Response <: Message
     body::Vector{UInt8}
     request::Message
 
+    @doc """
+        Response(status::Int, headers=[]; body=UInt8[], request=nothing) -> HTTP.Response
+    """
     function Response(status::Int, headers=[]; body=UInt8[], request=nothing)
         r = new()
         r.version = v"1.1"
@@ -120,6 +123,17 @@ mutable struct Response <: Message
     end
 end
 
+"""
+    HTTP.Response(status::Int, body) -> HTTP.Response
+
+## Examples
+```julia
+HTTP.Response(200, "Hello")
+
+headers = ["Server" => "Apache"]
+HTTP.Response(200, headers; body = "Hello")
+```
+"""
 Response() = Request().response
 
 Response(s::Int, body::AbstractVector{UInt8}) = Response(s; body=body)
@@ -187,6 +201,12 @@ end
 
 Request() = Request("", "")
 
+"""
+    HTTP.Request(method, target, headers, body; version, parent) -> HTTP.Request
+
+Constructor for `HTTP.Request`.
+For daily use, see [`HTTP.request`](@ref).
+"""
 function Request(method::String, target, headers=[], body=UInt8[];
                  version=v"1.1", parent=nothing)
     r = Request(method,


### PR DESCRIPTION
The documentation for using `HTTP.Response` and `HTTP.Request` wasn't very clear in the REPL. This PR changes the documentation for `HTTP.Response` from
```
help?> HTTP.Response
  Response <: Message

  Represents a HTTP Response Message.

    •    version::VersionNumber RFC7230 2.6 (https://tools.ietf.org/html/rfc7230#section-2.6)

    •    status::Int16 RFC7230 3.1.2 (https://tools.ietf.org/html/rfc7230#section-3.1.2) RFC7231 6
        (https://tools.ietf.org/html/rfc7231#section-6)

    •    headers::Vector{Pair{String,String}} RFC7230 3.2
        (https://tools.ietf.org/html/rfc7230#section-3.2)

    •    body::Vector{UInt8} RFC7230 3.3 (https://tools.ietf.org/html/rfc7230#section-3.3)

    •    request, the Request that yielded this Response.
```
to
```
help?> HTTP.Response
  Response <: Message

  Represents a HTTP Response Message.

    •    version::VersionNumber RFC7230 2.6 (https://tools.ietf.org/html/rfc7230#section-2.6)

    •    status::Int16 RFC7230 3.1.2 (https://tools.ietf.org/html/rfc7230#section-3.1.2) RFC7231 6
        (https://tools.ietf.org/html/rfc7231#section-6)

    •    headers::Vector{Pair{String,String}} RFC7230 3.2
        (https://tools.ietf.org/html/rfc7230#section-3.2)

    •    body::Vector{UInt8} RFC7230 3.3 (https://tools.ietf.org/html/rfc7230#section-3.3)

    •    request, the Request that yielded this Response.

  ─────────────────────────────────────────────────────────────────────────────────────────────────────

  Response(status::Int, headers=[]; body=UInt8[], request=nothing) -> HTTP.Response

  ─────────────────────────────────────────────────────────────────────────────────────────────────────

  HTTP.Response(status::Int, body) -> HTTP.Response

  Examples
  ==========

  HTTP.Response(200, "Hello")

  headers = ["Server" => "Apache"]
  HTTP.Response(200, headers; body = "Hello")
```
and changes the documentation from `HTTP.Request` from
```
help?> HTTP.Request
  Request <: Message

  Represents a HTTP Request Message.

    •    method::String RFC7230 3.1.1 (https://tools.ietf.org/html/rfc7230#section-3.1.1)

    •    target::String RFC7230 5.3 (https://tools.ietf.org/html/rfc7230#section-5.3)

    •    version::VersionNumber RFC7230 2.6 (https://tools.ietf.org/html/rfc7230#section-2.6)

    •    headers::Vector{Pair{String,String}} RFC7230 3.2
        (https://tools.ietf.org/html/rfc7230#section-3.2)

    •    body::Vector{UInt8} RFC7230 3.3 (https://tools.ietf.org/html/rfc7230#section-3.3)

    •    response, the Response to this Request

    •    txcount, number of times this Request has been sent (see RetryRequest.jl).

    •    parent, the Response (if any) that led to this request (e.g. in the case of a redirect).
        RFC7230 6.4 (https://tools.ietf.org/html/rfc7231#section-6.4)
```
to 
```
help?> HTTP.Request
  Request <: Message

  Represents a HTTP Request Message.

    •    method::String RFC7230 3.1.1 (https://tools.ietf.org/html/rfc7230#section-3.1.1)

    •    target::String RFC7230 5.3 (https://tools.ietf.org/html/rfc7230#section-5.3)

    •    version::VersionNumber RFC7230 2.6 (https://tools.ietf.org/html/rfc7230#section-2.6)

    •    headers::Vector{Pair{String,String}} RFC7230 3.2
        (https://tools.ietf.org/html/rfc7230#section-3.2)

    •    body::Vector{UInt8} RFC7230 3.3 (https://tools.ietf.org/html/rfc7230#section-3.3)

    •    response, the Response to this Request

    •    txcount, number of times this Request has been sent (see RetryRequest.jl).

    •    parent, the Response (if any) that led to this request (e.g. in the case of a redirect).
        RFC7230 6.4 (https://tools.ietf.org/html/rfc7231#section-6.4)

  ─────────────────────────────────────────────────────────────────────────────────────────────────────

  HTTP.Request(method, target, headers, body; version, parent) -> HTTP.Request

  Constructor for HTTP.Request. For daily use, see HTTP.request.
```