### PR TITLE
Store remote IP adress in connection struct

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -66,7 +66,8 @@ Fields:
 - `port::String`, exactly as specified in the URI (i.e. may be empty).
 - `pipeline_limit`, number of requests to send before waiting for responses.
 - `idle_timeout`, No. of seconds to maintain connection after last transaction.
-- `peerport`, remote TCP port number (used for debug messages).
+- `peerip`, remote IP adress (used for debug/log messages).
+- `peerport`, remote TCP port number (used for debug/log messages).
 - `localport`, local TCP port number (used for debug messages).
 - `io::T`, the `TCPSocket` or `SSLContext.
 - `clientconnection::Bool`, whether the Connection was created from client code (as opposed to server code)
@@ -88,7 +89,8 @@ mutable struct Connection{T <: IO}
     pipeline_limit::Int
     idle_timeout::Int
     require_ssl_verification::Bool
-    peerport::UInt16 # debug only
+    peerip::IPAddr # for debugging/logging
+    peerport::UInt16 # for debugging/logging
     localport::UInt16 # debug only
     io::T
     clientconnection::Bool
@@ -143,7 +145,7 @@ Connection(host::AbstractString, port::AbstractString,
     Connection{T}(host, port,
                   pipeline_limit, idle_timeout,
                   require_ssl_verification,
-                  peerport(io), localport(io),
+                  safe_getpeername(io)..., localport(io),
                   io, client, PipeBuffer(), Threads.Atomic{Int}(0),
                   0, Cond(), false,
                   0, Cond(), false,

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -12,7 +12,7 @@ using MbedTLS: MbedException
 
 export bytes, ByteView, nobytes, CodeUnits, IOError, isioerror,
        startwrite, closewrite, startread, closeread,
-       tcpsocket, localport, peerport
+       tcpsocket, localport, safe_getpeername
 
 
 """
@@ -85,11 +85,15 @@ localport(io) = try !isopen(tcpsocket(io)) ? 0 :
                     0
                 end
 
-peerport(io) = try !isopen(tcpsocket(io)) ? 0 :
-                  Sockets.getpeername(tcpsocket(io))[2]
-               catch
-                   0
-               end
+function safe_getpeername(io)
+    try
+        if isopen(tcpsocket(io))
+            return Sockets.getpeername(tcpsocket(io))
+        end
+    catch
+    end
+    return IPv4(0), UInt16(0)
+end
 
 
 const ByteView = typeof(view(UInt8[], 1:0))

--- a/src/access_log.jl
+++ b/src/access_log.jl
@@ -65,9 +65,9 @@ function symbol_mapping(s::Symbol)
         hdr = replace(String(m[1]), '_' => '-')
         :(HTTP.header(http.message.response, $hdr, "-"))
     elseif s === :remote_addr
-        :(Sockets.getpeername(http)[1])
+        :(http.stream.c.peerip)
     elseif s === :remote_port
-        :(Sockets.getpeername(http)[2])
+        :(http.stream.c.peerport)
     elseif s === :remote_user
         :("-") # TODO: find from Basic auth...
     elseif s === :time_iso8601

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,8 @@ const dir = joinpath(dirname(pathof(HTTP)), "..", "test")
 include("resources/TestRequest.jl")
 
 @testset "HTTP" begin
-    for f in ["ascii.jl",
+    for f in [
+              "ascii.jl",
               "chunking.jl",
               "utils.jl",
               "client.jl",
@@ -21,7 +22,8 @@ include("resources/TestRequest.jl")
               "async.jl",
               "aws4.jl",
               "insert_layers.jl",
-              "mwe.jl"]
+              "mwe.jl",
+             ]
         file = joinpath(dir, f)
         println("Running $file tests...")
         if isfile(file)


### PR DESCRIPTION
The remote IP is used in access logging but if the connection is closed
at the time of creating the log message it is not possible to fetch it.
(In fact, it currently segfaults, but will error in future Julia versions,
see JuliaLang/julia#40993). This should not cost anything since the call
to Sockets.getpeername(...) is already there for storing the remote port.