### PR TITLE
Reduce the time-to-first-request by adding pregenerated precompile statements

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -1,0 +1,40 @@
+name: Regenerate precompile statements
+on:
+  workflow_dispatch:
+permissions: # Permissions for the `GITHUB_TOKEN` token
+  contents: write
+  pull-requests: write
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `master` or `release-*` branches
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  regenerate_precompile_statements:
+    name: Regenerate precompile statements
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 'nightly' # TODO: delete this line once Julia 1.9 is releease
+          # version: '1'     # TODO: uncomment this line once Julia 1.9 is releease
+      - name: Instantiate
+        run: julia --project -e 'import Pkg; Pkg.instantiate(); Pkg.update(); Pkg.precompile()'
+      - name: Run the `contrib/precompile_generate.jl` script
+        run: julia --project contrib/precompile_generate.jl
+      - name: Create (or update) the pull request
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "bot/regenerate-precompile-statements"
+          delete-branch: true
+          commit-message: "🤖 Regenerate the precompile statements"
+          title: "🤖 Regenerate the precompile statements"
+          body: |
+            This PR regenerates the precompile statements.
+            Note: CI will not automatically run on this PR. To run CI, please
+            close and reopen the PR.

--- a/contrib/precompile_generate.jl
+++ b/contrib/precompile_generate.jl
@@ -1,0 +1,96 @@
+function gen_single_tracefile(
+        code::AbstractString,
+        tracefile::AbstractString,
+    )
+    julia_binary = Base.julia_cmd().exec[1]
+    cmd = `$(julia_binary)`
+    push!(cmd.exec, "--compile=all")
+    push!(cmd.exec, "--trace-compile=$(tracefile)")
+    push!(cmd.exec, "-e $(code)")
+    splitter = Sys.iswindows() ? ';' : ':'
+    project = Base.active_project()
+    env2 = copy(ENV)
+    env2["JULIA_LOAD_PATH"] = "$(project)$(splitter)@stdlib"
+    env2["JULIA_PROJECT"] = "$(project)"
+    run(setenv(cmd, env2))
+    return nothing
+end
+
+function gen_single_precompile(code::AbstractString)
+    str = mktempdir() do dir
+        tracefile = joinpath(dir, "tracefile")
+        gen_single_tracefile(code, tracefile)
+        return read(tracefile, String)::String
+    end::String
+    lines = convert(
+        Vector{String},
+        strip.(split(strip(str), '\n')),
+    )::Vector{String}
+    filter!(line -> !isempty(line), lines)
+    return lines
+end
+
+function gen_all_precompile()
+    codes = String[
+        "import HTTP; HTTP.get(\"https://example.com/\")",
+    ]
+    all_lines = String[]
+    for code in codes
+        lines = gen_single_precompile(code)
+        append!(all_lines, lines)
+    end
+    unique!(all_lines)
+end
+
+function write_all_precompile(io::IO, all_lines::Vector{String})
+    preamble_lines = String[
+        "import MbedTLS",
+        "const MbedTLS_jll = MbedTLS.MbedTLS_jll"
+    ]
+    for line in preamble_lines
+        println(io, line)
+    end
+    println(io)
+    println(io, """
+    function _precompile()
+    """)
+    println(io, """
+        if ccall(:jl_generating_output, Cint, ()) != 1
+            return nothing
+        end
+    """)
+    println(io, """
+        @static if Base.VERSION < v"1.9-"
+            # We need https://github.com/JuliaLang/julia/pull/43990, otherwise this isn't worth doing.
+            return nothing
+        end
+    """)
+    for line in all_lines
+        println(io, "    ", line)
+    end
+    println(io)
+    println(io, """
+        return nothing
+    end
+    """)
+    return nothing
+end
+
+function write_all_precompile(
+        output_file::AbstractString,
+        all_lines::Vector{String},
+    )
+    open(output_file, "w") do io
+        write_all_precompile(io, all_lines)
+    end
+    return nothing
+end
+
+function main()
+    output_file = joinpath(dirname(@__DIR__), "src", "precompile.jl")
+    all_lines = gen_all_precompile()
+    write_all_precompile(output_file, all_lines)
+    return nothing
+end
+
+main()

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -631,4 +631,7 @@ function Base.parse(::Type{T}, str::AbstractString)::T where T <: Message
     return m
 end
 
