### PR TITLE
[BREAKING]: Remove client support for pipelined requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 IniFile = "0.5"
 MbedTLS = "0.6.8, 0.7, 1"
 URIs = "1.3"
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/docs/src/internal_interface.md
+++ b/docs/src/internal_interface.md
@@ -55,11 +55,10 @@ HTTP.Streams.isaborted
 
 ```@docs
 HTTP.ConnectionPool.Connection
-HTTP.ConnectionPool.Transaction
-HTTP.ConnectionPool.getconnection
+HTTP.ConnectionPool.newconnection
 HTTP.ConnectionPool.POOL
-HTTP.IOExtras.startwrite(::HTTP.ConnectionPool.Transaction)
-HTTP.IOExtras.closewrite(::HTTP.ConnectionPool.Transaction)
-HTTP.IOExtras.startread(::HTTP.ConnectionPool.Transaction)
-HTTP.IOExtras.closeread(::HTTP.ConnectionPool.Transaction)
+HTTP.IOExtras.startwrite(::HTTP.ConnectionPool.Connection)
+HTTP.IOExtras.closewrite(::HTTP.ConnectionPool.Connection)
+HTTP.IOExtras.startread(::HTTP.ConnectionPool.Connection)
+HTTP.IOExtras.closeread(::HTTP.ConnectionPool.Connection)
 ```

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -25,7 +25,7 @@ and `closewrite`, with corresponding `startread` and `closeread`.
 module ConnectionPool
 
 export Connection, Transaction,
-       getconnection, getrawstream, inactiveseconds
+       newconnection, getrawstream, inactiveseconds
 
 using ..IOExtras, ..Sockets
 
@@ -37,6 +37,9 @@ import NetworkOptions
 const default_connection_limit = 8
 const default_pipeline_limit = 16
 const nolimit = typemax(Int)
+
+include("connectionpools.jl")
+using .ConnectionPools
 
 # certain operations, like locking Channels and Conditions
 # is only supported in >= 1.3
@@ -64,7 +67,6 @@ A `TCPSocket` or `SSLContext` connection to a HTTP `host` and `port`.
 Fields:
 - `host::String`
 - `port::String`, exactly as specified in the URI (i.e. may be empty).
-- `pipeline_limit`, number of requests to send before waiting for responses.
 - `idle_timeout`, No. of seconds to maintain connection after last transaction.
 - `peerip`, remote IP adress (used for debug/log messages).
 - `peerport`, remote TCP port number (used for debug/log messages).
@@ -74,37 +76,20 @@ Fields:
 - `buffer::IOBuffer`, left over bytes read from the connection after
    the end of a response header (or chunksize). These bytes are usually
    part of the response body.
-- `sequence`, number of most recent `Transaction`.
-- `writecount`, number of Messages that have been written, protected by `writelock`
-- `writelock`, lock writecount and writebusy, and signal that `writecount` was incremented.
-- `writebusy`, whether a Transaction currently holds the Connection write lock, protected by `writelock`
-- `readcount`, number of Messages that have been read, protected by `readlock`
-- `readlock`, lock readcount and readbusy, and signal that `readcount` was incremented.
-- `readbusy`, whether a Transaction currently holds the Connection read lock, protectecd by `readlock`
 - `timestamp`, time data was last received.
 """
-mutable struct Connection{T <: IO}
+mutable struct Connection
     host::String
     port::String
-    pipeline_limit::Int
     idle_timeout::Int
     require_ssl_verification::Bool
     peerip::IPAddr # for debugging/logging
     peerport::UInt16 # for debugging/logging
     localport::UInt16 # debug only
-    io::T
+    io::IO
     clientconnection::Bool
     buffer::IOBuffer
-    sequence::Threads.Atomic{Int}
-    writecount::Int
-    writelock::Cond # protects the writecount and writebusy fields, notifies on closewrite
-    writebusy::Bool
-    readcount::Int
-    readlock::Cond # protects the readcount and readbusy fields, notifies on closeread
-    readbusy::Bool
     timestamp::Float64
-    closelock::ReentrantLock
-    closed::Bool
 end
 
 """
@@ -112,50 +97,44 @@ end
 
 Used for "hashing" a Connection object on just the key properties necessary for determining
 connection re-useability. That is, when a new request calls `getconnection`, we take the
