### PR TITLE
Add `TopLayer` layer at the top of every stack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.9.12"
+version = "0.9.13"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -3,7 +3,7 @@ module HTTP
 export startwrite, startread, closewrite, closeread, stack, insert, insert_default!,
     remove_default!, AWS4AuthLayer, BasicAuthLayer, CanonicalizeLayer, ConnectionPoolLayer,
     ContentTypeDetectionLayer, DebugLayer, ExceptionLayer, MessageLayer, RedirectLayer,
-    RetryLayer, StreamLayer, TimeoutLayer,
+    RetryLayer, StreamLayer, TimeoutLayer, TopLayer,
     @logfmt_str, common_logfmt, combined_logfmt
 
 const DEBUG_LEVEL = Ref(0)

--- a/src/TopRequest.jl
+++ b/src/TopRequest.jl
@@ -1,0 +1,18 @@
+module TopRequest
+
+import ..Layer, ..request
+
+export TopLayer
+
+"""
+    request(TopLayer, args...; kwargs...)
+
+This layer is at the top of every stack, and does nothing.
+It's useful for inserting a custom layer at the top of the stack.
+"""
+abstract type TopLayer{Next <: Layer} <: Layer{Next} end
+
+request(::Type{TopLayer{Next}}, args...; kwargs...) where Next =
+    request(Next, args...; kwargs...)
+
+end

--- a/test/insert_layers.jl
+++ b/test/insert_layers.jl
@@ -5,7 +5,7 @@ using ..TestRequest
 @testset "HTTP Stack Inserting" begin
     @testset "Insert - Beginning" begin
         expected = TestLayer{TopLayer{RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}}
-        result = insert(stack(), RedirectLayer, TestLayer)
+        result = insert(stack(), TopLayer, TestLayer)
 
         @test expected == result
     end

--- a/test/insert_layers.jl
+++ b/test/insert_layers.jl
@@ -4,21 +4,21 @@ using ..TestRequest
 
 @testset "HTTP Stack Inserting" begin
     @testset "Insert - Beginning" begin
-        expected = TestLayer{RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}
+        expected = TestLayer{TopLayer{RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}}
         result = insert(stack(), RedirectLayer, TestLayer)
 
         @test expected == result
     end
 
     @testset "Insert - Middle" begin
-        expected = RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{TestLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}
+        expected = TopLayer{RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{TestLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}}
         result = insert(stack(), ExceptionLayer, TestLayer)
 
         @test expected == result
     end
 
     @testset "Insert - End" begin
-        expected = RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{TestLayer{Union{}}}}}}}}}
+        expected = TopLayer{RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{TestLayer{Union{}}}}}}}}}}
         result = insert(stack(), Union{}, TestLayer)
 
         @test expected == result
@@ -31,7 +31,7 @@ using ..TestRequest
     @testset "Insert - Multiple Same layer" begin
         test_stack = insert(stack(), RetryLayer, ExceptionLayer)
 
-        expected = RedirectLayer{BasicAuthLayer{MessageLayer{TestLayer{ExceptionLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}}
+        expected = TopLayer{RedirectLayer{BasicAuthLayer{MessageLayer{TestLayer{ExceptionLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}}}
         result = insert(test_stack, ExceptionLayer, TestLayer)
 
         @test expected == result


### PR DESCRIPTION
This is a fix for https://github.com/JuliaTesting/BrokenRecord.jl/issues/20.

BrokenRecord adds an extra default layer that is meant to go at the top of the stack, so the `before` layer is `top_layer(stack())`. Currently, that's `RedirectLayer`. But afterwards, if you try to create a stack with redirects disabled (AWS.jl does this), HTTP can't insert the extra layer anywhere.

This introduces a `TopLayer` that is always at the top of `stack()`, and does nothing but pass on its arguments to the next layer. That way, we can guarantee that a layer inserted before `top_layer(stack())` will always be insertable.

Before:

```jl
julia> using HTTP

julia> abstract type MyLayer{Next <: HTTP.Layer} <: HTTP.Layer{Next} end

julia> HTTP.insert_default!(HTTP.top_layer(HTTP.stack()), MyLayer);

julia> HTTP.stack()
MyLayer{RedirectLayer{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}}

julia> HTTP.stack(; redirect=false)
ERROR: HTTP.Layers.LayerNotFoundException: RedirectLayer not found in BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}

Stacktrace:
  [1] insert(stack::Type{BasicAuthLayer{MessageLayer{RetryLayer{ExceptionLayer{ConnectionPoolLayer{StreamLayer{Union{}}}}}}}}, layer_before::Type{RedirectLayer}, custom_layer::Type{MyLayer})
    @ HTTP.Layers ~/Code/HTTP/src/layers.jl:110
  [2] (::HTTP.var"#24#25")(stack::Type, ::Tuple{UnionAll, UnionAll})
    @ HTTP ~/Code/HTTP/src/HTTP.jl:603
  [3] BottomRF
    @ ./reduce.jl:81 [inlined]
  [4] _foldl_impl(op::Base.BottomRF{HTTP.var"#24#25"}, init::Type, itr::Set{Tuple{Union{Type{Union{}}, UnionAll}, UnionAll}})
    @ Base ./reduce.jl:58
  [5] foldl_impl
    @ ./reduce.jl:48 [inlined]
  [6] mapfoldl_impl(f::typeof(identity), op::HTTP.var"#24#25", nt::Type, itr::Set{Tuple{Union{Type{Union{}}, UnionAll}, UnionAll}})
    @ Base ./reduce.jl:44
  [7] mapfoldl(f::Function, op::Function, itr::Set{Tuple{Union{Type{Union{}}, UnionAll}, UnionAll}}; init::Type)
    @ Base ./reduce.jl:160
  [8] #mapreduce#218
    @ ./reduce.jl:287 [inlined]
  [9] #reduce#220
    @ ./reduce.jl:456 [inlined]
 [10] stack(; redirect::Bool, aws_authorization::Bool, cookies::Bool, canonicalize_headers::Bool, retry::Bool, status_exception::Bool, readtimeout::Int64, detect_content_type::Bool, verbose::Int64, kw::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ HTTP ~/Code/HTTP/src/HTTP.jl:602
 [11] top-level scope
    @ REPL[5]:1
```