### PR TITLE
Revert #778. Make incomplete content-length responses throw an EOFError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.17] - 2021-11-17
+### Fixed
+- Correctly throw an `EOFError` if the connection is closed with remaining bytes
+  to be transferred ([#778], [#781]).
+
 ## [0.9.16] - 2021-09-29
 See changes for 0.9.15: this release is equivalent to 0.9.15 with [#752] reverted.
 [#752] might be included in a future breaking release instead, see [#774].
@@ -148,7 +153,8 @@ See changes for 0.9.15: this release is equivalent to 0.9.15 with [#752] reverte
   `HTTP.request` and friends ([#619]).
 
 
-[Unreleased]: https://github.com/JuliaWeb/HTTP.jl/compare/v0.9.16...HEAD
+[Unreleased]: https://github.com/JuliaWeb/HTTP.jl/compare/v0.9.17...HEAD
+[0.9.17]: https://github.com/JuliaWeb/HTTP.jl/compare/v0.9.16...v0.9.17
 [0.9.16]: https://github.com/JuliaWeb/HTTP.jl/compare/v0.9.15...v0.9.16
 [0.9.15]: https://github.com/JuliaWeb/HTTP.jl/compare/v0.9.14...v0.9.15
 [0.9.14]: https://github.com/JuliaWeb/HTTP.jl/compare/v0.9.13...v0.9.14
@@ -222,3 +228,5 @@ See changes for 0.9.15: this release is equivalent to 0.9.15 with [#752] reverte
 [#766]: https://github.com/JuliaWeb/HTTP.jl/pull/766
 [#770]: https://github.com/JuliaWeb/HTTP.jl/pull/770
 [#774]: https://github.com/JuliaWeb/HTTP.jl/pull/774
+[#778]: https://github.com/JuliaWeb/HTTP.jl/pull/778
+[#781]: https://github.com/JuliaWeb/HTTP.jl/pull/781

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "0.9.16"
+version = "0.9.17"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -139,22 +139,16 @@ end
 writechunk(http, req, body::IO) = writebodystream(http, req, body)
 writechunk(http, req, body) = write(http, body)
 
-function readbody(http::Stream, res::Response, ::Nothing, ::Bool)
-    res.body = read(http)
-    return
-end
-
-function readbody(http::Stream, res::Response, response_stream, reached_redirect_limit::Bool)
-    if reached_redirect_limit || !isredirect(res)
-        res.body = body_was_streamed
-        if http.ntoread == unknown_length
+function readbody(http::Stream, res::Response, response_stream, reached_redirect_limit)
+    if response_stream === nothing
+        res.body = read(http)
+    else
+        if reached_redirect_limit || !isredirect(res)
+            res.body = body_was_streamed
             write(response_stream, http)
-        else
-            readbytes!(http, response_stream, http.ntoread)
+            close(response_stream)
         end
-        close(response_stream)
     end
-    return
 end
 
 end # module StreamRequest

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -92,7 +92,8 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
         closewrite(http)
         @debug 2 "client closeread"
         closeread(http)
-    catch;
+    catch e
+        e isa EOFError && rethrow()
     end
 
     verbose == 1 && printlncompact(response)

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -205,10 +205,7 @@ function Base.eof(http::Stream)
     if http.ntoread == 0
         return true
     end
-    if eof(http.stream)
-        return true
-    end
-    return false
+    return eof(http.stream)
 end
 
 @inline function ntoread(http::Stream)
@@ -355,6 +352,8 @@ function IOExtras.closeread(http::Stream{Response})
         # Close conncetion if server sent "Connection: close"...
         @debug 1 "✋  \"Connection: close\": $(http.stream)"
         close(http.stream)
+        # Error if Message is not complete...
+        incomplete(http) && throw(EOFError())
     else
 
         # Discard body bytes that were not read...

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -303,21 +303,10 @@ function Base.unsafe_read(http::Stream, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
-Base.readbytes!(http::Stream, buf::Base.BufferStream, n=bytesavailable(http)) = Base.readbytes!(http, buf.buffer, n)
-
 function Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))
     Base.ensureroom(buf, n)
     unsafe_read(http, pointer(buf.data, buf.size + 1), n)
     buf.size += n
-end
-
-# used in julia v1.0
-function Base.readbytes!(http::Stream, buf::IOStream, n=bytesavailable(http))
-    nread = 0
-    while nread < n
-        nread += write(buf, readavailable(http, n - nread))
-    end
-    nread
 end
 
 function Base.read(http::Stream)


### PR DESCRIPTION
- Reverts #778 (flawed.. this approach is cleaner)
- ~~Implements an `EOFError` throw if the `Base.eof(http::Stream)` method itself detects that eof has been reached before a promised `content-length` response has been delivered. That allows the existing `Base.write` methods to be used, so apart from the revert, the code change is much more minimal and general~~
- Fixes the `closeread` `iscomplete` check and EOFError throw to detect incomplete responses, which involves exposing if `closewrite` or `closeread` throw an EOFError, which was suppressed in https://github.com/JuliaWeb/HTTP.jl/pull/529

Should probably not be squash-merged, to keep the revert separate

Closes #780 


