### PR TITLE
Improved documentation for HTTP.Form and HTTP.Multipart.

### DIFF
--- a/docs/src/public_interface.md
+++ b/docs/src/public_interface.md
@@ -11,6 +11,12 @@ HTTP.post
 HTTP.head
 ```
 
+Request body types
+```@docs
+HTTP.Form
+HTTP.Multipart
+```
+
 Request functions may throw the following exceptions:
 
 ```@docs


### PR DESCRIPTION
xref e.g. https://stackoverflow.com/questions/66268254/julia-http-post-request-with-image-attachment