### PR TITLE
Sec-WebSocket-Accept: strip input key

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -85,7 +85,7 @@ function check_upgrade(http)
 end
 
 function accept_hash(key)
-    hashkey = "$(key)258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+    hashkey = "$(strip(key))258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
     return base64encode(digest(MD_SHA1, hashkey))
 end
 


### PR DESCRIPTION
To conform with the [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455#page-6) spec

```
For this header field, the server has to take the value (as present
   in the header field, e.g., the base64-encoded [[RFC4648](https://www.rfc-editor.org/rfc/rfc4648)] version minus
   any leading and trailing whitespace) and concatenate this with ...
```

A random shot at https://github.com/JuliaWeb/HTTP.jl/issues/807