### PR TITLE
Add `on_shutdown` to `HTTP.serve` docstring

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -314,6 +314,11 @@ Optional keyword arguments:
     per client IP address; excess connections are immediately closed. e.g. 5//1.
  - `stream::Bool=false`, the handler will operate on an `HTTP.Stream` instead of `HTTP.Request`
  - `verbose::Bool=false`, log connection information to `stdout`.
+ - `on_shutdown::Union{Function, Vector{<:Function}, Nothing}=nothing`, one or
+    more functions to be run if the server is closed (for example by an
+    `InterruptException`). Note, shutdown function(s) will not run if an
+    `IOServer` object is supplied to the `server` keyword argument and closed
+    by `close(server)`.
 
 # Examples
 ```julia

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -152,8 +152,9 @@ Optional keyword arguments:
     from. See also [`@logfmt_str`](@ref).
  - `on_shutdown::Union{Function, Vector{<:Function}, Nothing}=nothing`, one or
     more functions to be run if the server is closed (for example by an
-    `InterruptException`). Note, shutdown function(s) will not run if a
-    `IOServer` object is supplied and closed by `close(server)`.
+    `InterruptException`). Note, shutdown function(s) will not run if an
+    `IOServer` object is supplied to the `server` keyword argument and closed
+    by `close(server)`.
 
 e.g.
 ```julia


### PR DESCRIPTION
It's currently in the `listen` docstring, but not `serve`. Also improved the wording of the kwarg description