### PR TITLE
RFC: Disable pipelining to alleviate race conditions

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -343,7 +343,6 @@ function IOExtras.closewrite(t::Transaction)
         @v1_3 unlock(t.c.writelock)
     end
     flush(t.c)
-    release(t.c)
 
     return
 end
@@ -590,7 +589,7 @@ end
 function isvalid(pod, conn, reuse_limit, pipeline_limit)
     # Close connections that have reached the reuse limit...
     if reuse_limit != nolimit
-        if readcount(conn) >= reuse_limit && !readbusy(conn)
+        if conn.sequence[] >= reuse_limit && !readbusy(conn)
             @debug 2 "💀 overuse:         $conn"
             close(conn.io)
         end
@@ -615,7 +614,7 @@ function isvalid(pod, conn, reuse_limit, pipeline_limit)
         return false
     end
     # If we've hit our pipeline_limit, can't use this one, but don't close
-    if (writecount(conn) - readcount(conn)) >= pipeline_limit + 1
+    if (conn.sequence[] - readcount(conn)) >= pipeline_limit + 1
         return false
     end
 

--- a/src/IODebug.jl
+++ b/src/IODebug.jl
@@ -15,7 +15,7 @@ else
 
     struct IODebug{T <: IO} <: IO
         io::T
-        log::Vector{Tuple{String,String}}
+        log::Vector{Tuple{String,Symbol,String}}
     end
 
     IODebug(io::T) where T <: IO = IODebug{T}(io, [])

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -56,6 +56,7 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
 
         @sync begin
             if iofunction === nothing
+                # Writes request asynchronously with the read.
                 @async try
                     writebody(http, req, body)
                 catch e


### PR DESCRIPTION
## Some problems

As noted in #517 we've encountered hangs using the HTTP.jl client in production. In https://github.com/JuliaWeb/HTTP.jl/issues/517#issuecomment-881408734 I've found several potential concurrency problems with the current ConnectionPool:

* It seems both `closeread(::Transaction)` and `closewrite(::Transaction)` call `release(::Connection)` which returns the connection to the pool. So the connection will be returned to the pool multiple times per request-response. In addition, `closewrite` ends up being called twice as part of `request(::Type{StreamLayer{<:}})` - both in the body of that function and also in `writebody()`. So a given connection will be returned to the pool's channel up to three times. This seems weird to me and potentially broken.

* `reuse_limit` is not respected because it checks `readcount()` rather than the sequence number. But `readcount` isn't incremented immediately on assigning a transaction to a connection, but only later when `closeread` is called.

* It seems that `isvalid()` is happy to close connection streams based on various conditions (timeout and reuse counts) when the stream isn't currently reading/writing. But depending on the details of locking, a connection could already have had pending transactions assigned to it which have not yet started reading or writing. It seems easy for race conditions to creep in here.

## What to do?

Removing `release()` from `closeread()` disables HTTP/1.1 pipelining and seems to fix the issues at #517. This PR includes that trivial change as a strawman (and also a couple of other related concurrency fixes).

Rather than trying to fix pipelining properly, perhaps we should consider consider removing it. It seems that major HTTP implementations have deemed it not worthwhile in practice due to:
* Broken proxies
* The difficulty of correct implementation, especially for request cancellation / timeout
* Questionable performance improvements due to head-of-line blocking
* Effort better spent in "doing it right" using HTTP/2 multiplexing

For example,

* Curl removed it completely in 2019 https://daniel.haxx.se/blog/2019/04/06/curl-says-bye-bye-to-pipelining/
* No modern browser implements pipelining and most have removed the code entirely: https://stackoverflow.com/questions/30477476/why-is-pipelining-disabled-in-modern-browsers