### PR TITLE
Improve memory use and performance of multipart parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          PIE_SOCKET_API_KEY: ${{ secrets.PIE_SOCKET_API_KEY }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -610,7 +610,7 @@ end
 include("download.jl")
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
 include("Handlers.jl")                 ;using .Handlers; using .Handlers: serve
-include("parsemultipart.jl")
+include("parsemultipart.jl")           ;using .MultiPartParsing: parse_multipart_form
 include("WebSockets.jl")               ;using .WebSockets
 
 import .ConnectionPool: Transaction, Connection

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -66,14 +66,37 @@ _doc = """
 
 Signal start/end of write or read operations.
 """
-"$_doc"
-startwrite(io) = nothing
-"$_doc"
-closewrite(io) = nothing
-"$_doc"
-startread(io) = nothing
-"$_doc"
-closeread(io) = nothing
+if isdefined(Base, :startwrite)
+    "$_doc"
+    Base.startwrite(io) = nothing
+else
+    "$_doc"
+    startwrite(io) = nothing
+end
+
+if isdefined(Base, :closewrite)
+    "$_doc"
+    Base.closewrite(io) = nothing
+else
+    "$_doc"
+    closewrite(io) = nothing
+end
+
+if isdefined(Base, :startread)
+    "$_doc"
+    Base.startread(io) = nothing
+else
+    "$_doc"
+    startread(io) = nothing
+end
+
+if isdefined(Base, :closeread)
+    "$_doc"
+    Base.closeread(io) = nothing
+else
+    "$_doc"
+    closeread(io) = nothing
+end
 
 using MbedTLS: SSLContext
 tcpsocket(io::SSLContext)::TCPSocket = io.bio

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -11,7 +11,7 @@ const DASH_BYTE = 0x2d # -
 const HTAB_BYTE = 0x09 # \t
 const SPACE_BYTE = 0x20
 const SEMICOLON_BYTE = UInt8(';')
-const CRLFCRLF = [CR_BYTE, LF_BYTE, CR_BYTE, LF_BYTE]
+const CRLFCRLF = (CR_BYTE, LF_BYTE, CR_BYTE, LF_BYTE)
 
 "compare byte buffer `a` from index `i` to index `j` with `b` and check if they are byte-equal"
 function byte_buffers_eq(a, i, j, b)

--- a/test/chunking.jl
+++ b/test/chunking.jl
@@ -1,10 +1,11 @@
 using Test
-using HTTP
+using HTTP, HTTP.IOExtras
 using BufferedStreams
 
 # For more information see: https://github.com/JuliaWeb/HTTP.jl/pull/288
 @testset "Chunking" begin
     sz = 90
+    port = 8095
     hex(n) = string(n, base=16)
     encoded_data = "$(hex(sz + 9))\r\n" * "data: 1$(repeat("x", sz))\n\n" * "\r\n" *
                    "$(hex(sz + 9))\r\n" * "data: 2$(repeat("x", sz))\n\n" * "\r\n" *
@@ -15,7 +16,7 @@ using BufferedStreams
     split1 = 106
     split2 = 300
 
-    t = @async HTTP.listen("127.0.0.1", 8091) do http
+    t = @async HTTP.listen("127.0.0.1", port) do http
         startwrite(http)
         tcp = http.stream.c.io
 
@@ -34,7 +35,7 @@ using BufferedStreams
     sleep(1)
     @assert !istaskdone(t)
 
-    r = HTTP.get("http://127.0.0.1:8091")
+    r = HTTP.get("http://127.0.0.1:$port")
 
     @test String(r.body) == decoded_data
 
@@ -44,7 +45,7 @@ using BufferedStreams
         # Ignore byte-by-byte read warning
         CL = Base.CoreLogging
         CL.with_logger(CL.SimpleLogger(stderr, CL.Error)) do
-            HTTP.open("GET", "http://127.0.0.1:8091") do io
+            HTTP.open("GET", "http://127.0.0.1:$port") do io
                 io = wrap(io)
                 x = split(decoded_data, "\n")
 

--- a/test/client.jl
+++ b/test/client.jl
@@ -175,7 +175,11 @@ end
         # canonicalizeheaders
         @test status(HTTP.get("$sch://httpbin.org/ip"; canonicalizeheaders=false)) == 200
     end
+end
 
+if haskey(ENV, "PIE_SOCKET_API_KEY")
+    println("found pie socket api key, running websocket tests")
+    pie_socket_api_key = ENV["PIE_SOCKET_API_KEY"]
     @testset "openraw client method - $socket_protocol" for socket_protocol in ["wss", "ws"]
         # WebSockets require valid headers.
         headers = Dict(
@@ -184,7 +188,7 @@ end
             "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
             "Sec-WebSocket-Version" => "13")
 
-        socket, response = HTTP.openraw("GET", "$sch://echo.websocket.org", headers)
+        socket, response = HTTP.openraw("GET", "$socket_protocol://free3.piesocket.com/v3/http_test_channel?api_key=$pie_socket_api_key&notify_self", headers)
 
         @test response.status == 101
 

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,6 +1,6 @@
 module test_server
 
-using HTTP, Sockets, Test, MbedTLS
+using HTTP, HTTP.IOExtras, Sockets, Test, MbedTLS
 
 function testget(url, m=1)
     r = []


### PR DESCRIPTION
Memory usage and performance noted in
https://discourse.julialang.org/t/http-parse-multipart-form-does-a-lot-of-memory-allocations/66661.
This uses some of the same regex tricks we use in the other http parsing
code that operates on SubStrings and avoids excessive allocations. We
also streamline things to avoid allocating when comparing byte buffers
and the unnecessary allocated arrays of the content disposition
processing.

On my machine for current master, I see `35.022 μs (866 allocations:
70.27 KiB)` for parsing a simple multipart request from the tests, and
with this PR, I see `3.603 μs (42 allocations: 2.55 KiB)`.