### PR TITLE
Add access logging functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Access logging functionality to `HTTP.listen` and `HTTP.serve` ([#713]).
 ### Fixed
-- Include `Host` header for `CONNECT` proxy requests ([#714])
+- Include `Host` header for `CONNECT` proxy requests ([#714]).
 
 ## [0.9.8] - 2020-05-02
 ### Fixed
@@ -133,3 +135,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#704]: https://github.com/JuliaWeb/HTTP.jl/pull/704
 [#706]: https://github.com/JuliaWeb/HTTP.jl/pull/706
 [#707]: https://github.com/JuliaWeb/HTTP.jl/pull/707
+[#713]: https://github.com/JuliaWeb/HTTP.jl/pull/713
+[#714]: https://github.com/JuliaWeb/HTTP.jl/pull/713

--- a/docs/src/public_interface.md
+++ b/docs/src/public_interface.md
@@ -71,6 +71,7 @@ HTTP.RequestHandlerFunction
 HTTP.StreamHandlerFunction
 HTTP.Router
 HTTP.@register
+HTTP.@logfmt_str
 ```
 
 ## Messages Interface

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -3,7 +3,8 @@ module HTTP
 export startwrite, startread, closewrite, closeread, stack, insert, insert_default!,
     remove_default!, AWS4AuthLayer, BasicAuthLayer, CanonicalizeLayer, ConnectionPoolLayer,
     ContentTypeDetectionLayer, DebugLayer, ExceptionLayer, MessageLayer, RedirectLayer,
-    RetryLayer, StreamLayer, TimeoutLayer
+    RetryLayer, StreamLayer, TimeoutLayer,
+    @logfmt_str, common_logfmt, combined_logfmt
 
 const DEBUG_LEVEL = Ref(0)
 
@@ -26,6 +27,7 @@ end
 @noinline _length_assert() =  @assert false "0 < tid <= v"
 
 include("debug.jl")
+include("access_log.jl")
 
 include("Pairs.jl")                    ;using .Pairs
 include("IOExtras.jl")                 ;using .IOExtras

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -22,6 +22,7 @@ mutable struct Stream{M <: Message, S <: IO} <: IO
     readchunked::Bool
     warn_not_to_read_one_byte_at_a_time::Bool
     ntoread::Int
+    nwritten::Int
 end
 
 """
@@ -49,7 +50,7 @@ Creates a `HTTP.Stream` that wraps an existing `IO` stream.
     response to be read by another `Stream` that is waiting in `startread`.
     If a complete response has not been received, `closeread` throws `EOFError`.
 """
-Stream(r::M, io::S) where {M, S} = Stream{M,S}(r, io, false, false, true, 0)
+Stream(r::M, io::S) where {M, S} = Stream{M,S}(r, io, false, false, true, 0, 0)
 
 header(http::Stream, a...) = header(http.message, a...)
 setstatus(http::Stream, status) = (http.message.response.status = status)
@@ -91,7 +92,9 @@ function IOExtras.startwrite(http::Stream)
     end
     buf = IOBuffer()
     writeheaders(buf, m)
-    write(http.stream, take!(buf))
+    n = write(http.stream, take!(buf))
+    http.nwritten = 0 # should not include headers
+    return n
 end
 
 function Base.unsafe_write(http::Stream, p::Ptr{UInt8}, n::UInt)
@@ -101,12 +104,15 @@ function Base.unsafe_write(http::Stream, p::Ptr{UInt8}, n::UInt)
     if !iswritable(http) && isopen(http.stream)
         startwrite(http)
     end
-    if !http.writechunked
-        return unsafe_write(http.stream, p, n)
+    nw = if !http.writechunked
+        unsafe_write(http.stream, p, n)
+    else
+        write(http.stream, string(n, base=16), "\r\n") +
+        unsafe_write(http.stream, p, n) +
+        write(http.stream, "\r\n")
     end
-    return write(http.stream, string(n, base=16), "\r\n") +
-           unsafe_write(http.stream, p, n) +
-           write(http.stream, "\r\n")
+    http.nwritten += nw
+    return nw
 end
 
 """

--- a/src/access_log.jl
+++ b/src/access_log.jl
@@ -1,0 +1,122 @@
+@doc raw"""
+    logfmt"..."
+
+Parse an [NGINX-style log format string](https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format)
+and return a function mapping `(io::IO, http::HTTP.Stream) -> body` suitable for passing to
+[`HTTP.listen`](@ref) using the `access_logfmt` keyword argument.
+
+The following variables are currently supported:
+
+ - `$http_name`: arbitrary request header (with `-` replaced with `_`, e.g. `http_user_agent`)
+ - `$sent_http_name`: arbitrary response header (with `-` replaced with `_`)
+ - `$request`: the request line, e.g. `GET /index.html HTTP/1.1`
+ - `$request_method`: the request method
+ - `$request_uri`: the request URI
+ - `$remote_addr`: client address
+ - `$remote_port`: client port
+ - `$remote_user`: user name supplied with the Basic authentication
+ - `$server_protocol`: server protocol
+ - `$time_iso8601`: local time in ISO8601 format
+ - `$time_local`: local time in Common Log Format
+ - `$status`: response status code
+ - `$body_bytes_sent`: number of bytes in response body
+
+## Examples
+```julia
+logfmt"[$time_iso8601] \\"$request\\" $status" # [2021-05-01T12:34:40+0100] "GET /index.html HTTP/1.1" 200
+
+logfmt"$remote_addr \\"$http_user_agent\\"" # 127.0.0.1 "curl/7.47.0"
+```
+"""
+macro logfmt_str(s)
+    return logfmt_parser(s)
+end
+
+function logfmt_parser(s)
+    s = String(s)
+    vars = Symbol[]
+    ex = Expr(:call, :print, :io)
+    i = 1
+    while i <= lastindex(s)
+        j = findnext(==('\$'), s, i)
+        if j === nothing
+            j = lastindex(s)
+            push!(ex.args, String(s[i:j]))
+            break
+        end
+        if j > i
+            push!(ex.args, String(s[i:prevind(s, j)]))
+        end
+        sym, j = Meta.parse(s, nextind(s, j); greedy=false)
+        e = symbol_mapping(sym)
+        isa(e, Tuple) ? push!(ex.args, e...) : push!(ex.args, e)
+        i = j
+    end
+    f = Expr(:->, Expr(:tuple, :io, :http), ex)
+    return f
+end
+
+function symbol_mapping(s::Symbol)
+    str = string(s)
+    if (m = match(r"^http_(.+)$", str); m !== nothing)
+        hdr = replace(String(m[1]), '_' => '-')
+        :(HTTP.header(http.message, $hdr, "-"))
+    elseif (m = match(r"^sent_http_(.+)$", str); m !== nothing)
+        hdr = replace(String(m[1]), '_' => '-')
+        :(HTTP.header(http.message.response, $hdr, "-"))
+    elseif s === :remote_addr
+        :(Sockets.getpeername(http)[1])
+    elseif s === :remote_port
+        :(Sockets.getpeername(http)[2])
+    elseif s === :remote_user
+        :("-") # TODO: find from Basic auth...
+    elseif s === :time_iso8601
+        if !Sys.iswindows()
+            :(Libc.strftime("%FT%T%z", time()))
+        else
+            # TODO: Libc.strftime doesn't seem to work properly on Windows
+            # so format without timezone using Dates stdlib
+            :(Dates.format(now(), dateformat"yyyy-mm-dd\THH:MM:SS"))
+        end
+    elseif s === :time_local
+        if !Sys.iswindows()
+            :(Libc.strftime("%d/%b/%Y:%H:%M:%S %z", time()))
+        else
+            # TODO: Libc.strftime doesn't seem to work properly on Windows
+            # so format without timezone using Dates stdlib
+            :(Dates.format(now(), dateformat"dd/u/yyyy:HH:MM:SS"))
+        end
+    elseif s === :request
+        m = symbol_mapping(:request_method)
+        t = symbol_mapping(:request_uri)
+        p = symbol_mapping(:server_protocol)
+        (m, " ", t, " ", p...)
+    elseif s === :request_method
+        :(http.message.method)
+    elseif s === :request_uri
+        :(http.message.target)
+    elseif s === :server_protocol
+        ("HTTP/", :(http.message.version.major), ".", :(http.message.version.minor))
+    elseif s === :status
+        :(http.message.response.status)
+    elseif s === :body_bytes_sent
+        return :(http.nwritten)
+    else
+        error("unknown variable in logfmt: $s")
+    end
+end
+
+"""
+    common_logfmt(io::IO, http::HTTP.Stream)
+
+Format a log message in the Common Log Format and write to `io`.
+"""
+const common_logfmt = logfmt"$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent"
+
+"""
+    combined_logfmt(io::IO, http::HTTP.Stream)
+
+Format a log message in the Combined Log Format and write to `io`.
+"""
+const combined_logfmt = logfmt"$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
+

--- a/test/chunking.jl
+++ b/test/chunking.jl
@@ -38,25 +38,24 @@ using BufferedStreams
 
     @test String(r.body) == decoded_data
 
-    # Ignore byte-by-byte read warning
-    ll = Base.CoreLogging.min_enabled_level(Base.CoreLogging.global_logger())
-    Base.CoreLogging.disable_logging(Base.CoreLogging.Warn)
-
     for wrap in (identity, BufferedInputStream)
         r = ""
 
-        HTTP.open("GET", "http://127.0.0.1:8091") do io
-            io = wrap(io)
-            x = split(decoded_data, "\n")
+        # Ignore byte-by-byte read warning
+        CL = Base.CoreLogging
+        CL.with_logger(CL.SimpleLogger(stderr, CL.Error)) do
+            HTTP.open("GET", "http://127.0.0.1:8091") do io
+                io = wrap(io)
+                x = split(decoded_data, "\n")
 
-            for i in 1:6
-                l = readline(io)
-                @test l == x[i]
-                r *= l * "\n"
+                for i in 1:6
+                    l = readline(io)
+                    @test l == x[i]
+                    r *= l * "\n"
+                end
             end
         end
 
         @test r == decoded_data
     end
-    Base.CoreLogging.disable_logging(ll)
 end


### PR DESCRIPTION
This adds access logging functionality to `HTTP.listen`/`HTTP.serve`. This includes a string macro that parses NGINX style format strings (chose that since it is pretty readable, self-explanatory, and looks more like Julia code compared to e.g. Apache format strings).

Example usage:
```julia
HTTP.listen(handler, host, port; access_log = logfmt"$remote_addr $request")
```
which would then log
```
[ Info: ::1 GET / HTTP/1.1
[ Info: ::1 POST /hello/post HTTP/1.1
[ Info: ::ffff:7f00:1 POST /hello/post HTTP/1.1
[ Info: ::ffff:7f00:1 HEAD /hello/post HTTP/1.1
```
etc.

Originally I thought this had to be implemented "on the inside" in order to get access to e.g. number of written bytes etc, but (as done in this PR) those things can technically be stored in the `http::Stream` object and you could do:
```julia
HTTP.listen(host, port) do http
    # handle stuff
    do_log(http) # do logging like this instead
end
```
but it is pretty convenient to just  have to pass the `access_log` keyword and it does not really cost anything. In addition, if you want manual control you can still do it like above.