### PR TITLE
Make HTTP.download support redirects when the redirected URL does not set Content-Disposition

### DIFF
--- a/test/download.jl
+++ b/test/download.jl
@@ -40,6 +40,18 @@ using HTTP
             @test isfile(escaped_content_disposition_fn)
             @test basename(escaped_content_disposition_fn) == "\"quoting\" tested.html"
         end
+
+        # HTTP#760
+        # This has a redirect, where the original Response has the Content-Disposition
+        # but the redirected one doesn't
+        # Neither https://httpbingo.julialang.org/ nor http://test.greenbytes.de/tech/tc2231/
+        # has a test-case for this. See: https://github.com/postmanlabs/httpbin/issues/652
+        # This test might stop validating the code-path if FigShare changes how they do
+        # redirects (which they have done before, causing issue HTTP#760, in the first place)
+        redirected_content_disposition_fn = HTTP.download(
+            "https://ndownloader.figshare.com/files/6294558")
+        @test isfile(redirected_content_disposition_fn)
+        @test basename(redirected_content_disposition_fn) == "rsta20150293_si_001.xlsx"
     end
 
     @testset "Provided Filename" begin


### PR DESCRIPTION
Closes https://github.com/JuliaWeb/HTTP.jl/issues/760

I do not love this solution as it used HEAD requrests.
And I am pretty sure those are not supported everywhere.
Even though the standard requires that they are supported everywhere `GET` is.
But I don't have a counter-example handy.

Possibly the better way to do this is to first try and fully do the download with redirect off.
If that fails, remember the filename,
and then retry with redirect on.

Does anyone have thoughts (or a URL I can use to break this?)


This uses the URL from #760 as go-httpbin doesn't have a way to create a redirect chain that has the first with the content-disposition, and the last without.
https://github.com/postmanlabs/httpbin/issues/652