-request parameters of what socket type, the host and port, any pipeline_limit and if ssl
+request parameters of what socket type, the host and port, and if ssl
 verification is required, and if an existing Connection was already created with the exact
 same parameters, we can re-use it (as long as it's not already being used, obviously).
 """
 function hashconn end
 
-hashconn(x::Connection{T}) where {T} = hashconn(T, x.host, x.port, x.pipeline_limit, x.require_ssl_verification, x.clientconnection)
-hashconn(T, host, port, pipeline_limit, require_ssl_verification, client) = hash(T, hash(host, hash(port, hash(pipeline_limit, hash(require_ssl_verification, hash(client, UInt(0)))))))
+hashconn(x::Connection) = hashconn(typeof(x.io), x.host, x.port, x.require_ssl_verification, x.clientconnection)
+hashconn(T, host, port, require_ssl_verification, client) = hash(T, hash(host, hash(port, hash(require_ssl_verification, hash(client, UInt(0))))))
+
+@enum TransactionState Pre Busy Post
 
 """
     Transaction
 
-A single pipelined HTTP Request/Response transaction.
+A single HTTP Request/Response transaction.
 
 Fields:
  - `c`, the shared [`Connection`](@ref) used for this `Transaction`.
- - `sequence::Int`, identifies this `Transaction` among the others that share `c`.
- - `writebusy::Bool`, whether this Transaction holds its parent Connection write lock, protected by c.writelock
- - `readbusy::Bool`, whether this Transaction holds its parent Connection read lock, protected by c.readlock
 """
-mutable struct Transaction{T <: IO} <: IO
-    c::Connection{T}
-    sequence::Int
-    writebusy::Bool
-    readbusy::Bool
+mutable struct Transaction <: IO
+    c::Connection
+    writestate::TransactionState
+    readstate::TransactionState
 end
 
 Connection(host::AbstractString, port::AbstractString,
-           pipeline_limit::Int, idle_timeout::Int,
-           require_ssl_verification::Bool, io::T, client=true) where T <: IO =
-    Connection{T}(host, port,
-                  pipeline_limit, idle_timeout,
+           idle_timeout::Int,
+           require_ssl_verification::Bool, io::IO, client=true) =
+    Connection(host, port,
+                  idle_timeout,
                   require_ssl_verification,
                   safe_getpeername(io)..., localport(io),
-                  io, client, PipeBuffer(), Threads.Atomic{Int}(0),
-                  0, Cond(), false,
-                  0, Cond(), false,
-                  time(), ReentrantLock(), false)
+                  io, client, PipeBuffer(), time())
 
 Connection(io; require_ssl_verification::Bool=true) =
-    Connection("", "", default_pipeline_limit, 0, require_ssl_verification, io, false)
+    Connection("", "", 0, require_ssl_verification, io, false)
 
-Transaction(c::Connection{T}) where T <: IO =
-    Transaction{T}(c, (Threads.atomic_add!(c.sequence, 1)), false, false)
+Transaction(c::Connection) = Transaction(c, Pre, Pre)
 
 function client_transaction(c)
     t = Transaction(c)
@@ -175,18 +154,7 @@ Base.unsafe_write(t::Transaction, p::Ptr{UInt8}, n::UInt) =
     unsafe_write(t.c.io, p, n)
 
 Base.isopen(c::Connection) = isopen(c.io)
-
-Base.isopen(t::Transaction) = isopen(t.c) &&
-                              readcount(t.c) <= t.sequence &&
-                              writecount(t.c) <= t.sequence
-
-writebusy(c::Connection) = @v1_3 lock(() -> c.writebusy, c.writelock) c.writebusy
-writecount(c::Connection) = @v1_3 lock(() -> c.writecount, c.writelock) c.writecount
-readbusy(c::Connection) = @v1_3 lock(() -> c.readbusy, c.readlock) c.readbusy
-readcount(c::Connection) = @v1_3 lock(() -> c.readcount, c.readlock) c.readcount
-
-writebusy(t::Transaction) = @v1_3 lock(() -> t.writebusy, t.c.writelock) t.writebusy
-readbusy(t::Transaction) = @v1_3 lock(() -> t.readbusy, t.c.readlock) t.readbusy
+Base.isopen(t::Transaction) = isopen(t.c)
 
 """
     flush(c::Connection)
@@ -208,12 +176,6 @@ function Base.flush(c::Connection)
     end
 end
 
-"""
-Is `c` currently in use or expecting a response to request already sent?
-"""
-isbusy(c::Connection) = isopen(c) && (writebusy(c) || readbusy(c) ||
-                                      writecount(c) > readcount(c))
-
 function Base.eof(t::Transaction)
     @require isreadable(t) || !isopen(t)
     if bytesavailable(t) > 0
@@ -226,8 +188,8 @@ Base.bytesavailable(t::Transaction) = bytesavailable(t.c)
 Base.bytesavailable(c::Connection) = bytesavailable(c.buffer) +
                                      bytesavailable(c.io)
 
-Base.isreadable(t::Transaction) = readbusy(t)
-Base.iswritable(t::Transaction) = writebusy(t)
+Base.isreadable(t::Transaction) = t.readstate == Busy
+Base.iswritable(t::Transaction) = t.writestate == Busy
 
 function Base.read(t::Transaction, nb::Int)
     nb = min(nb, bytesavailable(t))
@@ -305,22 +267,12 @@ end
 Wait for prior pending writes to complete.
 """
 function IOExtras.startwrite(t::Transaction)
-    @require !iswritable(t)
-
-    @v1_3 lock(t.c.writelock)
-    try
-        while writecount(t.c) != t.sequence
-            @debug 1 "⏳  Wait write: $t"
-            wait(t.c.writelock)
-        end
-        t.writebusy = true
-        t.c.writebusy = true
-        @ensure iswritable(t)
-        @debug 2 "👁  Start write:$t"
-    finally
-        @v1_3 unlock(t.c.writelock)
+    @require t.writestate == Pre
+    while bytesavailable(t.c.io) > 0
+        readavailable(t.c.io)
     end
-
+    t.writestate = Busy
+    @debug 2 "👁  Start write:$t"
     return
 end
 
@@ -331,46 +283,20 @@ Signal that an entire Request Message has been written to the `Transaction`.
 """
 function IOExtras.closewrite(t::Transaction)
     @require iswritable(t)
-
-    @v1_3 lock(t.c.writelock)
-    try
-        t.writebusy = false
-        t.c.writecount += 1          ;@debug 2 "🗣  Write done: $t"
-        t.c.writebusy = false
-        notify(t.c.writelock)
-        @ensure !iswritable(t)
-    finally
-        @v1_3 unlock(t.c.writelock)
-    end
+    t.writestate = Post
+    @debug 2 "🗣  Write done: $t"
     flush(t.c)
-    release(t.c)
-
     return
 end
 
 """
     startread(::Transaction)
-
-Wait for prior pending reads to complete.
 """
 function IOExtras.startread(t::Transaction)
-    @require !isreadable(t)
-
+    @require t.readstate == Pre
     t.c.timestamp = time()
-    @v1_3 lock(t.c.readlock)
-    try
-        while readcount(t.c) != t.sequence
-            @debug 1 "⏳  Wait read: $t"
-            wait(t.c.readlock)
-        end
-        t.readbusy = true
-        t.c.readbusy = true
-        @debug 2 "👁  Start read: $t"
-        @ensure isreadable(t)
-    finally
-        @v1_3 unlock(t.c.readlock)
-    end
-
+    t.readstate = Busy
+    @debug 2 "👁  Start read: $t"
     return
 end
 
@@ -378,46 +304,31 @@ end
     closeread(::Transaction)
 
 Signal that an entire Response Message has been read from the `Transaction`.
-
-Increment `readcount` and wake up tasks waiting in `startread`.
 """
 function IOExtras.closeread(t::Transaction)
-    @require isreadable(t)
-
-    @v1_3 lock(t.c.readlock)
-    try
-        t.readbusy = false
-        t.c.readcount += 1         ;@debug 2 "✉️  Read done:  $t"
-        t.c.readbusy = false
-        notify(t.c.readlock)
-        @ensure !isreadable(t)
-        if !isbusy(t.c)
-            @async monitor_idle_connection(t.c)
-        end
-    finally
-        @v1_3 unlock(t.c.readlock)
-    end
-    release(t.c)
-
+    @require t.readstate == Busy
+    t.readstate = Post
+    @debug 2 "✉️  Read done:  $t"
+    t.c.clientconnection && release(POOL, hashconn(t.c), t.c)
     return
 end
 
-"""
-Wait for `c` to receive data or reach EOF.
-Close `c` on EOF or if response data arrives when no request was sent.
-"""
-function monitor_idle_connection(c::Connection)
-    if eof(c.io)                                  ;@debug 2 "💀  Closed:     $c"
-        close(c.io)
-    elseif !isbusy(c)                             ;@debug 1 "😈  Idle RX!!:  $c"
-        close(c.io)
-    end
-end
+# """
+# Wait for `c` to receive data or reach EOF.
+# Close `c` on EOF or if response data arrives when no request was sent.
+# """
+# function monitor_idle_connection(c::Connection)
+#     if eof(c.io)                                  ;@debug 2 "💀  Closed:     $c"
+#         close(c.io)
+#     elseif !isbusy(c)                             ;@debug 1 "😈  Idle RX!!:  $c"
+#         close(c.io)
+#     end
+# end
 
-function monitor_idle_connection(c::Connection{SSLContext})
-    # MbedTLS.jl monitors idle connections for TLS close_notify messages.
-    # https://github.com/JuliaWeb/MbedTLS.jl/pull/145
-end
+# function monitor_idle_connection(c::Connection{SSLContext})
+#     # MbedTLS.jl monitors idle connections for TLS close_notify messages.
+#     # https://github.com/JuliaWeb/MbedTLS.jl/pull/145
+# end
 
 Base.wait_close(t::Transaction) = Base.wait_close(tcpsocket(t.c.io))
 
@@ -461,68 +372,8 @@ end
 Close all connections in `pool`.
 """
 function closeall()
-    lock(POOL.lock) do
-        for pod in values(POOL.conns)
-            @v1_3 lock(pod.conns)
-            while isready(pod.conns)
-                close(take!(pod.conns))
-            end
-            pod.numactive = 0
-            @v1_3 unlock(pod.conns)
-        end
-    end
+    ConnectionPools.reset!(POOL)
     return
-end
-
-mutable struct Pod
-    conns::Channel{Connection}
-    numactive::Int
-end
-
-Pod() = Pod(Channel{Connection}(Inf), 0)
-
-function decr!(pod::Pod)
-    @v1_3 @assert islocked(pod.conns.cond_take)
-    pod.numactive -= 1
-    return
-end
-
-function incr!(pod::Pod)
-    @v1_3 @assert islocked(pod.conns.cond_take)
-    pod.numactive += 1
-    return
-end
-
-
-function release(c::Connection)
-    h = hashconn(c)
-    if haskey(POOL.conns, h)
-        pod = getpod(POOL, h)
-        @debug 2 "returning connection to pod: $c"
-        put!(pod.conns, c)
-    end
-    return
-end
-
-# "release" a Connection, without returning to pod for re-use
-# used for https proxy tunnel upgrades which shouldn't be reused
-function kill!(c::Connection)
-    h = hashconn(c)
-    if haskey(POOL.conns, h)
-        pod = getpod(POOL, h)
-        @v1_3 lock(pod.conns)
-        try
-            decr!(pod)
-        finally
-            @v1_3 unlock(pod.conns)
-        end
-    end
-    return
-end
-
-struct Pool
-    lock::ReentrantLock
-    conns::Dict{UInt, Pod}
 end
 
 """
@@ -530,13 +381,7 @@ end
 
 Global connection pool keeping track of active connections.
 """
-const POOL = Pool(ReentrantLock(), Dict{UInt, Pod}())
-
-function getpod(pool::Pool, x)
-    lock(pool.lock) do
-        get!(() -> Pod(), pool.conns, x)
-    end
-end
+const POOL = Pool(Connection)
 
 """
     getconnection(type, host, port) -> Connection
@@ -544,7 +389,7 @@ end
 Find a reusable `Connection` in the `pool`,
 or create a new `Connection` if required.
 """
-function getconnection(::Type{Transaction{T}},
+function newconnection(::Type{T},
                        host::AbstractString,
                        port::AbstractString;
                        connection_limit::Int=default_connection_limit,
@@ -552,83 +397,20 @@ function getconnection(::Type{Transaction{T}},
                        idle_timeout::Int=0,
                        reuse_limit::Int=nolimit,
                        require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
-                       kw...)::Transaction{T} where T <: IO
-    pod = getpod(POOL, hashconn(T, host, port, pipeline_limit, require_ssl_verification, true))
-    @v1_3 lock(pod.conns)
-    try
-        while isready(pod.conns)
-            conn = take!(pod.conns)
-            if isvalid(pod, conn, reuse_limit, pipeline_limit)
-                # this is a reuseable connection, so use it
-                @debug 2 "1 reusing connection: $conn"
-                return client_transaction(conn)
-            end
-        end
-        # If there are not too many connections to this host:port,
-        # create a new connection...
-        if pod.numactive < connection_limit
-            return newconnection(pod, T, host, port, pipeline_limit,
-                require_ssl_verification, idle_timeout; kw...)
-        end
-        # wait for a Connection to be released
-        while true
-            conn = take!(pod.conns)
-            if isvalid(pod, conn, reuse_limit, pipeline_limit)
-                # this is a reuseable connection, so use it
-                @debug 2 "2 reusing connection: $conn"
-                return client_transaction(conn)
-            elseif pod.numactive < connection_limit
-                return newconnection(pod, T, host, port, pipeline_limit,
-                    require_ssl_verification, idle_timeout; kw...)
-            end
-        end
-    finally
-        @v1_3 unlock(pod.conns)
+                       kw...)::Transaction where {T <: IO}
+    conn = acquire(
+            POOL,
+            hashconn(T, host, port, require_ssl_verification, true);
+            max=connection_limit,
+            idle=idle_timeout,
+            reuse=reuse_limit) do
+        Connection(host, port,
+            idle_timeout, require_ssl_verification,
+            getconnection(T, host, port;
+                require_ssl_verification=require_ssl_verification, kw...)
+        )
     end
-end
-
-function isvalid(pod, conn, reuse_limit, pipeline_limit)
-    # Close connections that have reached the reuse limit...
-    if reuse_limit != nolimit
-        if readcount(conn) >= reuse_limit && !readbusy(conn)
-            @debug 2 "💀 overuse:         $conn"
-            close(conn.io)
-        end
-    end
-    # Close connections that have reached the timeout limit...
-    if conn.idle_timeout > 0
-        if !isbusy(conn) && inactiveseconds(conn) > conn.idle_timeout
-            @debug 2 "💀 idle timeout:    $conn"
-            close(conn.io)
-        end
-    end
-    # For closed connections, we decrease active count in pod, and "continue"
-    # which effectively drops the connection
-    if !isopen(conn.io)
-        close(conn)
-        lock(conn.closelock) do
-            if !conn.closed
-                conn.closed = true
-                decr!(pod)
-            end
-        end
-        return false
-    end
-    # If we've hit our pipeline_limit, can't use this one, but don't close
-    if (writecount(conn) - readcount(conn)) >= pipeline_limit + 1
-        return false
-    end
-
-    return !writebusy(conn)
-end
-
-function newconnection(pod, T, host, port, pipeline_limit, require_ssl_verification, idle_timeout; kw...)
-    io = getconnection(T, host, port;
-            require_ssl_verification=require_ssl_verification, kw...)
-    c = Connection(host, port, pipeline_limit, idle_timeout, require_ssl_verification, io)
-    incr!(pod)
-    @debug 1 "🔗  New:            $c"
-    return client_transaction(c)
+    return client_transaction(conn)
 end
 
 function keepalive!(tcp)
@@ -746,15 +528,19 @@ function sslconnection(tcp::TCPSocket, host::AbstractString;
     return io
 end
 
-function sslupgrade(t::Transaction{TCPSocket},
+function sslupgrade(t::Transaction,
                     host::AbstractString;
                     require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
-                    kw...)::Transaction{SSLContext}
+                    kw...)::Transaction
+    # first we release the original connection, but we don't want it to be
+    # reused in the pool, because we're hijacking the TCPSocket
+    release(POOL, hashconn(t.c), t.c; return_for_reuse=false)
+    # now we hijack the TCPSocket and upgrade to SSLContext
     tls = sslconnection(t.c.io, host;
                         require_ssl_verification=require_ssl_verification,
                         kw...)
-    c = Connection(tls; require_ssl_verification=require_ssl_verification)
-    kill!(t.c)
+    conn = Connection(host, "", 0, require_ssl_verification, tls)
+    c = acquire(() -> conn, POOL, hashconn(conn))
     return client_transaction(c)
 end
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -333,9 +333,9 @@ function newconnection(::Type{T},
     return acquire(
             POOL,
             hashconn(T, host, port, require_ssl_verification, true);
-            max=connection_limit,
-            idle=idle_timeout,
-            reuse=reuse_limit) do
+            max=Int(connection_limit),
+            idle=Int(idle_timeout),
+            reuse=Int(reuse_limit)) do
         Connection(host, port,
             idle_timeout, require_ssl_verification,
             getconnection(T, host, port;

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -326,7 +326,7 @@ function newconnection(::Type{T},
                        port::AbstractString;
                        connection_limit=default_connection_limit,
                        pipeline_limit=default_pipeline_limit,
-                       idle_timeout=typemax(Int64),
+                       idle_timeout=typemax(Int),
                        reuse_limit=nolimit,
                        require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
                        kw...)::Connection where {T <: IO}

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -62,8 +62,7 @@ export ConnectionPoolLayer
 
 function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
                  proxy=getproxy(url.scheme, url.host),
-                 socket_type::Type=TCPSocket,
-                 reuse_limit::Int=ConnectionPool.nolimit, kw...) where Next
+                 socket_type::Type=TCPSocket, kw...) where Next
 
     if proxy !== nothing
         target_url = url
@@ -82,8 +81,7 @@ function request(::Type{ConnectionPoolLayer{Next}}, url::URI, req, body;
     IOType = sockettype(url, socket_type)
     local io
     try
-        io = newconnection(IOType, url.host, url.port;
-                           reuse_limit=reuse_limit, kw...)
+        io = newconnection(IOType, url.host, url.port; kw...)
     catch e
         rethrow(isioerror(e) ? IOError(e, "during request($url)") : e)
     end

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -548,7 +548,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 │┌───────────────────────────║────────┼──║────────────────────────────────────┐
 └▶ HTTP.ConnectionPool       ║        │  ║                                    │
  │                     ┌──────────────▼────────┐ ┌───────────────────────┐    │
- │ getconnection() ->  │ HTTP.Transaction <:IO │ │ HTTP.Transaction <:IO │    │
+ │ getconnection() ->  │ HTTP.Connection <:IO │ │ HTTP.Connection <:IO │    │
  │                     └───────────────────────┘ └───────────────────────┘    │
  │                           ║    ╲│╱    ║                  ╲│╱               │
  │                           ║     │     ║                   │                │

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -6,7 +6,7 @@ export startwrite, startread, closewrite, closeread, stack, insert, insert_defau
     RetryLayer, StreamLayer, TimeoutLayer, TopLayer,
     @logfmt_str, common_logfmt, combined_logfmt
 
-const DEBUG_LEVEL = Ref(2)
+const DEBUG_LEVEL = Ref(0)
 
 Base.@deprecate escape escapeuri
 

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -114,9 +114,6 @@ Connection Pool options
  - `connect_timeout = 0`, close the connection after this many seconds if it
    is still attempting to connect. Use `connect_timeout = 0` to disable.
  - `connection_limit = 8`, number of concurrent connections to each host:port.
- - `pipeline_limit = 16`, number of concurrent requests per connection.
- - `reuse_limit = nolimit`, number of times a connection is reused after the
-                            first request.
  - `socket_type = TCPSocket`
 
 
@@ -548,7 +545,7 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 │┌───────────────────────────║────────┼──║────────────────────────────────────┐
 └▶ HTTP.ConnectionPool       ║        │  ║                                    │
  │                     ┌──────────────▼────────┐ ┌───────────────────────┐    │
- │ getconnection() ->  │ HTTP.Connection <:IO │ │ HTTP.Connection <:IO │    │
+ │ getconnection() ->  │ HTTP.Connection  <:IO │ │ HTTP.Connection  <:IO │    │
  │                     └───────────────────────┘ └───────────────────────┘    │
  │                           ║    ╲│╱    ║                  ╲│╱               │
  │                           ║     │     ║                   │                │

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -6,7 +6,7 @@ export startwrite, startread, closewrite, closeread, stack, insert, insert_defau
     RetryLayer, StreamLayer, TimeoutLayer, TopLayer,
     @logfmt_str, common_logfmt, combined_logfmt
 
-const DEBUG_LEVEL = Ref(0)
+const DEBUG_LEVEL = Ref(2)
 
 Base.@deprecate escape escapeuri
 
@@ -613,14 +613,14 @@ include("Handlers.jl")                 ;using .Handlers; using .Handlers: serve
 include("parsemultipart.jl")           ;using .MultiPartParsing: parse_multipart_form
 include("WebSockets.jl")               ;using .WebSockets
 
-import .ConnectionPool: Transaction, Connection
+import .ConnectionPool: Connection
 
 function Base.parse(::Type{T}, str::AbstractString)::T where T <: Message
     buffer = Base.BufferStream()
     write(buffer, str)
     close(buffer)
     m = T()
-    http = Stream(m, Transaction(Connection(buffer)))
+    http = Stream(m, Connection(buffer))
     m.body = read(http)
     closeread(http)
     return m

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -331,9 +331,10 @@ end
 
 """
 Start a `check_readtimeout` task to close the `Connection` if it is inactive.
-Create a `Transaction` object for each HTTP Request received.
+Passes the `Connection` object to handle a single request/response transaction
+for each HTTP Request received.
 After `reuse_limit + 1` transactions, signal `final_transaction` to the
-transaction handler.
+transaction handler, which will close the connection.
 """
 function handle_connection(f, c::Connection, server, reuse_limit, readtimeout)
     if readtimeout > 0
@@ -376,7 +377,7 @@ function check_readtimeout(c, readtimeout, wait_for_timeout)
 end
 
 """
-Create a `HTTP.Stream` and parse the Request headers from a `HTTP.Transaction`
+Create a `HTTP.Stream` and parse the Request headers from a `HTTP.Connection`
 (by calling `startread(::Stream`).
 If there is a parse error, send an error Response.
 Otherwise, execute stream processing function `f`.

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -411,9 +411,8 @@ function handle_transaction(f, c::Connection, server; final_transaction::Bool=fa
         setheader(request.response, "Connection" => "close")
     end
 
-    @async try
+    try
         f(http)
-
         # If `startwrite()` was never called, throw an error so we send a 500 and log this
         if isopen(http) && !iswritable(http)
             error("Server never wrote a response")
@@ -437,7 +436,7 @@ function handle_transaction(f, c::Connection, server; final_transaction::Bool=fa
         final_transaction = true
     finally
         if server.access_log !== nothing
-            try @info sprint(server.access_log, http) _group=:access; catch end
+            try; @info sprint(server.access_log, http) _group=:access; catch; end
         end
         final_transaction && close(c.io)
     end

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -43,26 +43,18 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
         end
     end
 
-    if !isidempotent(req)
-        # Wait for pipelined reads to complete
-        # before sending non-idempotent request body.
-        @debug 2 "non-idempotent client startread"
-        startread(io)
-    end
-
-    aborted = false
     write_error = nothing
     try
-
         @sync begin
             if iofunction === nothing
                 @async try
                     writebody(http, req, body)
+                    @debug 2 "client closewrite"
+                    closewrite(http)
                 catch e
                     write_error = e
                     isopen(io) && try; close(io); catch; end
                 end
-                yield()
                 @debug 2 "client startread"
                 startread(http)
                 readbody(http, response, response_stream, reached_redirect_limit)
@@ -74,10 +66,8 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
                 # The server may have closed the connection.
                 # Don't propagate such errors.
                 try; close(io); catch; end
-                aborted = true
             end
         end
-
     catch e
         if write_error !== nothing
             throw(write_error)
@@ -86,15 +76,10 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
         end
     end
 
-    # Suppress errors from closing
-    try
-        @debug 2 "client closewrite"
-        closewrite(http)
-        @debug 2 "client closeread"
-        closeread(http)
-    catch e
-        e isa EOFError && rethrow()
-    end
+    @debug 2 "client closewrite"
+    closewrite(http)
+    @debug 2 "client closeread"
+    closeread(http)
 
     verbose == 1 && printlncompact(response)
     verbose == 2 && println(response)
@@ -112,18 +97,7 @@ function writebody(http::Stream, req::Request, body)
     end
 
     req.txcount += 1
-
-    if isidempotent(req)
-        @debug 2 "client closewrite"
-        closewrite(http)
-    else
-        @debug 2 "🔒  $(req.method) non-idempotent, " *
-                 "holding write lock: $(http.stream)"
-        # "A user agent SHOULD NOT pipeline requests after a
-        #  non-idempotent method, until the final response
-        #  status code for that method has been received"
-        # https://tools.ietf.org/html/rfc7230#section-6.3.2
-    end
+    return
 end
 
 function writebodystream(http, req, body)

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -33,22 +33,17 @@ Creates a `HTTP.Stream` that wraps an existing `IO` stream.
  - `startwrite(::Stream)` sends the `Request` headers to the `IO` stream.
  - `write(::Stream, body)` sends the `body` (or a chunk of the body).
  - `closewrite(::Stream)` sends the final `0` chunk (if needed) and calls
-   `closewrite` on the `IO` stream. When the `IO` stream is a
-   [`HTTP.ConnectionPool.Transaction`](@ref), calling `closewrite` releases
-   the [`HTTP.ConnectionPool.Connection`](@ref) back into the pool for use by the
-   next pipelined request.
+   `closewrite` on the `IO` stream.
 
  - `startread(::Stream)` calls `startread` on the `IO` stream then
-    reads and parses the `Response` headers.  When the `IO` stream is a
-   [`HTTP.ConnectionPool.Transaction`](@ref), calling `startread` waits for other
-   pipelined responses to be read from the [`HTTP.ConnectionPool.Connection`](@ref).
+    reads and parses the `Response` headers.
  - `eof(::Stream)` and `readavailable(::Stream)` parse the body from the `IO`
     stream.
  - `closeread(::Stream)` reads the trailers and calls `closeread` on the `IO`
-    stream.  When the `IO` stream is a [`HTTP.ConnectionPool.Transaction`](@ref),
-    calling `closeread` releases the readlock and allows the next pipelined
-    response to be read by another `Stream` that is waiting in `startread`.
-    If a complete response has not been received, `closeread` throws `EOFError`.
+    stream.  When the `IO` stream is a [`HTTP.ConnectionPool.Connection`](@ref),
+    calling `closeread` releases the connection back to the connection pool
+    for reuse. If a complete response has not been received, `closeread` throws
+    `EOFError`.
 """
 Stream(r::M, io::S) where {M, S} = Stream{M,S}(r, io, false, false, true, 0, 0)
 

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -102,7 +102,7 @@ function open(f::Function, url; binary=false, verbose=false, headers = [], kw...
     ]
 
     HTTP.open("GET", url, headers;
-              reuse_limit=0, verbose=verbose ? 2 : 0, kw...) do http
+              verbose=verbose ? 2 : 0, kw...) do http
 
         startread(http)
 

--- a/src/access_log.jl
+++ b/src/access_log.jl
@@ -65,9 +65,9 @@ function symbol_mapping(s::Symbol)
         hdr = replace(String(m[1]), '_' => '-')
         :(HTTP.header(http.message.response, $hdr, "-"))
     elseif s === :remote_addr
-        :(http.stream.c.peerip)
+        :(http.stream.peerip)
     elseif s === :remote_port
-        :(http.stream.c.peerport)
+        :(http.stream.peerport)
     elseif s === :remote_user
         :("-") # TODO: find from Basic auth...
     elseif s === :time_iso8601

--- a/src/connectionpools.jl
+++ b/src/connectionpools.jl
@@ -1,0 +1,233 @@
+module ConnectionPools
+
+export Pod, Pool, acquire, release
+
+import Base: acquire, release
+
+connectionid(x) = objectid(x)
+
+"""
+    ConnectionTracker(conn::T)
+
+Wraps a `Connection` of type `T`.
+A `Connection` object must support the following interface:
+  * `isopen(x)`: check if a `Connection` object is still open and can be used
+  * `close(x)`: close a `Connection` object; `isopen(x)` should return false after calling `close`
+  * `ConnectionPools.connectionid(x)`: optional method to distinguish `Connection` objects from each other; by default, calls `objectid(x)`, which is valid for `mutable struct` objects
+
+The `idle` field is a timestamp to track when a `Connection` was returned to a `Pod` and became idle.
+
+The `count` field keeps track of how many times the connection has been used.
+"""
+mutable struct ConnectionTracker{T}
+    conn::T
+    idle::Float64
+    count::Int
+end
+
+ConnectionTracker(conn::T) where {T} = ConnectionTracker(conn, time(), 1)
+
+"""
+    Pod(T; max::Int, idle::Int, reuse::Int)
+
+A threadsafe object for managing a pool of and the reuse of `Connection` objects (see [`ConnectionTracker`](@ref)).
+
+A Pod manages a collection of `Connection`s and the following keyword arguments allow configuring the management thereof:
+
+  * `max::Int=typemax(Int64)`: controls the max # of currently acquired `Connection`s allowed
+  * `idle::Int=typemax(Int64)`: controls the max # of seconds a `Connection` may be idle before it should be closed and not reused
+  * `reuse::Int=typemax(Int64)`: controls the max # of times a `Connection` may be reused before it should be closed
+
+After creating a `Pod`, `Connection`s can be acquired by calling [`acquire`](@ref) and MUST
+be subsequently released by calling [`release`](@ref).
+"""
+struct Pod{T}
+    # this lock/condition protects the `conns` Vector and `active` Dict
+    # no changes to either field should be made without holding this lock
+    lock::Threads.Condition
+    conns::Vector{ConnectionTracker{T}}
+    active::Dict{Any, ConnectionTracker{T}}
+    max::Int
+    idle::Int
+    reuse::Int
+end
+
+const MAX = typemax(Int64)
+
+function Pod(T; max::Int=MAX, idle::Int=MAX, reuse::Int=MAX)
+    return Pod(Threads.Condition(), ConnectionTracker{T}[], Dict{Any, ConnectionTracker{T}}(), max, idle, reuse)
+end
+
+# check if an idle `Connection` is still valid to be reused
+function isvalid(pod::Pod{C}, conn::ConnectionTracker{C}) where {C}
+    if (time() - conn.idle) > pod.idle
+        # if the connection has been idle too long, close it
+        close(conn.conn)
+    elseif conn.count >= pod.reuse
+        # if the connection has been used too many times, close it
+        close(conn.conn)
+    elseif isopen(conn.conn)
+        # otherwise, if the connection is open, this is a valid connection we can use!
+        return true
+    end
+    return false
+end
+
+"""
+    acquire(f, pod::Pod{C}) -> C
+
+Check first for existing `Connection`s in a `Pod` still valid to reuse,
+and if so, return one. If no existing `Connection` is available for reuse,
+call the provided function `f()`, which must return a new connection instance of type `C`.
+This new connection instance will be tracked by the `Pod` and MUST be returned to the `Pod`
+after use by calling `release(pod, conn)`.
+"""
+function acquire(f, pod::Pod)
+    lock(pod.lock)
+    try
+        # if there are already connections in the pod that have been
+        # returned, let's check if they're still valid and can be used directly
+        while !isempty(pod.conns)
+            # Pod connections are FIFO, so grab the earliest returned connection
+            conn = popfirst!(pod.conns)
+            if isvalid(pod, conn)
+                # connection is valid! increment its usage count
+                # and move the ConnectionTracker to the `active` Dict tracker
+                conn.count += 1
+                pod.active[connectionid(conn.conn)] = conn
+                return conn.conn
+            end
+        end
+        # There were no existing connections able to be reused
+        # If there are not too many already-active connections, create new
+        if length(pod.active) < pod.max
+            conn = ConnectionTracker(f())
+            pod.active[connectionid(conn.conn)] = conn
+            return conn.conn
+        end
+        # If we reach here, there were no valid idle connections and too many
+        # currently-active connections, so we need to wait until a connection
+        # is released back to the Pod
+        while true
+            # this `wait` call will block on our Pod `lock` condition
+            # until a connection is `release`ed and the condition
+            # is notified
+            conn = wait(pod.lock)
+            if conn !== nothing
+                if isvalid(pod, conn)
+                    # connection just returned to the Pod is valid and can be reused
+                    conn.count += 1
+                    pod.active[connectionid(conn.conn)] = conn
+                    return conn.conn
+                end
+            end
+            # if the Connection just returned to the Pod wasn't valid, the active
+            # count at least went down, so we should be able to create a new one
+            if length(pod.active) < pod.max
+                conn = ConnectionTracker(f())
+                pod.active[connectionid(conn.conn)] = conn
+                return conn.conn
+            end
+            # If for some reason there were still too many active connections, let's
+            # start the loop back over waiting for idle connections to be returned
+            # Hey, we get it, writing threadsafe code can be hard
+        end
+    finally
+        unlock(pod.lock)
+    end
+end
+
+function release(pod::Pod{C}, conn::C; return_for_reuse::Bool=true) where {C}
+    lock(pod.lock)
+    try
+        # We first want to look up this connection object in our
+        # Pod `active` Dict that tracks active connections
+        id = connectionid(conn)
+        # if, for some reason, it's not in our `active` tracking Dict
+        # then something is wrong; you're trying to release a `Connection`
+        # that this Pod currently doesn't think is active
+        if !haskey(pod.active, id)
+            error("invalid connection pool release call; each acquired connection should be `release`ed ONLY once")
+        end
+        cp_conn = pod.active[id]
+        # remove the ConnectionTracker from our `active` Dict tracker
+        delete!(pod.active, id)
+        if return_for_reuse
+            # reset the idle timestamp of the ConnectionTracker
+            cp_conn.idle = time()
+            # now we put the connection back in the pod idle queue
+            push!(pod.conns, cp_conn)
+            # and notify our Pod condition that a connection has been returned
+            # in order to "wake up" any `wait`ers looking for a new connection
+            notify(pod.lock, cp_conn)
+        else
+            notify(pod.lock, nothing)
+        end
+    finally
+        unlock(pod.lock)
+    end
+    return
+end
+
+"""
+    Pool(T)
+
+A threadsafe convenience object for managing multiple [`Pod`](@ref)s of connections.
+A `Pod` of reuseable connections will be looked up by the `key` when calling `acquire(f, pool, key)`.
+"""
+struct Pool{C}
+    lock::ReentrantLock
+    pods::Dict{Any, Pod{C}}
+end
+
+Pool(C) = Pool(ReentrantLock(), Dict{Any, Pod{C}}())
+
+"""
+    acquire(f, pool::Pool{C}, key; max::Int, idle::Int, reuse::Int) -> C
+
+Get a connection from a `pool`, looking up a `Pod` of reuseable connections
+by the provided `key`. If no `Pod` exists for the given key yet, one will be
+created and passed the `max`, `idle`, and `reuse` keyword arguments if provided.
+The provided function `f` must create a new connection instance of type `C`.
+The acquired connection MUST be returned to the pool by calling `release(pool, key, conn)` exactly once.
+"""
+function acquire(f, pool::Pool{C}, key; kw...) where {C}
+    pod = lock(pool.lock) do
+        get!(() -> Pod(C; kw...), pool.pods, key)
+    end
+    return acquire(f, pod)
+end
+
+"""
+    release(pool::Pool{C}, key, conn::C)
+
+Return an acquired connection to a `pool` with the same `key` provided when it was acquired.
+"""
+function release(pool::Pool{C}, key, conn::C; kw...) where {C}
+    pod = lock(pool.lock) do
+        pool.pods[key]
+    end
+    release(pod, conn; kw...)
+    return
+end
+
+function reset!(pool::Pool)
+    lock(pool.lock) do
+        for pod in values(pool.pods)
+            lock(pod.lock) do
+                foreach(pod.conns) do conn
+                    close(conn.conn)
+                end
+                empty!(pod.conns)
+                for conn in values(pod.active)
+                    close(conn.conn)
+                end
+                empty!(pod.active)
+            end
+        end
+        empty!(pool.pods)
+    end
+    return
+end
+
+end # module

--- a/src/connectionpools.jl
+++ b/src/connectionpools.jl
@@ -34,9 +34,9 @@ A threadsafe object for managing a pool of and the reuse of `Connection` objects
 
 A Pod manages a collection of `Connection`s and the following keyword arguments allow configuring the management thereof:
 
-  * `max::Int=typemax(Int64)`: controls the max # of currently acquired `Connection`s allowed
-  * `idle::Int=typemax(Int64)`: controls the max # of seconds a `Connection` may be idle before it should be closed and not reused
-  * `reuse::Int=typemax(Int64)`: controls the max # of times a `Connection` may be reused before it should be closed
+  * `max::Int=typemax(Int)`: controls the max # of currently acquired `Connection`s allowed
+  * `idle::Int=typemax(Int)`: controls the max # of seconds a `Connection` may be idle before it should be closed and not reused
+  * `reuse::Int=typemax(Int)`: controls the max # of times a `Connection` may be reused before it should be closed
 
 After creating a `Pod`, `Connection`s can be acquired by calling [`acquire`](@ref) and MUST
 be subsequently released by calling [`release`](@ref).
@@ -52,7 +52,7 @@ struct Pod{T}
     reuse::Int
 end
 
-const MAX = typemax(Int64)
+const MAX = typemax(Int)
 
 function Pod(T; max::Int=MAX, idle::Int=MAX, reuse::Int=MAX)
     return Pod(Threads.Condition(), ConnectionTracker{T}[], Dict{Any, ConnectionTracker{T}}(), max, idle, reuse)

--- a/test/chunking.jl
+++ b/test/chunking.jl
@@ -18,7 +18,7 @@ using BufferedStreams
 
     t = @async HTTP.listen("127.0.0.1", port) do http
         startwrite(http)
-        tcp = http.stream.c.io
+        tcp = http.stream.io
 
         write(tcp, encoded_data[1:split1])
         flush(tcp)

--- a/test/client.jl
+++ b/test/client.jl
@@ -124,26 +124,30 @@ end
 
     @testset "Incomplete response with known content length" begin
         server = Sockets.listen(ip"0.0.0.0", 8080)
-        task = @async HTTP.listen("0.0.0.0", 8080; server=server) do http
-            HTTP.setstatus(http, 200)
-            HTTP.setheader(http, "Content-Length" => "64") # Promise 64 bytes...
-            HTTP.startwrite(http)
-            HTTP.write(http, rand(UInt8, 63)) # ...but only send 63 bytes.
-            # Close the stream so that eof(stream) is true and the client isn't
-            # waiting forever for the last byte.
-            HTTP.close(http.stream)
-        end
+        try
+            task = @async HTTP.listen("0.0.0.0", 8080; server=server) do http
+                HTTP.setstatus(http, 200)
+                HTTP.setheader(http, "Content-Length" => "64") # Promise 64 bytes...
+                HTTP.startwrite(http)
+                HTTP.write(http, rand(UInt8, 63)) # ...but only send 63 bytes.
+                # Close the stream so that eof(stream) is true and the client isn't
+                # waiting forever for the last byte.
+                HTTP.close(http.stream)
+            end
 
-        err = try
-            HTTP.get("http://localhost:8080"; retry=false)
-        catch err
-            err
-        end
-        @test err isa HTTP.IOError
-        @test err.e isa EOFError
+            err = try
+                HTTP.get("http://localhost:8080"; retry=false)
+            catch err
+                err
+            end
+            @test err isa HTTP.IOError
+            @test err.e isa EOFError
 
-        # Shutdown
-        try; close(server); wait(task); catch; end
+        finally
+            # Shutdown
+            try; close(server); wait(task); catch; end
+            HTTP.ConnectionPool.closeall()
+        end
     end
 
     @testset "ASync Client Request Body" begin
@@ -257,50 +261,57 @@ end
     if ip"127.0.0.1" in alladdrs && ip"::1" in alladdrs
         for interface in (IPv4(0), IPv6(0))
             server = listen(interface, 8080)
-            @async HTTP.listen(string(interface), 8080; server=server) do http
-                HTTP.setstatus(http, 200)
-                HTTP.startwrite(http)
-                HTTP.write(http, "hello, world")
+            try
+                @async HTTP.listen(string(interface), 8080; server=server) do http
+                    HTTP.setstatus(http, 200)
+                    HTTP.startwrite(http)
+                    HTTP.write(http, "hello, world")
+                end
+                req = HTTP.get("http://localhost:8080")
+                @test req.status == 200
+                @test String(req.body) == "hello, world"
+            finally
+                close(server)
+                HTTP.ConnectionPool.closeall()
             end
-            req = HTTP.get("http://localhost:8080")
-            close(server)
-            @test req.status == 200
-            @test String(req.body) == "hello, world"
         end
     end
 end
 
 @testset "Sockets.get(sock|peer)name(::HTTP.Stream)" begin
     server = listen(IPv4(0), 8080)
-    @async HTTP.listen("0.0.0.0", 8080; server=server) do http
-        sock = Sockets.getsockname(http)
-        peer = Sockets.getpeername(http)
-        str = sprint() do io
-            print(io, sock[1], ":", sock[2], " - ", peer[1], ":", peer[2])
+    try
+        @async HTTP.listen("0.0.0.0", 8080; server=server) do http
+            sock = Sockets.getsockname(http)
+            peer = Sockets.getpeername(http)
+            str = sprint() do io
+                print(io, sock[1], ":", sock[2], " - ", peer[1], ":", peer[2])
+            end
+            HTTP.setstatus(http, 200)
+            HTTP.setheader(http, "Content-Length" => string(sizeof(str)))
+            HTTP.startwrite(http)
+            HTTP.write(http, str)
         end
-        HTTP.setstatus(http, 200)
-        HTTP.setheader(http, "Content-Length" => string(sizeof(str)))
-        HTTP.startwrite(http)
-        HTTP.write(http, str)
-    end
 
-    # Tests for Stream{TCPSocket}
-    HTTP.open("GET", "http://localhost:8080") do http
-        # Test server peer/sock
-        reg = r"^127\.0\.0\.1:8080 - 127\.0\.0\.1:(\d+)$"
-        m = match(reg, read(http, String))
-        @test m !== nothing
-        server_peerport = parse(Int, m[1])
-        # Test client peer/sock
-        sock = Sockets.getsockname(http)
-        @test sock[1] == ip"127.0.0.1"
-        @test sock[2] == server_peerport
-        peer = Sockets.getpeername(http)
-        @test peer[1] == ip"127.0.0.1"
-        @test peer[2] == 8080
+        # Tests for Stream{TCPSocket}
+        HTTP.open("GET", "http://localhost:8080") do http
+            # Test server peer/sock
+            reg = r"^127\.0\.0\.1:8080 - 127\.0\.0\.1:(\d+)$"
+            m = match(reg, read(http, String))
+            @test m !== nothing
+            server_peerport = parse(Int, m[1])
+            # Test client peer/sock
+            sock = Sockets.getsockname(http)
+            @test sock[1] == ip"127.0.0.1"
+            @test sock[2] == server_peerport
+            peer = Sockets.getpeername(http)
+            @test peer[1] == ip"127.0.0.1"
+            @test peer[2] == 8080
+        end
+    finally
+        close(server)
+        HTTP.ConnectionPool.closeall()
     end
-
-    close(server)
 
     # Tests for Stream{SSLContext}
     HTTP.open("GET", "https://julialang.org") do http
@@ -326,71 +337,79 @@ end
 
 @testset "Implicit request headers" begin
     server = listen(IPv4(0), 8080)
-    tsk = @async HTTP.listen("0.0.0.0", 8080; server=server) do http
-        data = Dict{String,String}(http.message.headers)
-        HTTP.setstatus(http, 200)
-        HTTP.startwrite(http)
-        HTTP.write(http, sprint(JSON.print, data))
-    end
-    old_user_agent = HTTP.MessageRequest.USER_AGENT[]
-    default_user_agent = "HTTP.jl/$VERSION"
-    # Default values
-    HTTP.setuseragent!(default_user_agent)
-    d = JSON.parse(IOBuffer(HTTP.get("http://localhost:8080").body))
-    @test d["Host"] == "localhost:8080"
-    @test d["Accept"] == "*/*"
-    @test d["User-Agent"] == default_user_agent
-    # Overwriting behavior
-    headers = ["Host" => "http.jl", "Accept" => "application/json"]
-    HTTP.setuseragent!("HTTP.jl test")
-    d = JSON.parse(IOBuffer(HTTP.get("http://localhost:8080", headers).body))
-    @test d["Host"] == "http.jl"
-    @test d["Accept"] == "application/json"
-    @test d["User-Agent"] == "HTTP.jl test"
-    # No User-Agent
-    HTTP.setuseragent!(nothing)
-    d = JSON.parse(IOBuffer(HTTP.get("http://localhost:8080").body))
-    @test !haskey(d, "User-Agent")
+    try
+        tsk = @async HTTP.listen("0.0.0.0", 8080; server=server) do http
+            data = Dict{String,String}(http.message.headers)
+            HTTP.setstatus(http, 200)
+            HTTP.startwrite(http)
+            HTTP.write(http, sprint(JSON.print, data))
+        end
+        old_user_agent = HTTP.MessageRequest.USER_AGENT[]
+        default_user_agent = "HTTP.jl/$VERSION"
+        # Default values
+        HTTP.setuseragent!(default_user_agent)
+        d = JSON.parse(IOBuffer(HTTP.get("http://localhost:8080").body))
+        @test d["Host"] == "localhost:8080"
+        @test d["Accept"] == "*/*"
+        @test d["User-Agent"] == default_user_agent
+        # Overwriting behavior
+        headers = ["Host" => "http.jl", "Accept" => "application/json"]
+        HTTP.setuseragent!("HTTP.jl test")
+        d = JSON.parse(IOBuffer(HTTP.get("http://localhost:8080", headers).body))
+        @test d["Host"] == "http.jl"
+        @test d["Accept"] == "application/json"
+        @test d["User-Agent"] == "HTTP.jl test"
+        # No User-Agent
+        HTTP.setuseragent!(nothing)
+        d = JSON.parse(IOBuffer(HTTP.get("http://localhost:8080").body))
+        @test !haskey(d, "User-Agent")
 
-    HTTP.setuseragent!(old_user_agent)
-    close(server)
+        HTTP.setuseragent!(old_user_agent)
+    finally
+        close(server)
+        HTTP.ConnectionPool.closeall()
+    end
 end
 
 import NetworkOptions, MbedTLS
 @testset "NetworkOptions for host verification" begin
     # Set up server with self-signed cert
     server = listen(IPv4(0), 8443)
-    cert, key = joinpath.(@__DIR__, "resources", ("cert.pem", "key.pem"))
-    sslconfig = MbedTLS.SSLConfig(cert, key)
-    tsk = @async HTTP.listen("0.0.0.0", 8443; server=server, sslconfig=sslconfig) do http
-        HTTP.setstatus(http, 200)
-        HTTP.startwrite(http)
-        HTTP.write(http, "hello, world")
+    try
+        cert, key = joinpath.(@__DIR__, "resources", ("cert.pem", "key.pem"))
+        sslconfig = MbedTLS.SSLConfig(cert, key)
+        tsk = @async HTTP.listen("0.0.0.0", 8443; server=server, sslconfig=sslconfig) do http
+            HTTP.setstatus(http, 200)
+            HTTP.startwrite(http)
+            HTTP.write(http, "hello, world")
+        end
+        url = "https://localhost:8443"
+        env = ["JULIA_NO_VERIFY_HOSTS" => nothing, "JULIA_SSL_NO_VERIFY_HOSTS" => nothing, "JULIA_ALWAYS_VERIFY_HOSTS" => nothing]
+        withenv(env...) do
+            @test NetworkOptions.verify_host(url)
+            @test NetworkOptions.verify_host(url, "SSL")
+            @test_throws HTTP.IOError HTTP.get(url; retries=1)
+            @test_throws HTTP.IOError HTTP.get(url; require_ssl_verification=true, retries=1)
+            @test HTTP.get(url; require_ssl_verification=false).status == 200
+        end
+        withenv(env..., "JULIA_NO_VERIFY_HOSTS" => "localhost") do
+            @test !NetworkOptions.verify_host(url)
+            @test !NetworkOptions.verify_host(url, "SSL")
+            @test HTTP.get(url).status == 200
+            @test_throws HTTP.IOError HTTP.get(url; require_ssl_verification=true, retries=1)
+            @test HTTP.get(url; require_ssl_verification=false).status == 200
+        end
+        withenv(env..., "JULIA_SSL_NO_VERIFY_HOSTS" => "localhost") do
+            @test NetworkOptions.verify_host(url)
+            @test !NetworkOptions.verify_host(url, "SSL")
+            @test HTTP.get(url).status == 200
+            @test_throws HTTP.IOError HTTP.get(url; require_ssl_verification=true, retries=1)
+            @test HTTP.get(url; require_ssl_verification=false).status == 200
+        end
+    finally
+        close(server)
+        HTTP.ConnectionPool.closeall()
     end
-    url = "https://localhost:8443"
-    env = ["JULIA_NO_VERIFY_HOSTS" => nothing, "JULIA_SSL_NO_VERIFY_HOSTS" => nothing, "JULIA_ALWAYS_VERIFY_HOSTS" => nothing]
-    withenv(env...) do
-        @test NetworkOptions.verify_host(url)
-        @test NetworkOptions.verify_host(url, "SSL")
-        @test_throws HTTP.IOError HTTP.get(url; retries=1)
-        @test_throws HTTP.IOError HTTP.get(url; require_ssl_verification=true, retries=1)
-        @test HTTP.get(url; require_ssl_verification=false).status == 200
-    end
-    withenv(env..., "JULIA_NO_VERIFY_HOSTS" => "localhost") do
-        @test !NetworkOptions.verify_host(url)
-        @test !NetworkOptions.verify_host(url, "SSL")
-        @test HTTP.get(url).status == 200
-        @test_throws HTTP.IOError HTTP.get(url; require_ssl_verification=true, retries=1)
-        @test HTTP.get(url; require_ssl_verification=false).status == 200
-    end
-    withenv(env..., "JULIA_SSL_NO_VERIFY_HOSTS" => "localhost") do
-        @test NetworkOptions.verify_host(url)
-        @test !NetworkOptions.verify_host(url, "SSL")
-        @test HTTP.get(url).status == 200
-        @test_throws HTTP.IOError HTTP.get(url; require_ssl_verification=true, retries=1)
-        @test HTTP.get(url; require_ssl_verification=false).status == 200
-    end
-    close(server)
 end
 
 @testset "Public entry point of HTTP.request and friends (e.g. issue #463)" begin
@@ -446,23 +465,26 @@ end
         # We are only interested in the request passed in by the client
         # Returns 400 after reading the http request into req
         proxy = listen(IPv4(0), 8082)
-        @async begin
-            sock = accept(proxy)
-            while isopen(sock)
-                line = readline(sock)
-                isempty(line) && break
+        try
+            @async begin
+                sock = accept(proxy)
+                while isopen(sock)
+                    line = readline(sock)
+                    isempty(line) && break
 
-                push!(req, line)
+                    push!(req, line)
+                end
+                write(sock, "HTTP/1.1 400 Bad Request\r\n\r\n")
             end
-            write(sock, "HTTP/1.1 400 Bad Request\r\n\r\n")
+
+            # Make the HTTP request
+            HTTP.get("https://example.com"; proxy="http://localhost:8082", retry=false, status_exception=false)
+
+            # Test if the host header exist in the request
+            @test "Host: example.com:443" in req
+        finally
+            close(proxy)
+            HTTP.ConnectionPool.closeall()
         end
-
-        # Make the HTTP request
-        HTTP.get("https://example.com"; proxy="http://localhost:8082", retry=false, status_exception=false)
-
-        # Test if the host header exist in the request
-        @test "Host: example.com:443" in req
-
-        close(proxy)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test, HTTP, JSON
 
 const dir = joinpath(dirname(pathof(HTTP)), "..", "test")
-include("resources/TestRequest.jl")
+include(joinpath(dir, "resources/TestRequest.jl"))
 
 @testset "HTTP" begin
     for f in [

--- a/test/server.jl
+++ b/test/server.jl
@@ -316,6 +316,7 @@ end # @testset
         sleep(1) # necessary to properly forget the closed connection from the previous call
         try HTTP.get("http://localhost:1234/close"; retry=false) catch end
         HTTP.get("http://localhost:1234", ["Connection" => "close"])
+        sleep(1) # we want to make sure the server has time to finish logging before checking logs
     end
     @test length(logs) == 7
     @test all(x -> x.group === :access, logs)


### PR DESCRIPTION
Follows up on the discussion and work started in
https://github.com/JuliaWeb/HTTP.jl/pull/732.

The gist is this: supporting "pipelined requests" is not well-supported
across the web these days and severely complicates the threadsafe client
implementation in HTTP.jl. And as has been pointed out in various
discussions, the attempt to support pipelining is affecting our ability
to avoid thread-safety issues in general (see
https://github.com/JuliaWeb/HTTP.jl/issues/517).

This commit has a few key pieces:
  * Splits "connection pooling" logic into a new connectionpools.jl file
  * Removes pipeline-related fields/concepts from the ConnectionPool.jl
  file and specifically the `Connection`/`Transaction` data structures
  * Attempts to simplify a lot of the work/logic around managing a
  `Transaction`'s lifecycle

Things I haven't done yet:
  * Actually deprecated the `pipeline_limit` keyword argument
  * Got all tests passing; I think the websockets/server code isn't
  quite ironed out yet, but I'll dig into it some more tomorrow

Big thanks to @nickrobinson251 for help reviewing the connectionpools.jl
logic.

Pinging people to help review: @c42f, @vtjnash, @s2maki, @fredrikekre