### PR TITLE
add example for a persistent session and logging into a webform

### DIFF
--- a/docs/examples/session.jl
+++ b/docs/examples/session.jl
@@ -1,0 +1,14 @@
+"""
+A simple example of creating a persistent session and logging into a web form. HTTP.jl does not have a distinct session object like requests.session() or rvest::html_session() but rather uses the `cookies` flag along with standard functions
+"""
+using HTTP
+
+#dummy site, any credentials work
+url = "http://quotes.toscrape.com/login"
+session = HTTP.get(url; cookies = true)
+
+credentials = Dict(
+    "Username" => "username",
+    "Password" => "password")
+
+response = HTTP.post(url, credentials)


### PR DESCRIPTION
I've been working on porting some code over from a co-worker and found myself searching for the equivalent of the various "session"  functions (pythons `requests.Session()` or `rvest::html_session()` in R). I asked about this on slack and it sounds like `HTTP.get(...; cookies = true)` is functionally equivalent.

This PR adds a new example file starting a session and logging into a webform along with a little blurb explaining. Any additions/modifications welcome as I am not a webdev person.

