### PR TITLE
Fix bad catch on StreamRequest.writebody

### DIFF
--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -79,11 +79,12 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
         end
 
     catch e
-        if write_error !== nothing
-            throw(write_error)
-        else
+        if write_error === nothing
             rethrow(e)
         end
+    end
+    if write_error !== nothing
+        throw(write_error)
     end
 
     # Suppress errors from closing


### PR DESCRIPTION
Errors from within `StreamRequest.writebody` were't being caught because of this.