### PR TITLE
Prefactoring: Add broken test case for parsing multipart content type (#782)

### DIFF
--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -3,31 +3,33 @@ using HTTP
 import HTTP.MultiPartParsing: find_multipart_boundary, find_multipart_boundaries, find_header_boundary, parse_multipart_chunk, parse_multipart_body, parse_multipart_form
 
 function generate_test_body()
-    Vector{UInt8}("""----------------------------918073721150061572809433\r
-    Content-Disposition: form-data; name="namevalue"; filename="multipart.txt"\r
-    Content-Type: text/plain\r
-    \r
-    not much to say\n\r
-    ----------------------------918073721150061572809433\r
-    Content-Disposition: form-data; name="key1"\r
-    \r
-    1\r
-    ----------------------------918073721150061572809433\r
-    Content-Disposition: form-data; name="key2"\r
-    \r
-    key the second\r
-    ----------------------------918073721150061572809433\r
-    Content-Disposition: form-data; name="namevalue2"; filename="multipart-leading-newline.txt"\r
-    Content-Type: text/plain\r
-    \r
-    \nfile with leading newline\n\r
-    ----------------------------918073721150061572809433\r
-    Content-Disposition: form-data; name="json_file1"; filename="my-json-file-1.json"\r
-    Content-Type: application/json\r
-    \r
-    {"data": ["this is json data"]}\r
-    ----------------------------918073721150061572809433--\r
-    """)
+    Vector{UInt8}(join([
+        "----------------------------918073721150061572809433",
+        "Content-Disposition: form-data; name=\"namevalue\"; filename=\"multipart.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "not much to say\n",
+        "----------------------------918073721150061572809433",
+        "Content-Disposition: form-data; name=\"key1\"",
+        "",
+        "1",
+        "----------------------------918073721150061572809433",
+        "Content-Disposition: form-data; name=\"key2\"",
+        "",
+        "key the second",
+        "----------------------------918073721150061572809433",
+        "Content-Disposition: form-data; name=\"namevalue2\"; filename=\"multipart-leading-newline.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "\nfile with leading newline\n",
+        "----------------------------918073721150061572809433",
+        "Content-Disposition: form-data; name=\"json_file1\"; filename=\"my-json-file-1.json\"",
+        "Content-Type: application/json",
+        "",
+        "{\"data\": [\"this is json data\"]}",
+        "----------------------------918073721150061572809433--",
+        "",
+    ], "\r\n"))
 end
 
 function generate_test_request()

--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -3,7 +3,26 @@ using HTTP
 import HTTP.MultiPartParsing: find_multipart_boundary, find_multipart_boundaries, find_header_boundary, parse_multipart_chunk, parse_multipart_body, parse_multipart_form
 
 function generate_test_body()
-    Vector{UInt8}("----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue\"; filename=\"multipart.txt\"\r\nContent-Type: text/plain\r\n\r\nnot much to say\n\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key1\"\r\n\r\n1\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"key2\"\r\n\r\nkey the second\r\n----------------------------918073721150061572809433\r\nContent-Disposition: form-data; name=\"namevalue2\"; filename=\"multipart-leading-newline.txt\"\r\nContent-Type: text/plain\r\n\r\n\nfile with leading newline\n\r\n----------------------------918073721150061572809433--\r\n")
+    Vector{UInt8}("""----------------------------918073721150061572809433\r
+    Content-Disposition: form-data; name="namevalue"; filename="multipart.txt"\r
+    Content-Type: text/plain\r
+    \r
+    not much to say\n\r
+    ----------------------------918073721150061572809433\r
+    Content-Disposition: form-data; name="key1"\r
+    \r
+    1\r
+    ----------------------------918073721150061572809433\r
+    Content-Disposition: form-data; name="key2"\r
+    \r
+    key the second\r
+    ----------------------------918073721150061572809433\r
+    Content-Disposition: form-data; name="namevalue2"; filename="multipart-leading-newline.txt"\r
+    Content-Type: text/plain\r
+    \r
+    \nfile with leading newline\n\r
+    ----------------------------918073721150061572809433--\r
+    """)
 end
 
 function generate_test_request()
@@ -83,7 +102,7 @@ end
 
     @testset "parse_multipart_form" begin
         @test HTTP.parse_multipart_form(generate_non_multi_test_request()) === nothing
-        
+
         multiparts = HTTP.parse_multipart_form(generate_test_request())
         @test 4 == length(multiparts)
 


### PR DESCRIPTION
This PR makes the parsemultipart.jl test file a bit easier to edit, and then adds a broken test case for a form section with a non-text content type.

This can be merged as-is, since it only adds a `@test_broken`. I'll try to follow this up soon with a fix, but I'm done working for the day, and figured this is a nice place to stop already. :)

Part of #782.