### PR TITLE
fix minor typos in request docstring

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -78,8 +78,8 @@ conf = (readtimeout = 10,
         retry = false,
         redirect = false)
 
-HTTP.get("http://httpbin.org/ip"; conf..)
-HTTP.put("http://httpbin.org/put", [], "Hello"; conf..)
+HTTP.get("http://httpbin.org/ip"; conf...)
+HTTP.put("http://httpbin.org/put", [], "Hello"; conf...)
 ```
 
 


### PR DESCRIPTION
I saw these typos during browsing the documentation.

Not sure if this is the right way to address it though.