+include("precompile.jl")
+_precompile()
+
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,73 @@
+import MbedTLS
+const MbedTLS_jll = MbedTLS.MbedTLS_jll
+
+function _precompile()
+
+    if ccall(:jl_generating_output, Cint, ()) != 1
+        return nothing
+    end
+
+    @static if Base.VERSION < v"1.9-"
+        # We need https://github.com/JuliaLang/julia/pull/43990, otherwise this isn't worth doing.
+        return nothing
+    end
+
+    precompile(Tuple{typeof(Base.:(!=)), UInt64, UInt64})
+    precompile(Tuple{typeof(MbedTLS_jll.__init__)})
+    precompile(Tuple{typeof(MbedTLS.f_send), Ptr{Nothing}, Ptr{UInt8}, UInt64})
+    precompile(Tuple{typeof(MbedTLS.f_recv), Ptr{Nothing}, Ptr{UInt8}, UInt64})
+    precompile(Tuple{typeof(MbedTLS.__init__)})
+    precompile(Tuple{typeof(URIs.__init__)})
+    precompile(Tuple{typeof(HTTP.Parsers.__init__)})
+    precompile(Tuple{typeof(HTTP.CookieRequest.__init__)})
+    precompile(Tuple{typeof(HTTP.ConnectionRequest.__init__)})
+    precompile(Tuple{typeof(HTTP.Servers.__init__)})
+    precompile(Tuple{typeof(HTTP.MultiPartParsing.__init__)})
+    precompile(Tuple{typeof(HTTP.get), String})
+    precompile(Tuple{Type{NamedTuple{(:init,), T} where T<:Tuple}, Tuple{DataType}})
+    precompile(Tuple{Base.var"#reduce##kw", NamedTuple{(:init,), Tuple{DataType}}, typeof(Base.reduce), Function, Base.Set{Tuple{Union{Type{Union{}}, UnionAll}, UnionAll}}})
+    precompile(Tuple{typeof(Base.mapfoldl_impl), typeof(Base.identity), HTTP.var"#24#25", Type, Base.Set{Tuple{Union{Type{Union{}}, UnionAll}, UnionAll}}})
+    precompile(Tuple{typeof(HTTP.request), Type{HTTP.TopRequest.TopLayer{HTTP.RedirectRequest.RedirectLayer{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}}}, String, URIs.URI, Array{Pair{Base.SubString{String}, Base.SubString{String}}, 1}, Array{UInt8, 1}})
+    precompile(Tuple{HTTP.var"#request##kw", NamedTuple{(:iofunction, :reached_redirect_limit), Tuple{Nothing, Bool}}, typeof(HTTP.request), Type{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}, URIs.URI, HTTP.Messages.Request, Array{UInt8, 1}})
+    precompile(Tuple{HTTP.var"#request##kw", NamedTuple{(:iofunction, :reached_redirect_limit), Tuple{Nothing, Bool}}, typeof(HTTP.request), Type{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}, URIs.URI, HTTP.Messages.Request, Array{UInt8, 1}})
+    precompile(Tuple{typeof(Sockets.uv_getaddrinfocb), Ptr{Nothing}, Int32, Ptr{Nothing}})
+    precompile(Tuple{HTTP.ConnectionPool.var"#newconnection##kw", NamedTuple{(:iofunction, :reached_redirect_limit), Tuple{Nothing, Bool}}, typeof(HTTP.ConnectionPool.newconnection), Type{MbedTLS.SSLContext}, Base.SubString{String}, Base.SubString{String}})
+    precompile(Tuple{typeof(Sockets.uv_connectcb), Ptr{Nothing}, Int32})
+    precompile(Tuple{typeof(Sockets.connect), Sockets.IPv4, UInt64})
+    precompile(Tuple{typeof(Base.setproperty!), Sockets.TCPSocket, Symbol, Int64})
+    precompile(Tuple{typeof(Base.notify), Base.GenericCondition{Base.Threads.SpinLock}})
+    precompile(Tuple{typeof(MbedTLS.f_rng), MbedTLS.CtrDrbg, Ptr{UInt8}, UInt64})
+    precompile(Tuple{typeof(Base.isopen), Sockets.TCPSocket})
+    precompile(Tuple{typeof(Base.getproperty), Sockets.TCPSocket, Symbol})
+    precompile(Tuple{typeof(Base.unsafe_write), Sockets.TCPSocket, Ptr{UInt8}, UInt64})
+    precompile(Tuple{typeof(Base.bytesavailable), Sockets.TCPSocket})
+    precompile(Tuple{typeof(Base.eof), Sockets.TCPSocket})
+    precompile(Tuple{typeof(Base.alloc_buf_hook), Sockets.TCPSocket, UInt64})
+    precompile(Tuple{Base.var"#readcb_specialized#671", Sockets.TCPSocket, Int64, UInt64})
+    precompile(Tuple{typeof(Base.min), UInt64, Int64})
+    precompile(Tuple{typeof(Base.unsafe_read), Sockets.TCPSocket, Ptr{UInt8}, UInt64})
+    precompile(Tuple{Type{Int32}, UInt64})
+    precompile(Tuple{typeof(HTTP.Messages.hasheader), HTTP.Messages.Request, String})
+    precompile(Tuple{typeof(HTTP.Messages.ischunked), HTTP.Messages.Request})
+    precompile(Tuple{typeof(HTTP.Messages.writeheaders), Base.GenericIOBuffer{Array{UInt8, 1}}, HTTP.Messages.Request})
+    precompile(Tuple{typeof(Base.unsafe_write), MbedTLS.SSLContext, Ptr{UInt8}, UInt64})
+    precompile(Tuple{typeof(Base.check_open), Sockets.TCPSocket})
+    precompile(Tuple{MbedTLS.var"#25#26"{MbedTLS.SSLContext}})
+    precompile(Tuple{typeof(Base.eof), MbedTLS.SSLContext})
+    precompile(Tuple{HTTP.StreamRequest.var"#2#3"{HTTP.ConnectionPool.Connection, HTTP.Messages.Request, Array{UInt8, 1}, HTTP.Streams.Stream{HTTP.Messages.Response, HTTP.ConnectionPool.Connection}}})
+    precompile(Tuple{typeof(Base.bytesavailable), MbedTLS.SSLContext})
+    precompile(Tuple{typeof(Base.unsafe_read), MbedTLS.SSLContext, Ptr{UInt8}, Int64})
+    precompile(Tuple{typeof(Base.readuntil), Base.GenericIOBuffer{Array{UInt8, 1}}, typeof(HTTP.Parsers.find_end_of_header)})
+    precompile(Tuple{typeof(Base.release), HTTP.ConnectionPool.ConnectionPools.Pool{HTTP.ConnectionPool.Connection}, Tuple{DataType, String, String, Bool, Bool}, HTTP.ConnectionPool.Connection})
+    precompile(Tuple{typeof(Base.isequal), Tuple{DataType, String, String, Bool, Bool}, Tuple{DataType, Base.SubString{String}, Base.SubString{String}, Bool, Bool}})
+    precompile(Tuple{typeof(Base.isopen), MbedTLS.SSLContext})
+    precompile(Tuple{MbedTLS.var"#21#23"{MbedTLS.SSLContext}, MbedTLS.SSLContext})
+    precompile(Tuple{MbedTLS.var"#15#16", MbedTLS.CRT})
+    precompile(Tuple{MbedTLS.var"#10#11", MbedTLS.CtrDrbg})
+    precompile(Tuple{MbedTLS.var"#8#9", MbedTLS.Entropy})
+    precompile(Tuple{MbedTLS.var"#17#19", MbedTLS.SSLConfig})
+    precompile(Tuple{typeof(Base.uvfinalize), Sockets.TCPSocket})
+
+    return nothing
+end
+


