### PR TITLE
Widen support for parsing MultiPartForms to include Responses

### DIFF
--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -1,6 +1,6 @@
 module MultiPartParsing
 
-import ..access_threaded, ..Request, ..Multipart, ..payload
+import ..access_threaded, ..Message, ..Request, ..Multipart, ..payload
 using ..Parsers
 
 export parse_multipart_form
@@ -232,9 +232,9 @@ that the boundary delimiter does not need to have '-' characters, but a line usi
 the boundary delimiter will start with '--' and end in \r\n.
 [RFC2046 5.1](https://tools.ietf.org/html/rfc2046#section-5.1.1)
 """
-function parse_multipart_form(req::Request)::Union{Vector{Multipart}, Nothing}
+function parse_multipart_form(msg::Message)::Union{Vector{Multipart}, Nothing}
     # parse boundary from Content-Type
-    m = match(r"multipart/form-data; boundary=(.*)$", req["Content-Type"])
+    m = match(r"multipart/form-data; boundary=(.*)$", msg["Content-Type"])
     m === nothing && return nothing
 
     boundary_delimiter = m[1]
@@ -242,7 +242,7 @@ function parse_multipart_form(req::Request)::Union{Vector{Multipart}, Nothing}
     # [RFC2046 5.1.1](https://tools.ietf.org/html/rfc2046#section-5.1.1)
     length(boundary_delimiter) > 70 && error("boundary delimiter must not be greater than 70 characters")
 
-    return parse_multipart_body(payload(req), boundary_delimiter)
+    return parse_multipart_body(payload(msg), boundary_delimiter)
 end
 
 function __init__()

--- a/test/parsemultipart.jl
+++ b/test/parsemultipart.jl
@@ -33,6 +33,8 @@ function generate_test_body()
 end
 
 function generate_test_request()
+    body = generate_test_body()
+    
     headers = [
         "User-Agent" => "PostmanRuntime/7.15.2",
         "Accept" => "*/*",
@@ -42,11 +44,11 @@ function generate_test_request()
         "Accept-Encoding" => "gzip, deflate",
         "Accept-Encoding" => "gzip, deflate",
         "Content-Type" => "multipart/form-data; boundary=--------------------------918073721150061572809433",
-        "Content-Length" => "861",
+        "Content-Length" => string(length(body)),
         "Connection" => "keep-alive",
     ]
 
-    HTTP.Request("POST", "/", headers, generate_test_body())
+    HTTP.Request("POST", "/", headers, body)
 end
 
 function generate_non_multi_test_request()
@@ -66,15 +68,17 @@ function generate_non_multi_test_request()
 end
 
 function generate_test_response()
+    body = generate_test_body()
+
     headers = [
         "Date" => "Fri, 25 Mar 2022 14:16:21 GMT",
         "Transfer-Encoding" => "chunked",
         "Content-Type" => "multipart/form-data; boundary=--------------------------918073721150061572809433",
-        "Content-Length" => "861",
+        "Content-Length" => string(length(body)),
         "Connection" => "keep-alive",
     ]
 
-    HTTP.Response(200, headers, body=generate_test_body())
+    HTTP.Response(200, headers, body=body)
 end
 
 


### PR DESCRIPTION
HTTP multi-part forms can be used for both requests and responses.
Extend the support for HTTP.parse_multipart_form(::Message) to support
both requests and responses.

Add a test for parsing a response.

Closes https://github.com/JuliaWeb/HTTP.jl/issues/816.

