### PR TITLE
Proxy environment variables are only used when they are non-empty

### DIFF
--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -34,13 +34,13 @@ end
 
 function getproxy(scheme, host)
     isnoproxy(host) && return nothing
-    if scheme == "http" && haskey(ENV, "http_proxy")
+    if scheme == "http" && haskey(ENV, "http_proxy") && !isempty(ENV["http_proxy"])
         return ENV["http_proxy"]
-    elseif scheme == "http" && haskey(ENV, "HTTP_PROXY")
+    elseif scheme == "http" && haskey(ENV, "HTTP_PROXY") && !isempty(ENV["HTTP_PROXY"])
         return ENV["HTTP_PROXY"]
-    elseif scheme == "https" && haskey(ENV, "https_proxy")
+    elseif scheme == "https" && haskey(ENV, "https_proxy") && !isempty(ENV["https_proxy"])
         return ENV["https_proxy"]
-    elseif scheme == "https" && haskey(ENV, "HTTPS_PROXY")
+    elseif scheme == "https" && haskey(ENV, "HTTPS_PROXY") && !isempty(ENV["HTTPS_PROXY"])
         return ENV["HTTPS_PROXY"]
     end
     return nothing

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -36,12 +36,12 @@ function getproxy(scheme, host)
     isnoproxy(host) && return nothing
     if scheme == "http" && (p = get(ENV, "http_proxy", ""); !isempty(p))
         return p
-    elseif scheme == "http" && !isempty(get(ENV, "HTTP_PROXY", ""))
-        return ENV["HTTP_PROXY"]
-    elseif scheme == "https" && !isempty(get(ENV, "https_proxy", ""))
-        return ENV["https_proxy"]
-    elseif scheme == "https" && !isempty(get(ENV, "HTTPS_PROXY", ""))
-        return ENV["HTTPS_PROXY"]
+    elseif scheme == "http" && (p = get(ENV, "HTTP_PROXY", ""); !isempty(p))
+        return p
+    elseif scheme == "https" && (p = get(ENV, "https_proxy", ""); !isempty(p))
+        return p
+    elseif scheme == "https" && (p = get(ENV, "HTTPS_PROXY", ""); !isempty(p))
+        return p
     end
     return nothing
 end

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -36,11 +36,11 @@ function getproxy(scheme, host)
     isnoproxy(host) && return nothing
     if scheme == "http" && !isempty(get(ENV, "http_proxy", ""))
         return ENV["http_proxy"]
-    elseif scheme == "http" && haskey(ENV, "HTTP_PROXY") && !isempty(ENV["HTTP_PROXY"])
+    elseif scheme == "http" && !isempty(get(ENV, "HTTP_PROXY", ""))
         return ENV["HTTP_PROXY"]
-    elseif scheme == "https" && haskey(ENV, "https_proxy") && !isempty(ENV["https_proxy"])
+    elseif scheme == "https" && !isempty(get(ENV, "https_proxy", ""))
         return ENV["https_proxy"]
-    elseif scheme == "https" && haskey(ENV, "HTTPS_PROXY") && !isempty(ENV["HTTPS_PROXY"])
+    elseif scheme == "https" && !isempty(get(ENV, "HTTPS_PROXY", ""))
         return ENV["HTTPS_PROXY"]
     end
     return nothing

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -34,8 +34,8 @@ end
 
 function getproxy(scheme, host)
     isnoproxy(host) && return nothing
-    if scheme == "http" && !isempty(get(ENV, "http_proxy", ""))
-        return ENV["http_proxy"]
+    if scheme == "http" && (p = get(ENV, "http_proxy", ""); !isempty(p))
+        return p
     elseif scheme == "http" && !isempty(get(ENV, "HTTP_PROXY", ""))
         return ENV["HTTP_PROXY"]
     elseif scheme == "https" && !isempty(get(ENV, "https_proxy", ""))

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -34,7 +34,7 @@ end
 
 function getproxy(scheme, host)
     isnoproxy(host) && return nothing
-    if scheme == "http" && haskey(ENV, "http_proxy") && !isempty(ENV["http_proxy"])
+    if scheme == "http" && !isempty(get(ENV, "http_proxy", ""))
         return ENV["http_proxy"]
     elseif scheme == "http" && haskey(ENV, "HTTP_PROXY") && !isempty(ENV["HTTP_PROXY"])
         return ENV["HTTP_PROXY"]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -35,4 +35,32 @@ import HTTP.URIs
         )
         @test HTTP.Strings.iso8859_1_to_utf8(bytes) == utf8
     end
