### PR TITLE
Fix missing docstrings in docs.

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
-Documenter = "0.25"
+Documenter = "0.26"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, HTTP
+using Documenter, HTTP, Sockets, URIs
 
 """
 Loops through the files in the examples folder and adds them (with any header comments) to the examples.md
@@ -72,7 +72,7 @@ end
 generateExamples()
 
 makedocs(
-    modules = [HTTP],
+    # modules = [HTTP],
     sitename = "HTTP.jl",
     pages = [
         "Home" => "index.md",

--- a/docs/src/internal_interface.md
+++ b/docs/src/internal_interface.md
@@ -58,8 +58,8 @@ HTTP.Streams.isaborted
 ```@docs
 HTTP.ConnectionPool.Connection
 HTTP.ConnectionPool.Transaction
-HTTP.ConnectionPool.pool
 HTTP.ConnectionPool.getconnection
+HTTP.ConnectionPool.POOL
 HTTP.IOExtras.startwrite(::HTTP.ConnectionPool.Transaction)
 HTTP.IOExtras.closewrite(::HTTP.ConnectionPool.Transaction)
 HTTP.IOExtras.startread(::HTTP.ConnectionPool.Transaction)

--- a/docs/src/public_interface.md
+++ b/docs/src/public_interface.md
@@ -11,11 +11,14 @@ HTTP.post
 HTTP.head
 ```
 
-Request body types
+### Request body types
+
 ```@docs
 HTTP.Form
 HTTP.Multipart
 ```
+
+### Request exceptions
 
 Request functions may throw the following exceptions:
 
@@ -24,18 +27,21 @@ HTTP.StatusError
 HTTP.ParseError
 HTTP.IOError
 ```
-```
+```@docs
 Sockets.DNSError
 ```
 
 ## URIs
 
+HTTP.jl uses the [URIs.jl](https://github.com/JuliaWeb/URIs.jl) package for handling
+URIs. Some functionality from URIs.jl, relevant to HTTP.jl, are listed below:
+
 ```@docs
-HTTP.URI
-HTTP.URIs.escapeuri
-HTTP.URIs.unescapeuri
-HTTP.URIs.splitpath
-Base.isvalid(::HTTP.URIs.URI)
+URI
+URIs.escapeuri
+URIs.unescapeuri
+URIs.splitpath
+Base.isvalid(::URIs.URI)
 ```
 
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -522,6 +522,11 @@ struct Pool
     conns::Dict{UInt, Pod}
 end
 
+"""
+    POOL
+
+Global connection pool keeping track of active connections.
+"""
 const POOL = Pool(ReentrantLock(), Dict{UInt, Pod}())
 
 function getpod(pool::Pool, x)


### PR DESCRIPTION
Fix a bunch of missing docstring warnings in docs.