### PR TITLE
[Breaking] Remove the type piracy of several `Base` functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.9.14"
+version = "1.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -66,37 +66,18 @@ _doc = """
 
 Signal start/end of write or read operations.
 """
-if isdefined(Base, :startwrite)
-    "$_doc"
-    Base.startwrite(io) = nothing
-else
-    "$_doc"
-    startwrite(io) = nothing
-end
 
-if isdefined(Base, :closewrite)
-    "$_doc"
-    Base.closewrite(io) = nothing
-else
-    "$_doc"
-    closewrite(io) = nothing
-end
+"$_doc"
+startwrite(io) = nothing
 
-if isdefined(Base, :startread)
-    "$_doc"
-    Base.startread(io) = nothing
-else
-    "$_doc"
-    startread(io) = nothing
-end
+"$_doc"
+closewrite(io) = nothing
 
-if isdefined(Base, :closeread)
-    "$_doc"
-    Base.closeread(io) = nothing
-else
-    "$_doc"
-    closeread(io) = nothing
-end
+"$_doc"
+startread(io) = nothing
+
+"$_doc"
+closeread(io) = nothing
 
 using MbedTLS: SSLContext
 tcpsocket(io::SSLContext)::TCPSocket = io.bio


### PR DESCRIPTION
This pull request removes the type piracy of several `Base` functions. Specifically, it removes the following pirated methods:
1. `Base.startwrite(io::Any)`
2. `Base.closewrite(io::Any)`
3. `Base.startread(io::Any)`
4. `Base.closeread(io::Any)`

According to https://github.com/JuliaWeb/HTTP.jl/pull/745#discussion_r699633657, this is a breaking change. Therefore, I took advantage of the opportunity to bump the version number to `1.0.0`.

For context, see: https://github.com/JuliaWeb/HTTP.jl/pull/745#pullrequestreview-743118202 and https://github.com/JuliaLang/julia/pull/42080.