### PR TITLE
Bugfixes and improvements to rate limit check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Bugfixes and improvements to rate limit check

 - use the correct IP adress of the client
 - use `DateTime(0)` for first time connections
 - don't warn when capping the rate limit allowance
 - fix rate_limit specification with non-1 denominator