### PR TITLE
fix bug in websocket with proxy

### DIFF
--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -97,7 +97,7 @@ function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
             if target_url.scheme in ("https", "wss")
                 target_url = merge(target_url, port=443)
             elseif target_url.scheme in ("ws", ) && target_url.port == ""
-                target_url = merge(target_url, port=80)
+                target_url = merge(target_url, port=80) # if there is no port info, connect_tunnel will fail
             end
             r = connect_tunnel(io, target_url, req)
             if r.status != 200


### PR DESCRIPTION
issue:https://github.com/JuliaWeb/HTTP.jl/issues/705
Now, both separate WebSockets.jl package and HTTP.jl package can use websocket with proxy now. 
The main bug is:
* for wss with proxy: it's not enabled with ssl
* for ws, maybe it is because the default 80 port not concated to the url end, so the request returned `Bad Request`