### PR TITLE
Removed unnecessary export for HeaderSizeError

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -54,7 +54,7 @@ Streaming of request and response bodies is handled by the
 """
 module Messages
 
-export Message, Request, Response, HeaderSizeError,
+export Message, Request, Response,
        reset!, status, method, headers, uri, body,
        iserror, isredirect, ischunked, issafe, isidempotent,
        header, hasheader, headercontains, setheader, defaultheader!, appendheader,


### PR DESCRIPTION
This is a very small PR to remove unnecessary export for HeaderSizeError.
I think `HeaderSizeError` function is not defined in the file, so it is not needed.