### PR DESCRIPTION
## Summary

This pull request makes two changes:
1. Reduce the time-to-first-request by adding a pregenerated list of precompile statements.
2. Add a GitHub Actions workflow for automatically regenerating list of precompile statements.

## Description

This pull request reduces the time to first `HTTP.get("https://example.com/")` as shown in the following table. All times are in seconds.

| Branch           | Sample Size | Median   | Δ vs master | Mean ± Standard Deviation |  Δ vs master |
| ---------------- | ----------- | -------- | ----------- | ------------------------- | ------------ |
| `master`         | 20          | 5.252848 |             | 5.318844 ± 0.241039       |              |
| `dpa/precompile` | 20          | 3.723808 | -1.529040   | 3.947450 ± 0.104822       | -1.371394    |

All measurements were taken using Julia version `1.9.0-DEV.165`:

```
$ julia --project -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
Julia Version 1.9.0-DEV.165
Commit 8076517c97 (2022-03-09 19:46 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin20.6.0)
  CPU: 4 × Intel(R) Core(TM) i5-4278U CPU @ 2.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, haswell)
  Threads: 1 on 4 virtual cores
```

Note: this pull request does not make any web requests when the user does `Pkg.precompile()` or `import HTTP`.

## List of time measurements

<details>

<summary>Time measurements for the <code>master</code> branch (click to expand)</summary>