+
+    @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
+    withenv("HTTPS_PROXY"=>"") do
+        @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
+    end
+    withenv("https_proxy"=>"") do
+        @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
+    end
+    withenv("HTTPS_PROXY"=>"https://user:pass@server:80") do
+        @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == "https://user:pass@server:80"
+    end
+    withenv("https_proxy"=>"https://user:pass@server:80") do
+        @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == "https://user:pass@server:80"
+    end
+
+    @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
+    withenv("HTTP_PROXY"=>"") do
+        @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
+    end
+    withenv("http_proxy"=>"") do
+        @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
+    end
+    withenv("HTTP_PROXY"=>"http://user:pass@server:80") do
+        @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == "http://user:pass@server:80"
+    end
+    withenv("http_proxy"=>"http://user:pass@server:80") do
+        @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == "http://user:pass@server:80"
+    end
 end # testset

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -53,7 +53,9 @@ import HTTP.URIs
         @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == "https://user:pass@server:80"
     end
 
-    @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
+    withenv("HTTP_PROXY"=>nothing, "http_proxy"=>nothing) do
+        @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
+    end
     withenv("HTTP_PROXY"=>"") do
         @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -36,7 +36,7 @@ import HTTP.URIs
         @test HTTP.Strings.iso8859_1_to_utf8(bytes) == utf8
     end
 
-    @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
+    @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing
     withenv("HTTPS_PROXY"=>"") do
         # to be compatible with Julia 1.0
         @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing
@@ -51,7 +51,7 @@ import HTTP.URIs
         @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == "https://user:pass@server:80"
     end
 
-    @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
+    @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
     withenv("HTTP_PROXY"=>"") do
         @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -36,7 +36,9 @@ import HTTP.URIs
         @test HTTP.Strings.iso8859_1_to_utf8(bytes) == utf8
     end
 
-    @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing
+    withenv("HTTPS_PROXY"=>nothing, "https_proxy"=>nothing) do
+        @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing
+    end
     withenv("HTTPS_PROXY"=>"") do
         # to be compatible with Julia 1.0
         @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -38,10 +38,11 @@ import HTTP.URIs
 
     @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
     withenv("HTTPS_PROXY"=>"") do
-        @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
+        # to be compatible with Julia 1.0
+        @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing
     end
     withenv("https_proxy"=>"") do
-        @test isnothing(HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/"))
+        @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == nothing
     end
     withenv("HTTPS_PROXY"=>"https://user:pass@server:80") do
         @test HTTP.ConnectionRequest.getproxy("https", "https://julialang.org/") == "https://user:pass@server:80"
@@ -52,10 +53,10 @@ import HTTP.URIs
 
     @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
     withenv("HTTP_PROXY"=>"") do
-        @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
+        @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
     end
     withenv("http_proxy"=>"") do
-        @test isnothing(HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/"))
+        @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == nothing
     end
     withenv("HTTP_PROXY"=>"http://user:pass@server:80") do
         @test HTTP.ConnectionRequest.getproxy("http", "http://julialang.org/") == "http://user:pass@server:80"


### PR DESCRIPTION
Motivation: 
Once environment variable is set, it's quite hard to unset it, e.g. in docker it's impossible to unset environment variable once it's set, see: https://stackoverflow.com/questions/55789409/how-to-unset-env-in-dockerfile

Lots of other software treat empty environment variable in same way as unset environment variable. 
For example here https://docs.pivotal.io/application-service/2-8/operating/config-proxy.html in troubleshooting section.
Also curl states in https://curl.se/libcurl/c/CURLOPT_PROXY.html
"Setting the proxy string to "" (an empty string) will explicitly disable the use of a proxy, even if there is an environment variable set for it."

Git mentions them too in https://git-scm.com/docs/git-config/2.9.5#Documentation/git-config.txt-httpproxy , linking curl documentation, so I assume the behavior is same as in curl.

I'm not sure how exactly it's in Pkg, but for correct functionality of Pkg.jl behind proxy setting them is advised too, e.g. here: https://discourse.julialang.org/t/install-packages-behind-the-proxy/23298/18 but I'm not sure if Pkg.jl handles them on its own or delegates it to git, which delegates it to curl.

Fixes #671 . 

I'm not sure if this is desired behavior or not, so let's discuss this if we want to have such behavior or if it's better to keep the old one.

I wanted to also add tests for this, but I couldn't find a way to call some method with environment variable set without affecting it globally. 

Or should I simply add tests with
```julia
ENV["HTTP_PROXY"] = ""
@test getproxy.....
delete!(ENV, "HTTP_PROXY")
```
?
