### PR TITLE
Use NetworkOptions stdlib for default value of host verification.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 IniFile = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
+NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -32,6 +32,7 @@ using ..IOExtras, ..Sockets
 import ..@debug, ..@debugshow, ..DEBUG_LEVEL, ..taskid
 import ..@require, ..precondition_error, ..@ensure, ..postcondition_error
 using MbedTLS: SSLConfig, SSLContext, setup!, associate!, hostname!, handshake!
+import NetworkOptions
 
 const default_connection_limit = 8
 const default_pipeline_limit = 16
@@ -543,7 +544,7 @@ function getconnection(::Type{Transaction{T}},
                        pipeline_limit::Int=default_pipeline_limit,
                        idle_timeout::Int=0,
                        reuse_limit::Int=nolimit,
-                       require_ssl_verification::Bool=true,
+                       require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
                        kw...)::Transaction{T} where T <: IO
     pod = getpod(POOL, hashconn(T, host, port, pipeline_limit, require_ssl_verification, true))
     @v1_3 lock(pod.conns)
@@ -722,7 +723,7 @@ function getconnection(::Type{SSLContext},
 end
 
 function sslconnection(tcp::TCPSocket, host::AbstractString;
-                       require_ssl_verification::Bool=true,
+                       require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
                        sslconfig::SSLConfig=nosslconfig,
                        kw...)::SSLContext
 
@@ -740,7 +741,7 @@ end
 
 function sslupgrade(t::Transaction{TCPSocket},
                     host::AbstractString;
-                    require_ssl_verification::Bool=true,
+                    require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
                     kw...)::Transaction{SSLContext}
     tls = sslconnection(t.c.io, host;
                         require_ssl_verification=require_ssl_verification,

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -132,7 +132,7 @@ Status Exception options
 
 SSLContext options
 
- - `require_ssl_verification = false`, pass `MBEDTLS_SSL_VERIFY_REQUIRED` to
+ - `require_ssl_verification = NetworkOptions.verify_host(host)`, pass `MBEDTLS_SSL_VERIFY_REQUIRED` to
    the mbed TLS library.
    ["... peer must present a valid certificate, handshake is aborted if
      verification failed."](https://tls.mbed.org/api/ssl_8h.html#a5695285c9dbfefec295012b566290f37)


### PR DESCRIPTION
This is used by `LibGit2.jl` and `Downloads.jl` so it makes sense to use it here too. `NetworkOptions.jl` is available as a regular Julia package in the registry for Julia versions < 1.6, and as a stdlib for Julia versions >= 1.6.

cc: @staticfloat, @StefanKarpinski, @quinnj 