### PR TITLE
Fix chance of incomplete read in partial response stream reading

### DIFF
--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -145,7 +145,7 @@ function readbody(http::Stream, res::Response, response_stream, reached_redirect
     else
         if reached_redirect_limit || !isredirect(res)
             res.body = body_was_streamed
-            write(response_stream, http)
+            write(response_stream, read(http)) # use read(http) to ensure ntoread is respected
             close(response_stream)
         end
     end

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -139,22 +139,22 @@ end
 writechunk(http, req, body::IO) = writebodystream(http, req, body)
 writechunk(http, req, body) = write(http, body)
 
-function readbody(http::Stream, res::Response, response_stream, reached_redirect_limit)
-    if response_stream === nothing
-        res.body = read(http)
-    else
-        if reached_redirect_limit || !isredirect(res)
-            res.body = body_was_streamed
-            if Streams.ntoread(http) == unknown_length
-                write(response_stream, http)
-            else
-                while http.ntoread > 0
-                    readbytes!(http, response_stream, http.ntoread)
-                end
-            end
-            close(response_stream)
+function readbody(http::Stream, res::Response, ::Nothing, ::Bool)
+    res.body = read(http)
+    return
+end
+
+function readbody(http::Stream, res::Response, response_stream, reached_redirect_limit::Bool)
+    if reached_redirect_limit || !isredirect(res)
+        res.body = body_was_streamed
+        if http.ntoread == unknown_length
+            write(response_stream, http)
+        else
+            readbytes!(http, response_stream, http.ntoread)
         end
+        close(response_stream)
     end
+    return
 end
 
 end # module StreamRequest

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -145,7 +145,13 @@ function readbody(http::Stream, res::Response, response_stream, reached_redirect
     else
         if reached_redirect_limit || !isredirect(res)
             res.body = body_was_streamed
-            write(response_stream, read(http)) # use read(http) to ensure ntoread is respected
+            if Streams.ntoread(http) == unknown_length
+                write(response_stream, http)
+            else
+                while http.ntoread > 0
+                    readbytes!(http, response_stream, http.ntoread)
+                end
+            end
             close(response_stream)
         end
     end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -311,6 +311,15 @@ function Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))
     buf.size += n
 end
 
+# used in julia v1.0
+function Base.readbytes!(http::Stream, buf::IOStream, n=bytesavailable(http))
+    nread = 0
+    while nread < n
+        nread += write(buf, readavailable(http, n - nread))
+    end
+    nread
+end
+
 function Base.read(http::Stream)
     buf = PipeBuffer()
     if ntoread(http) == unknown_length

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -303,6 +303,8 @@ function Base.unsafe_read(http::Stream, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
+Base.readbytes!(http::Stream, buf::Base.BufferStream, n=bytesavailable(http)) = Base.readbytes!(http, buf.buffer, n)
+
 function Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))
     Base.ensureroom(buf, n)
     unsafe_read(http, pointer(buf.data, buf.size + 1), n)


### PR DESCRIPTION
This appears to fix a bug seen over in https://github.com/JuliaCloud/AWS.jl/issues/515 where a 206 partial request response has the correct Content-Length in the header but HTTP.jl returns fewer bytes with no error.

The bug is seen most frequently when running many `@async` `HTTP.request`s each requesting a data `Range` on slower internet connections.

The problem appears to be that a simple `write(response_stream, http)` bypassed the `ntoread` handling [here](https://github.com/JuliaWeb/HTTP.jl/blob/f359667aa6a7ea3c0436f1922c0b2f65d0717d81/src/Streams.jl#L312-L324) that ensures successive reads were done if the promised content length wasn't fully retrieved the first time, which allows for the buffer to populate slowly on slower connections, so it needs to be `write(response_stream, read(http))` instead