### PR TITLE
Catch ECONNRESET error codes from other platforms

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -303,7 +303,8 @@ function listenloop(f, server, tcpisvalid, connection_count,
                 handle_connection(f, conn, server, reuse_limit, readtimeout)
                 # verbose && @info "Closed ($count):  $conn"
             catch e
-                if e isa Base.IOError && (e.code == -54 || e.code == -4077)
+                if e isa Base.IOError &&
+                    (e.code == -54 || e.code == -4077 || e.code == -104 || e.code == -131 || e.code == -232)
                     verbose && @warn "connection reset by peer (ECONNRESET)"
                 else
                     @error "" exception=(e, stacktrace(catch_backtrace()))


### PR DESCRIPTION
Windows uses -4077
SPAC and ALPHA architectures on linux use -54
Generic architectures on linux uses -104 (this includes x86, x86_64, arm, and arm64)
PARSIC on linux uses -232
MIPS on linux uses -131
I'm guessing MacOS uses -54 too, as this was one code that already worked for a large group of people.
Fixes #763 #547