### PR TITLE
Avoid allocations in ascii_lc_isequal

### DIFF
--- a/src/ascii.jl
+++ b/src/ascii.jl
@@ -12,12 +12,12 @@ ascii_lc_isequal(a::UInt8, b::UInt8) = ascii_lc(a) == ascii_lc(b)
 Case insensitive ASCII string comparison.
 """
 function ascii_lc_isequal(a, b)
-    a = Iterators.Stateful(codeunits(a))
-    b = Iterators.Stateful(codeunits(b))
-    for (i, j) in zip(a, b)
-        if !ascii_lc_isequal(i, j)
-            return false
-        end
+    acu = codeunits(a)
+    bcu = codeunits(b)
+    len = length(acu)
+    len != length(bcu) && return false
+    for i = 1:len
+        @inbounds !ascii_lc_isequal(acu[i], bcu[i]) && return false
     end
-    return isempty(a) && isempty(b)
+    return true
 end


### PR DESCRIPTION
Fixes #724. Maybe in a perfect world, the compiler would be able to "see
through" the calls to `Iterators.Stateful` and `zip` iterating through
them to avoid allocating `Stateful` at all, but this also just feels
like a case of a very low-level function trying to use high-level
constructs. The proposed code here is an order of magnitude faster (~10x
in the few cases I tested), avoids all allocations, and IMO, is simpler
(I'm guessing most users don't immediately understand what
`Iterators.Stateful` is for).