```
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.332501 seconds (7.34 M allocations: 373.428 MiB, 3.00% gc time, 98.47% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.323024 seconds (7.34 M allocations: 373.428 MiB, 3.16% gc time, 98.49% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.236754 seconds (7.34 M allocations: 373.428 MiB, 3.13% gc time, 98.42% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.235521 seconds (7.34 M allocations: 373.428 MiB, 3.15% gc time, 98.30% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.219502 seconds (7.34 M allocations: 373.428 MiB, 3.14% gc time, 98.42% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.235383 seconds (7.34 M allocations: 373.428 MiB, 3.15% gc time, 98.35% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  6.321999 seconds (7.34 M allocations: 373.428 MiB, 2.64% gc time, 98.65% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.250412 seconds (7.34 M allocations: 373.428 MiB, 3.05% gc time, 98.41% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.323672 seconds (7.34 M allocations: 373.428 MiB, 3.16% gc time, 98.44% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.255284 seconds (7.34 M allocations: 373.428 MiB, 3.09% gc time, 98.32% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.339982 seconds (7.34 M allocations: 373.428 MiB, 3.25% gc time, 98.50% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.318435 seconds (7.34 M allocations: 373.428 MiB, 3.17% gc time, 98.35% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.211436 seconds (7.34 M allocations: 373.428 MiB, 3.14% gc time, 98.43% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.285089 seconds (7.34 M allocations: 373.428 MiB, 2.98% gc time, 98.49% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.203090 seconds (7.34 M allocations: 373.428 MiB, 3.12% gc time, 98.39% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.342181 seconds (7.34 M allocations: 373.428 MiB, 3.08% gc time, 98.47% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.191504 seconds (7.34 M allocations: 373.428 MiB, 3.37% gc time, 98.46% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.272862 seconds (7.34 M allocations: 373.428 MiB, 3.03% gc time, 98.45% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.238501 seconds (7.34 M allocations: 373.428 MiB, 3.32% gc time, 98.49% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.239750 seconds (7.34 M allocations: 373.428 MiB, 3.05% gc time, 98.46% compilation time)
```

</details>

<details>

<summary>Time measurements for the <code>dpa/precompile</code> branch (click to expand)</summary>

```
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  4.626500 seconds (76.96 k allocations: 4.030 MiB, 97.84% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  4.705703 seconds (76.96 k allocations: 4.030 MiB, 97.70% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  4.739228 seconds (76.96 k allocations: 4.030 MiB, 97.95% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.817014 seconds (76.96 k allocations: 4.030 MiB, 97.74% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.720888 seconds (76.96 k allocations: 4.030 MiB, 97.91% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.679500 seconds (76.96 k allocations: 4.030 MiB, 97.84% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.669254 seconds (76.96 k allocations: 4.030 MiB, 97.68% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.733760 seconds (76.96 k allocations: 4.030 MiB, 97.75% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  5.142341 seconds (76.96 k allocations: 4.030 MiB, 97.91% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.845968 seconds (76.96 k allocations: 4.030 MiB, 97.80% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.713366 seconds (76.96 k allocations: 4.031 MiB, 97.76% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.703498 seconds (76.96 k allocations: 4.030 MiB, 97.80% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.734557 seconds (76.96 k allocations: 4.030 MiB, 97.74% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.746249 seconds (76.96 k allocations: 4.030 MiB, 97.76% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.782660 seconds (76.96 k allocations: 4.031 MiB, 97.74% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.741732 seconds (76.96 k allocations: 4.030 MiB, 97.64% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.693289 seconds (76.96 k allocations: 4.030 MiB, 97.79% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.713094 seconds (76.96 k allocations: 4.030 MiB, 97.84% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.726727 seconds (76.96 k allocations: 4.030 MiB, 97.77% compilation time)
$ julia --project -e 'import HTTP; @time(HTTP.get("https://example.com"));'
  3.713672 seconds (76.96 k allocations: 4.030 MiB, 97.88% compilation time)
```

</details>

## How to regenerate the list of precompile statements

To regenerate the list of precompile statements, there are two options:
1. If you are a committer on this repository, you can go to the [Actions tab](https://github.com/JuliaWeb/HTTP.jl/actions) of this repository, select the `Precompile` workflow, and manually trigger a new workflow run. This will automatically open a pull request to update the precompile statements.
3. You can clone the repository locally and run the following command: `julia --project contrib/precompile_generate.jl`