### PR TITLE
Change internal layers stack to be value-based instead of type-based

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -453,7 +453,6 @@ include("ConnectionRequest.jl");        using .ConnectionRequest
 include("DebugRequest.jl");             using .DebugRequest
 include("StreamRequest.jl");            using .StreamRequest
 include("ContentTypeRequest.jl");       using .ContentTypeDetection
-include("exceptions.jl")
 
 """
 The `stack()` function returns the default HTTP Layer-stack type.
@@ -569,39 +568,23 @@ relationship with [`HTTP.Response`](@ref), [`HTTP.Parsers`](@ref),
 ```
 *See `docs/src/layers`[`.monopic`](http://monodraw.helftone.com).*
 """
-function stack(;redirect=true,
-                aws_authorization=false,
-                cookies=false,
-                canonicalize_headers=false,
-                retry=true,
-                status_exception=true,
-                readtimeout=0,
-                detect_content_type=false,
-                verbose=0,
-                kw...)
+function stack(; kw...)
 
-    NoLayer = Union
-    stack =                 TopLayer{
-    (redirect             ? RedirectLayer             : NoLayer){
-                            BasicAuthLayer{
-    (detect_content_type  ? ContentTypeDetectionLayer : NoLayer){
-    (cookies === true || (cookies isa AbstractDict && !isempty(cookies)) ?
-                            CookieLayer               : NoLayer){
-    (canonicalize_headers ? CanonicalizeLayer         : NoLayer){
-                            MessageLayer{
-    (aws_authorization    ? AWS4AuthLayer             : NoLayer){
-    (retry                ? RetryLayer                : NoLayer){
-    (status_exception     ? ExceptionLayer            : NoLayer){
-                            ConnectionPoolLayer{
-    (verbose >= 3 ||
-     DEBUG_LEVEL[] >= 3   ? DebugLayer                : NoLayer){
-    (readtimeout > 0      ? TimeoutLayer              : NoLayer){
-                            StreamLayer{Union{}}
-    }}}}}}}}}}}}}
+    layers = stacklayertypes(Layers.ConnectionLayer, StreamLayer(); kw...)
+    layers = ConnectionPoolLayer(layers; kw...)
+    layers = stacklayertypes(Layers.RequestLayer, layers; kw...)
+    layers = MessageLayer(layers; kw...)
+    return stacklayertypes(Layers.InitialLayer, layers; kw...)
+end
 
-    reduce(Layers.EXTRA_LAYERS; init=stack) do stack, (before, custom)
-        insert(stack, before, custom)
+function stacklayertypes(::Type{T}, layers; kw...) where {T}
+    for (k, _) in pairs(kw)
+        layer = Layers.keywordforlayer(Val(k))
+        if layer !== nothing && layer <: T
+            layers = layer(layers; kw...)
+        end
     end
+    return layers
 end
 
 include("download.jl")

