### PR TITLE
lazily allocate the threaded buffers and allocate them on the thread that will access it

### DIFF
--- a/src/CookieRequest.jl
+++ b/src/CookieRequest.jl
@@ -5,12 +5,12 @@ import ..Layer, ..request
 using URIs
 using ..Cookies
 using ..Pairs: getkv, setkv
-import ..@debug, ..DEBUG_LEVEL
+import ..@debug, ..DEBUG_LEVEL, ..access_threaded
 
-const default_cookiejar = [Dict{String, Set{Cookie}}()]
+const default_cookiejar = Dict{String, Set{Cookie}}[]
 
 function __init__()
-    Threads.resize_nthreads!(default_cookiejar)
+    resize!(empty!(default_cookiejar), Threads.nthreads())
     return
 end
 
@@ -26,7 +26,7 @@ export CookieLayer
 function request(::Type{CookieLayer{Next}},
                  method::String, url::URI, headers, body;
                  cookies::Union{Bool, Dict{<:AbstractString, <:AbstractString}}=Dict{String, String}(),
-                 cookiejar::Dict{String, Set{Cookie}}=default_cookiejar[Threads.threadid()],
+                 cookiejar::Dict{String, Set{Cookie}}=access_threaded(Dict{String, Set{Cookie}}, default_cookiejar),
                  kw...) where {Next}
 
     hostcookies = get!(cookiejar, url.host, Set{Cookie}())

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -12,6 +12,19 @@ Base.@deprecate escape escapeuri
 using Base64, Sockets, Dates
 using URIs
 
+function access_threaded(f, v::Vector)
+    tid = Threads.threadid()
+    0 < tid <= length(v) || _length_assert()
+    if @inbounds isassigned(v, tid)
+        @inbounds x = v[tid]
+    else
+        x = f()
+        @inbounds v[tid] = x
+    end
+    return x
+end
+@noinline _length_assert() =  @assert false "0 < tid <= v"
+
 include("debug.jl")
 
 include("Pairs.jl")                    ;using .Pairs

--- a/test/client.jl
+++ b/test/client.jl
@@ -37,7 +37,7 @@ end
     end
 
     @testset "Cookie Requests" begin
-        empty!(HTTP.CookieRequest.default_cookiejar[1])
+        empty!(HTTP.access_threaded(Dict{String, Set{HTTP.Cookie}}, HTTP.CookieRequest.default_cookiejar))
         r = HTTP.get("$sch://httpbin.org/cookies", cookies=true)
 
         body = String(r.body)


### PR DESCRIPTION
This package does quite a bit of work on load time since it allocates and compiles some regular expressions. That code needs to be inferred and run which causes some penalty to the load time of the package. In particular, the function `Threads.resize_nthreads!` seems to be slow to infer (https://github.com/JuliaLang/julia/issues/40630). In addition, it is generally better to allocate objects on the actual thread that they will be used. The pattern used in this PR is the same as the Random stdlib uses to allocate thread local RNGs: https://github.com/JuliaLang/julia/blob/e4fcdf5b04fd9751ce48b0afc700330475b42443/stdlib/Random/src/RNGs.jl#L369-L385.

Together with https://github.com/JuliaWeb/URIs.jl/pull/27 the timings for loading the package are:

Before:

```
julia> @time using HTTP
  0.428206 seconds (1.05 M allocations: 63.117 MiB, 2.00% gc time, 0.89% compilation time)
```

After:

```
julia> @time using HTTP
  0.113877 seconds (64.19 k allocations: 5.825 MiB, 7.65% compilation time)
```