### PR TITLE
Generalize readbytes!

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -303,8 +303,6 @@ function Base.unsafe_read(http::Stream, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
-Base.readbytes!(http::Stream, buf::Base.BufferStream, n=bytesavailable(http)) = Base.readbytes!(http, buf.buffer, n)
-
 function Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))
     Base.ensureroom(buf, n)
     unsafe_read(http, pointer(buf.data, buf.size + 1), n)

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -311,8 +311,7 @@ function Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))
     buf.size += n
 end
 
-# used in julia v1.0
-function Base.readbytes!(http::Stream, buf::IOStream, n=bytesavailable(http))
+function Base.readbytes!(http::Stream, buf::IO, n=bytesavailable(http))
     nread = 0
     while nread < n
         nread += write(buf, readavailable(http, n - nread))


### PR DESCRIPTION
Intending to address @fredrikekre's comment on https://github.com/JuliaWeb/HTTP.jl/pull/778/files#r750049062

Fixes unintentional IO handling narrowing that #778 introduced

Given `Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))` already existed, I thought it best to leave `IOBuffer`-backed IO's to use that method, but I wasn't sure if there's a generic way to do that?