--- a/src/StreamRequest.jl
+++ b/src/StreamRequest.jl
@@ -19,15 +19,15 @@ immediately so that the transmission can be aborted if the `Response` status
 indicates that the server does not wish to receive the message body.
 [RFC7230 6.5](https://tools.ietf.org/html/rfc7230#section-6.5).
 """
-abstract type StreamLayer{Next <: Layer} <: Layer{Next} end
+struct StreamLayer <: ConnectionLayer end
 export StreamLayer
 
-function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
+function request(::StreamLayer, io::IO, req::Request, body;
                  reached_redirect_limit=false,
                  response_stream=nothing,
                  iofunction=nothing,
                  verbose::Int=0,
-                 kw...)::Response where Next
+                 kw...)::Response
 
     verbose == 1 && printlncompact(req)
 
@@ -84,7 +84,7 @@ function request(::Type{StreamLayer{Next}}, io::IO, req::Request, body;
     verbose == 1 && printlncompact(response)
     verbose == 2 && println(response)
 
-    return request(Next, response)
+    return response
 end
 
 function writebody(http::Stream, req::Request, body)

--- a/src/TopRequest.jl
+++ b/src/TopRequest.jl
@@ -10,7 +10,7 @@ export TopLayer
 This layer is at the top of every stack, and does nothing.
 It's useful for inserting a custom layer at the top of the stack.
 """
-abstract type TopLayer{Next <: Layer} <: Layer{Next} end
+struct TopLayer{Next <: Layer} <: Layer{Next} end
 
 request(::Type{TopLayer{Next}}, args...; kwargs...) where Next =
     request(Next, args...; kwargs...)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,7 +1,0 @@
-struct LayerNotFoundException <: Exception
-    var::String
-end
-
-function Base.showerror(io::IO, e::LayerNotFoundException)
-    println(io, typeof(e), ": ", e.var)
-end


### PR DESCRIPTION
This is very proof-of-concept currently, but wanted to put the code up
to get initial feedback/ideas. Here's the gist:

  * I define 3 abstract subtypes of `Layer` in the Layers module:
  `InitialLayer`, `RequestLayer`, and `ConnectionLayer`; these
  correspond to the types of arguments the layer would receive when
  overloading `request`; `InitialLayer` => `request(method, url,
  headers, body), `RequestLayer` => `request(url, req, body)`, and
  `ConnectionLayer` => `request(io, req, body)`. I feel like these are
  useful abstract types to help distinguish the different _kinds_ of
  layers based on the arguments they receive in different parts of the
  overall stack. I feel like it hopefully also solves the "how do I
  insert my layer in the appropriate level of the stack" because you
  just pick which abstract layer to subtype
  * Custom layers are then required to:
    * be concrete types
    * must subtype one of the 3 abstract layer types mentioned
    * must have a constructor of the form: `Layer(next::Layer; kw...)
    * must have a field to store the `next::Layer` argument
    * must overload: `request(x::MyLayer, args...; kw...)` where `args`
    will depend on which abstract layer `MyLayer` subtypes
    * in the overloaded `request` method, it must, at some point, call
    `request(layer.next, args...; kw...)` to move to the next layer in
    the stack
    * the final requirement is the custom layer must overload
    `Layers.keywordforlayer(::Val{:kw}) = MyLayer` where `:kw` is a
    keyword argument "hook" or trigger that will result in `MyLayer`
    being inserted into the stack

What I like about this approach so far:
  * It feels more straightforward to define my own custom layer: pick
  which level of the stack I want it in, subtype that abstract layer,
  register a keyword argument that will include my layer, then define my
  own `request` overload; we can define all the current HTTP layers in
  terms of this machinery, custom packages could define their own layers
  and they all are treated just like any HTTP.jl-baked layer
  * It also feels like it would be easier to create my own custom "http
  client"; what I mean by this is that I feel like it's common for API
  packages to basically have their own `AWS.get`/`AWS.post`/`AWS.put`
  wrapper methods that eventually call `HTTP.get`/`HTTP.post`/etc., but
  in between, they're adding custom headers, validating targets, and
  whatever. A lot of that is _like_ a custom layer, but by having your
  own `AWS.get`/`AWS.post` wrapper methods, you can _ensure_ certain
  layers are included; and with this approach that's straightforward
  because they can indeed make their own custom layer as described
  above, and then just ensure every `HTTP.request` call includes the new
  keyword argument to "hook in" their custom layer

Potential downsides:
  * Relying on a global keyword registry; i.e. there's potential for
  clashes if two different packages try to overload
  `Layers.keywordforlayer(::Val{:readtimeout}) = ...`. Whichever package
  is loaded last will "pirate" the keyword arg and overwrite the
  previous method. We could potentially add some extra safety around
  this by having another `clientenv=:default` keyword and then devs
  could overload `Layers.keywordforlayer(::Val{:default},
  ::Val{:readtimeout}) = ...` but that feels a tad icky. I also don't
  expect there to be even dozens of total keywords/layers to process, so
  with that in mind, it also lowers the risk of clash.
  * The previous layer functionality allowed specifying the _exact_
  layer you wanted your custom layer to be inserted before; do we think
  that level of specificity/granularity is really necessary? I'm kind of
  going on a gut feel here that what you really want control over is
  _what kind of args_ your overloaded `request` method will receive and
  that's what my 3 new abstract layer subtypes aim to solve. So you can
  pick 1 of 3 different _general_ layers of where your custom layer gets
  inserted, but don't have control over anything more specific in terms
  of what layer comes before/after
  * One thing I noticed is that the current `stack` function actually
  has some hard-coded logic that checks keyword arguments and
  _conditionally_ will include layers based on the _value_ of the
  keyword arg. We could potentially handle that in the proposed scheme
  by saying that your custom `Layer(next; kw...)` constructor can
  return the `nothing` value, in which case, no layer will be inserted.
  That would give, for example, the `TimeoutLayer` the chance to check
  if the `readtimeout > 0` before returning a `TimeoutLayer` or
  `nothing`