### PR TITLE
Include Host header for CONNECT proxy requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Include Host header for CONNECT proxy requests ([#714])
 
 ## [0.9.8] - 2020-05-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Include Host header for CONNECT proxy requests ([#714])
+- Include `Host` header for `CONNECT` proxy requests ([#714])
 
 ## [0.9.8] - 2020-05-02
 ### Fixed

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -126,7 +126,10 @@ sockettype(url::URI, default) = url.scheme in ("wss", "https") ? SSLContext : de
 function connect_tunnel(io, target_url, req)
     target = "$(URIs.hoststring(target_url.host)):$(target_url.port)"
     @debug 1 "📡  CONNECT HTTPS tunnel to $target"
-    headers = Dict(filter(x->x.first in ("Host", "Proxy-Authorization"), req.headers))
+    headers = Dict("Host" => target)
+    if (auth = header(req, "Proxy-Authorization"); !isempty(auth))
+        headers["Proxy-Authorization"] = auth
+    end
     request = Request("CONNECT", target, headers)
     writeheaders(io, request)
     startread(io)

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -126,7 +126,7 @@ sockettype(url::URI, default) = url.scheme in ("wss", "https") ? SSLContext : de
 function connect_tunnel(io, target_url, req)
     target = "$(URIs.hoststring(target_url.host)):$(target_url.port)"
     @debug 1 "📡  CONNECT HTTPS tunnel to $target"
-    headers = Dict(filter(x->x.first == "Proxy-Authorization", req.headers))
+    headers = Dict(filter(x->x.first in ("Host", "Proxy-Authorization"), req.headers))
     request = Request("CONNECT", target, headers)
     writeheaders(io, request)
     startread(io)

--- a/test/client.jl
+++ b/test/client.jl
@@ -421,9 +421,7 @@ end
             sock = accept(proxy)
             while isopen(sock)
                 line = readline(sock)
-                if line == ""
-                    break
-                end
+                isempty(line) && break
 
                 push!(req, line)
             end

--- a/test/client.jl
+++ b/test/client.jl
@@ -432,7 +432,7 @@ end
         HTTP.get("https://example.com"; proxy="http://localhost:8082", retry=false, status_exception=false)
 
         # Test if the host header exist in the request
-        @test "Host: example.com" in req
+        @test "Host: example.com:443" in req
 
         close(proxy)
     end

--- a/test/client.jl
+++ b/test/client.jl
@@ -407,3 +407,35 @@ end
         test(HTTP.delete(uri, headers, body; query=query), "DELETE")
     end
 end
+
+@testset "HTTP CONNECT Proxy" begin
+    @testset "Host header" begin
+        # Stores the http request passed by the client
+        req = String[]
+
+        # Trivial implementation of a proxy server
+        # We are only interested in the request passed in by the client
+        # Returns 400 after reading the http request into req
+        proxy = listen(IPv4(0), 8082)
+        @async begin
+            sock = accept(proxy)
+            while isopen(sock)
+                line = readline(sock)
+                if line == ""
+                    break
+                end
+
+                push!(req, line)
+            end
+            write(sock, "HTTP/1.1 400 Bad Request\r\n\r\n")
+        end
+
+        # Make the HTTP request
+        HTTP.get("https://example.com"; proxy="http://localhost:8082", retry=false, status_exception=false)
+
+        # Test if the host header exist in the request
+        @test "Host: example.com" in req
+
+        close(proxy)
+    end
+end


### PR DESCRIPTION
We have encountered an issue where we would get HTTP 400 when we specify a proxy when making a HTTP request:
```
julia> import HTTP

julia> HTTP.request("GET","https://example.com", proxy="http://proxy:80")
ERROR: HTTP.ExceptionRequest.StatusError(400, "CONNECT", "example.com:443", HTTP.Messages.Response:
"""
HTTP/1.1 400 Bad Request
Date: Wed, 19 May 2021 16:15:03 GMT
Server: Apache
Strict-Transport-Security: max-age=63072000; includeSubdomains; preload
X-Frame-Options: SAMEORIGIN
Content-Length: 226
Connection: close
Content-Type: text/html; charset=iso-8859-1

""")
Stacktrace:
 [1] request(::Type{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}, ::URIs.URI, ::Vararg{Any, N} where N; kw::Base.Iterators.Pairs{Symbol, Any, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :reached_redirect_limit, :proxy), Tuple{Nothing, Bool, String}}})
   @ HTTP.ExceptionRequest ~/.julia/packages/HTTP/cxgat/src/ExceptionRequest.jl:22
 [2] (::Base.var"#70#72"{Base.var"#70#71#73"{ExponentialBackOff, HTTP.RetryRequest.var"#2#3"{Bool, HTTP.Messages.Request}, typeof(HTTP.request)}})(::Type, ::Vararg{Any, N} where N; kwargs::Base.Iterators.Pairs{Symbol, Any, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :reached_redirect_limit, :proxy), Tuple{Nothing, Bool, String}}})
   @ Base ./error.jl:288
 [3] #request#1
   @ ~/.julia/packages/HTTP/cxgat/src/RetryRequest.jl:44 [inlined]
 [4] request(::Type{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}, method::String, url::URIs.URI, headers::Vector{Pair{SubString{String}, SubString{String}}}, body::Vector{UInt8}; http_version::VersionNumber, target::String, parent::Nothing, iofunction::Nothing, kw::Base.Iterators.Pairs{Symbol, Any, Tuple{Symbol, Symbol}, NamedTuple{(:reached_redirect_limit, :proxy), Tuple{Bool, String}}})
   @ HTTP.MessageRequest ~/.julia/packages/HTTP/cxgat/src/MessageRequest.jl:66
 [5] request(::Type{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}, method::String, url::URIs.URI, headers::Vector{Pair{SubString{String}, SubString{String}}}, body::Vector{UInt8}; kw::Base.Iterators.Pairs{Symbol, Any, Tuple{Symbol, Symbol}, NamedTuple{(:reached_redirect_limit, :proxy), Tuple{Bool, String}}})
   @ HTTP.BasicAuthRequest ~/.julia/packages/HTTP/cxgat/src/BasicAuthRequest.jl:28
 [6] request(::Type{HTTP.RedirectRequest.RedirectLayer{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}}, method::String, url::URIs.URI, headers::Vector{Pair{SubString{String}, SubString{String}}}, body::Vector{UInt8}; redirect_limit::Int64, forwardheaders::Bool, kw::Base.Iterators.Pairs{Symbol, String, Tuple{Symbol}, NamedTuple{(:proxy,), Tuple{String}}})
   @ HTTP.RedirectRequest ~/.julia/packages/HTTP/cxgat/src/RedirectRequest.jl:24
 [7] request(method::String, url::String, h::Vector{Pair{SubString{String}, SubString{String}}}, b::Vector{UInt8}; headers::Vector{Pair{SubString{String}, SubString{String}}}, body::Vector{UInt8}, query::Nothing, kw::Base.Iterators.Pairs{Symbol, String, Tuple{Symbol}, NamedTuple{(:proxy,), Tuple{String}}})
   @ HTTP ~/.julia/packages/HTTP/cxgat/src/HTTP.jl:315
 [8] top-level scope
   @ REPL[2]:1
```

Turns out that our http proxy server (apache configured as a forward proxy) would return HTTP 400 when the Host header is not specified as part of CONNECT request. The following is observed in the apache logs:

```
httpd_1            | [Wed May 19 16:15:03.242807 2021] [core:debug] [pid 15:tid 140522410957600] protocol.c(1445): [client <ip>:53238] AH00569: client sent HTTP/1.1 request without hostname (see RFC2616 section 14.23): /
httpd_1            | [Wed May 19 16:15:03.242840 2021] [headers:debug] [pid 15:tid 140522410957600] mod_headers.c(899): AH01503: headers: ap_headers_error_filter()
httpd_1            | <ip> - - [19/May/2021:16:15:03 +0000] "CONNECT example.com:443 HTTP/1.1" 400 0 "-" "-" 14375 0
```

From the [RFC2616 section 14.23](https://datatracker.ietf.org/doc/html/rfc2616#section-14.23):
```
   A client MUST include a Host header field in all HTTP/1.1 request
   messages . If the requested URI does not include an Internet host
   name for the service being requested, then the Host header field MUST
   be given with an empty value. An HTTP/1.1 proxy MUST ensure that any
   request message it forwards does contain an appropriate Host header
   field that identifies the service being requested by the proxy.
```

---

This PR fixes the issue by including the original `Host` header in the request. After this change, Apache correctly accepts the CONNECT requests and forwards the HTTP request

```
julia> HTTP.request("GET","https://example.com", proxy="http://proxy:80")
HTTP.Messages.Response:
"""
HTTP/1.1 200 OK
Accept-Ranges: bytes
Age: 343609
Cache-Control: max-age=604800
Content-Type: text/html; charset=UTF-8
Date: Wed, 19 May 2021 16:17:05 GMT
Etag: "3147526947"
Expires: Wed, 26 May 2021 16:17:05 GMT
Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
Server: ECS (oxr/8324)
Vary: Accept-Encoding
X-Cache: HIT
Content-Length: 1256
<body truncated>
"""

# Apache logs:
httpd_1            | <ip> - - [19/May/2021:16:17:04 +0000] "CONNECT example.com:443 HTTP/1.1" 200 6382 "-" "-" 1719673 0
```