### PR TITLE
[BREAKING]: Overhaul Handlers framework + rewrite Router to be trie-based and support dynamic use-cases

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -331,7 +331,7 @@ function request(method, url, h=Header[], b=nobody;
 end
 
 const STREAM_LAYERS = [timeoutlayer, exceptionlayer, debuglayer]
-const REQUEST_LAYERS = [messagelayer, redirectlayer, defaultheaderslayer, basicauthlayer, contenttypedetectionlayer, cookielayer, retrylayer, canonicalizelayer]
+const REQUEST_LAYERS = [redirectlayer, defaultheaderslayer, basicauthlayer, contenttypedetectionlayer, cookielayer, retrylayer, canonicalizelayer]
 
 pushlayer!(layer; request::Bool=true) = push!(request ? REQUEST_LAYERS : STREAM_LAYERS, layer)
 pushfirstlayer!(layer; request::Bool=true) = pushfirst!(request ? REQUEST_LAYERS : STREAM_LAYERS, layer)
@@ -349,7 +349,7 @@ function stack(
     # request layers
     # messagelayer must be the 1st/outermost layer to convert initial args to Request
     layers3 = foldr((x, y) -> x(y), requestlayers; init=connectionlayer(layers2))
-    return foldr((x, y) -> x(y), REQUEST_LAYERS; init=layers3)
+    return messagelayer(foldr((x, y) -> x(y), REQUEST_LAYERS; init=layers3))
 end
 
 function request(stack::Base.Callable, method, url, h=Header[], b=nobody, q=nothing;

--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -1,478 +1,246 @@
-"""
-# Examples
-Let's put together an example http REST server for our hypothetical "ZooApplication" that utilizes various
-parts of the Servers & Handler frameworks.
-
-Our application allows users to interact with custom "animal" JSON objects.
-
-First we have our "model" or data structures:
-```julia
-mutable struct Animal
-    id::Int
-    type::String
-    name::String
-end
-```
-
-Now we want to define our REST api, or how do we allow users to create, update,
-retrieve and delete animals:
-```julia
-# use a plain `Dict` as a "data store"
-const ANIMALS = Dict{Int, Animal}()
-const NEXT_ID = Ref(0)
-function getNextId()
-    id = NEXT_ID[]
-    NEXT_ID[] += 1
-    return id
-end
-
-# "service" functions to actually do the work
-function createAnimal(req::HTTP.Request)
-    animal = JSON3.read(IOBuffer(HTTP.payload(req)), Animal)
-    animal.id = getNextId()
-    ANIMALS[animal.id] = animal
-    return HTTP.Response(200, JSON3.write(animal))
-end
-
-function getAnimal(req::HTTP.Request)
-    animalId = HTTP.URIs.splitpath(req.target)[5] # /api/zoo/v1/animals/10, get 10
-    animal = ANIMALS[parse(Int, animalId)]
-    return HTTP.Response(200, JSON3.write(animal))
-end
-
-function updateAnimal(req::HTTP.Request)
-    animal = JSON3.read(IOBuffer(HTTP.payload(req)), Animal)
-    ANIMALS[animal.id] = animal
-    return HTTP.Response(200, JSON3.write(animal))
-end
-
-function deleteAnimal(req::HTTP.Request)
-    animalId = HTTP.URIs.splitpath(req.target)[5] # /api/zoo/v1/animals/10, get 10
-    delete!(ANIMALS, parse(Int, animal.id))
-    return HTTP.Response(200)
-end
-
-# define REST endpoints to dispatch to "service" functions
-const ANIMAL_ROUTER = HTTP.Router()
-HTTP.@register(ANIMAL_ROUTER, "POST", "/api/zoo/v1/animals", createAnimal)
-# note the use of `*` to capture the path segment "variable" animal id
-HTTP.@register(ANIMAL_ROUTER, "GET", "/api/zoo/v1/animals/*", getAnimal)
-HTTP.@register(ANIMAL_ROUTER, "PUT", "/api/zoo/v1/animals", updateAnimal)
-HTTP.@register(ANIMAL_ROUTER, "DELETE", "/api/zoo/v1/animals/*", deleteAnimal)
-```
-
-Great! At this point, we could spin up our server and let users start managing their animals:
-```julia
-HTTP.serve(ANIMAL_ROUTER, Sockets.localhost, 8081)
-```
-
-Now, you may have noticed that there was a bit of repetition in our "service" functions, particularly
-with regards to the JSON serialization/deserialization. Perhaps we can simplify things by writing
-a custom "JSONHandler" to do some of the repetitive work for us.
-```julia
-function JSONHandler(req::HTTP.Request)
-    # first check if there's any request body
-    body = IOBuffer(HTTP.payload(req))
-    if eof(body)
-        # no request body
-        response_body = handle(ANIMAL_ROUTER, req)
-    else
-        # there's a body, so pass it on to the handler we dispatch to
-        response_body = handle(ANIMAL_ROUTER, req, JSON3.read(body, Animal))
-    end
-    return HTTP.Response(200, JSON3.write(response_body))
-end
-
-# **simplified** "service" functions
-function createAnimal(req::HTTP.Request, animal)
-    animal.id = getNextId()
-    ANIMALS[animal.id] = animal
-    return animal
-end
-
-function getAnimal(req::HTTP.Request)
-    animalId = HTTP.URIs.splitpath(req.target)[5] # /api/zoo/v1/animals/10, get 10
-    return ANIMALS[animalId]
-end
-
-function updateAnimal(req::HTTP.Request, animal)
-    ANIMALS[animal.id] = animal
-    return animal
-end
-
-function deleteAnimal(req::HTTP.Request)
-    animalId = HTTP.URIs.splitpath(req.target)[5] # /api/zoo/v1/animals/10, get 10
-    delete!(ANIMALS, animal.id)
-    return ""
-end
-```
-
-And we modify slightly how we run our server, letting our new `JSONHandler` be the entry point
-instead of our router:
-```julia
-HTTP.serve(JSONHandler, Sockets.localhost, 8081)
-```
-
-Our `JSONHandler` is nice because it saves us a bunch of repetition: if a request body comes in,
-we automatically deserialize it and pass it on to the service function. And each service function
-doesn't need to worry about returning `HTTP.Response`s anymore, but can just focus on returning
-plain Julia objects/strings. The other huge advantage is it provides a clean separation of concerns
-between the "service" layer, which should really concern itself with application logic, and the
-"REST API" layer, which should take care of translating between our model and a web data format (JSON).
-
-Let's take this one step further and allow multiple users to manage users, and add in one more
-custom handler to provide an authentication layer to our application. We can't just let anybody
-be modifying another user's animals!
-```julia
-# modified Animal struct to associate with specific user
-mutable struct Animal
-    id::Int
-    userId::Base.UUID
-    type::String
-    name::String
-end
-
-# modify our data store to allow for multiple users
-const ANIMALS = Dict{Base.UUID, Dict{Int, Animal}}()
-
-# creating a user returns a new UUID key unique to the user
-createUser(req) = Base.UUID(rand(UInt128))
-
-# add an additional endpoint for user creation
-HTTP.@register(ANIMAL_ROUTER, "POST", "/api/zoo/v1/users", createUser)
-# modify service endpoints to have user pass UUID in
-HTTP.@register(ANIMAL_ROUTER, "GET", "/api/zoo/v1/users/*/animals/*", getAnimal)
-HTTP.@register(ANIMAL_ROUTER, "DELETE", "/api/zoo/v1/users/*/animals/*", deleteAnimal)
-
-# modified service functions to account for multiple users
-function createAnimal(req::HTTP.Request, animal)
-    animal.id = getNextId()
-    ANIMALS[animal.userId][animal.id] = animal
-    return animal
-end
-
-function getAnimal(req::HTTP.Request)
-    paths = HTTP.URIs.splitpath(req.target)
-    userId = path[5] # /api/zoo/v1/users/x92jf-.../animals/10, get user UUID
-    animalId = path[7] # /api/zoo/v1/users/x92jf-.../animals/10, get 10
-    return ANIMALS[userId][parse(Int, animalId)]
-end
-
-function updateAnimal(req::HTTP.Request, animal)
-    ANIMALS[animal.userId][animal.id] = animal
-    return animal
-end
-
-function deleteAnimal(req::HTTP.Request)
-    paths = HTTP.URIs.splitpath(req.target)
-    userId = path[5] # /api/zoo/v1/users/x92jf-.../animals/10, get user UUID
-    animalId = path[7] # /api/zoo/v1/users/x92jf-.../animals/10, get 10
-    delete!(ANIMALS[userId], parse(Int, animal.id))
-    return ""
-end
-
-# AuthHandler to reject any unknown users
-function AuthHandler(req)
-    if HTTP.hasheader(req, "Animal-UUID")
-        uuid = HTTP.header(req, "Animal-UUID")
-        if haskey(ANIMALS, uuid)
-            return JSONHandler(req)
-        end
-    end
-    return HTTP.Response(401, "unauthorized")
-end
-```
-
-And our modified server invocation:
-```julia
-HTTP.serve(AuthHandler, Sockets.localhost, 8081)
-```
-
-Let's review what's going on here:
-  * Each `Animal` object now includes a `UUID` object unique to a user
-  * We added a `/api/zoo/v1/users` endpoint for creating a new user
-  * Each of our service functions now account for individual users
-  * We made a new `AuthHandler` as the very first entry point in our middleware stack,
-    this means that every single request must first pass through this authentication
-    layer before reaching the service layer. Our `AuthHandler` checks that the user
-    provided our security request header `Animal-UUID` and if so, ensures the provided
-    UUID corresponds to a valid user. If not, the `AuthHandler` returns a 401
-    HTTP response, signalling that the request is unauthorized
-
-Voila, hopefully that helps provide a slightly-more-than-trivial example of utilizing the
-HTTP.Handler framework in conjunction with running an HTTP server.
-"""
 module Handlers
 
-export serve, Handler, handle, RequestHandlerFunction, StreamHandlerFunction,
-       RequestHandler, StreamHandler,
-       Router, @register, register!
+export serve, Router, register!
 
 using URIs
 using ..Messages, ..Streams, ..IOExtras, ..Servers, ..Sockets
 
-"""
-    HTTP.handle(handler::HTTP.RequestHandler, ::HTTP.Request) => HTTP.Response
-    HTTP.handle(handler::HTTP.StreamHandler, ::HTTP.Stream)
-
-Dispatch function used to handle incoming requests to a server. Can be
-overloaded by custom `HTTP.Handler` subtypes to implement custom "handling"
-behavior.
-"""
-function handle end
-
-abstract type Handler end
-
-"""
-    RequestHandler
-
-Abstract type representing objects that handle `HTTP.Request` and return `HTTP.Response` objects.
-
-See `?HTTP.RequestHandlerFunction` for an example of a concrete implementation.
-"""
-abstract type RequestHandler <: Handler end
-
-"""
-    StreamHandler
-
-Abstract type representing objects that handle `HTTP.Stream` objects directly.
-
-See `?HTTP.StreamHandlerFunction` for an example of a concrete implementation.
-"""
-abstract type StreamHandler <: Handler end
-
-"""
-    RequestHandlerFunction(f)
-
-A function-wrapper type that is a subtype of `RequestHandler`. Takes a single function as an argument
-that should be of the form `f(::HTTP.Request) => HTTP.Response`
-"""
-struct RequestHandlerFunction{F} <: RequestHandler
-    func::F # func(req)
-end
-
-handle(h::RequestHandlerFunction, req::Request, args...) = h.func(req, args...)
-
-# deprecated
-const HandlerFunction = RequestHandlerFunction
-
-"""
-    StreamHandlerFunction(f)
-
-A function-wrapper type that is a subtype of `StreamHandler`. Takes a single function as an argument
-that should be of the form `f(::HTTP.Stream) => Nothing`, i.e. it accepts a raw `HTTP.Stream`,
-handles the incoming request, writes a response back out to the stream directly, then returns.
-"""
-struct StreamHandlerFunction{F} <: StreamHandler
-    func::F # func(stream)
-end
-
-handle(h::StreamHandlerFunction, stream::Stream, args...) = h.func(stream, args...)
-
-"For request handlers, read a full request from a stream, pass to the handler, then write out the response"
-function handle(h::RequestHandler, http::Stream, args...)
-    request::Request = http.message
-    request.body = read(http)
-    closeread(http)
-    request.response::Response = handle(h, request, args...)
-    request.response.request = request
-    startwrite(http)
-    write(http, request.response.body)
-    return
-end
-
-"A default 404 Handler"
-const FourOhFour = RequestHandlerFunction(req -> Response(404))
-
-"""
-    HTTP.serve([host=Sockets.localhost[, port=8081]]; kw...) do req::HTTP.Request
-        ...
+function streamhandler(handler)
+    return function(stream::Stream)
+        request::Request = stream.message
+        request.body = read(stream)
+        closeread(stream)
+        request.response::Response = handler(request)
+        request.response.request = request
+        startwrite(stream)
+        write(stream, request.response.body)
+        return
     end
-    HTTP.serve([host=Sockets.localhost[, port=8081]]; stream=true, kw...) do stream::HTTP.Stream
-        ...
-    end
-    HTTP.serve(handler, [host=Sockets.localhost[, port=8081]]; kw...)
-
-Listen for HTTP connections and handle each request received. The "handler" can be a function
-that operates directly on `HTTP.Stream`, `HTTP.Request`, or any kind of `HTTP.Handler` instance.
-For functions like `f(::HTTP.Stream)`, also pass `stream=true` to signal a streaming handler.
-
-Optional keyword arguments:
- - `sslconfig=nothing`, Provide an `MbedTLS.SSLConfig` object to handle ssl connections.
-    Pass `sslconfig=MbedTLS.SSLConfig(false)` to disable ssl verification (useful for testing)
- - `reuse_limit = nolimit`, number of times a connection is allowed to be reused
-    after the first request.
- - `tcpisvalid::Function (::TCPSocket) -> Bool`, check accepted connection before
-    processing requests. e.g. to implement source IP filtering, rate-limiting, etc.
- - `readtimeout::Int=0`, close the connection if no data is received for this
-    many seconds. Use readtimeout = 0 to disable.
- - `reuseaddr::Bool=false`, allow multiple server processes to listen on the same port. Only fully supported on linux; OSX will allow multiple server processes to listen, but only one will accept connections
- - `server::Base.IOServer=nothing`, provide an `IOServer` object to listen on;
-    allows manual control over closing the server.
- - `connection_count::Ref{Int}`, reference to track the # of currently open connections.
- - `rate_limit::Rational{Int}=nothing"`, number of `connections//second` allowed
-    per client IP address; excess connections are immediately closed. e.g. 5//1.
- - `stream::Bool=false`, the handler will operate on an `HTTP.Stream` instead of `HTTP.Request`
- - `verbose::Bool=false`, log connection information to `stdout`.
- - `on_shutdown::Union{Function, Vector{<:Function}, Nothing}=nothing`, one or
-    more functions to be run if the server is closed (for example by an
-    `InterruptException`). Note, shutdown function(s) will not run if an
-    `IOServer` object is supplied to the `server` keyword argument and closed
-    by `close(server)`.
-
-# Examples
-```julia
-HTTP.serve(; stream=true) do http::HTTP.Stream
-    @show http.message
-    @show HTTP.header(http, "Content-Type")
-    while !eof(http)
-        println("body data: ", String(readavailable(http)))
-    end
-    HTTP.setstatus(http, 404)
-    HTTP.setheader(http, "Foo-Header" => "bar")
-    startwrite(http)
-    write(http, "response body")
-    write(http, "more response body")
-    return
 end
-
-# pass in own server socket to control shutdown
-using Sockets
-server = Sockets.listen(Sockets.InetAddr(parse(IPAddr, host), port))
-@async HTTP.serve(f, host, port; server=server)
-# close server which will stop HTTP.serve
-close(server)
-```
-"""
-function serve end
 
 function serve(f, host=Sockets.localhost, port=8081; stream::Bool=false, kw...)
-    handler = f isa Handler ? f : stream ? StreamHandlerFunction(f) : RequestHandlerFunction(f)
-    return Servers.listen(x->handle(handler, x), host, port; kw...)
+    return Servers.listen(stream ? f : streamhandler(f), host, port; kw...)
 end
 
-struct Route
-    method::String
-    scheme::String
-    host::String
-    path::String
-end
-getprt(s) = isempty(s) ? "*" : s
-Base.show(io::IO, r::Route) = print(io, "HTTP.Route(method=$(getprt(r.method)), scheme=$(getprt(r.scheme)), host=$(getprt(r.host)), path=$(r.path))")
-
-"""
-    HTTP.Router(h::Handler)
-    HTTP.Router(f::Function)
-    HTTP.Router()
-
-An `HTTP.Handler` type that supports pattern matching request url paths to registered `HTTP.Handler`s.
-Can accept a default `Handler` or `Function` that will be used in case no other handlers match; by
-default, a 404 response handler is used.
-Paths can be mapped to a handler via `HTTP.@register(r::Router, path, handler)`, see `?HTTP.@register` for more details.
-"""
-struct Router{sym} <: Handler
-    default::Handler
-    routes::Dict{Route, Any}
-    segments::Dict{String, Val}
+# tree-based router handler
+mutable struct Variable
+    name::String
+    pattern::Union{Nothing, Regex}
 end
 
-function Router(default::Union{Handler, Function}=FourOhFour)
-    # each router gets a unique symbol as a type parameter so that dispatching
-    # requests always go to the correct router
-    sym = gensym()
-    return Router{sym}(default isa Function ? RequestHandlerFunction(default) : default, Dict{Route, String}(), Dict{String, Val}())
-end
+const VARREGEX = r"^{([[:alnum:]]+):?(.*)}$"
 
-const SCHEMES = Dict{String, Val}("http" => Val{:http}(), "https" => Val{:https}())
-const EMPTYVAL = Val{()}()
-
-function newsplitsegments(segments)
-    vals = Expr[]
-    for s in segments
-        if s == "*" #TODO: or variable, keep track of variable types and store in handler
-            T = Any
-        else
-            T = Val{Symbol(s)}
-        end
-        push!(vals, Expr(:(::), T))
+function Variable(pattern)
+    re = match(VARREGEX, pattern)
+    if re === nothing
+        error("problem parsing path variable for route: `$pattern`")
     end
-    return vals
+    pat = re.captures[2]
+    return Variable(re.captures[1], pat == "" ? nothing : Regex(pat))
 end
 
-"Dispatch function from a request target to router handler mapping; each `HTTP.@register` defines a new method to `gethandler` for a specific router to dispatch on"
-function gethandler end
-"fallback for all routers, calls the default handler the router was created with"
-gethandler(r::Router, args...) = r.default
+struct Leaf
+    method::String
+    variables::Vector{Tuple{Int, String}}
+    path::String
+    handler::Any
+end
 
-# convenience function to turn a path segment in to a Val{:segment} or Any if empty
-gh(s::String) = isempty(s) ? Any : Val{Symbol(s)}
-gh(s::Symbol) = Val{s}
+Base.show(io::IO, x::Leaf) = print(io, "Leaf($(x.method))")
 
-function generate_gethandler(router, method, scheme, host, path, handler)
-    vals = newsplitsegments(map(String, split(path, '/'; keepempty=false)))
-    route = Route(string(method), string(scheme), string(host), string(path))
-    q = esc(quote
-        $(router).routes[$route] = $handler
-        function HTTP.Handlers.gethandler(r::typeof($router),
-            ::$(gh(method)),
-            ::$(gh(scheme)),
-            ::$(gh(host)),
-            $(vals...),
-            args...)
-            handler = $handler
-            return handler isa HTTP.Handler ? handler : HTTP.Handlers.RequestHandlerFunction(handler)
+export Node
+mutable struct Node
+    segment::Union{String, Variable}
+    exact::Vector{Node} # sorted alphabetically, all x.segment are String
+    conditional::Vector{Node} # unsorted; will be applied in source-order; all x.segment are Regex
+    wildcard::Union{Node, Nothing} # unconditional variable or wildcard
+    doublestar::Union{Node, Nothing} # /** to match any length of path; must be final segment
+    methods::Vector{Leaf}
+end
+
+Base.show(io::IO, x::Node) = print(io, "Node($(x.segment))")
+
+isvariable(x) = startswith(x, "{") && endswith(x, "}")
+segment(x) = segment == "*" ? String(segment) : isvariable(x) ? Variable(x) : String(x)
+
+Node(x) = Node(x, Node[], Node[], nothing, nothing, Leaf[])
+Node() = Node("*")
+
+function find(y, itr; by=identity, eq=(==))
+    for (i, x) in enumerate(itr)
+        eq(by(x), y) && return i
+    end
+    return nothing
+end
+
+function Base.insert!(node::Node, leaf, segments, i)
+    if i > length(segments)
+        # time to insert leaf method match node
+        j = find(leaf.method, node.methods; by=x->x.method, eq=(x, y) -> x == "*" || x == y)
+        if j === nothing
+            push!(node.methods, leaf)
+        else
+            # hmmm, we've seen this route before, warn that we're replacing
+            @warn "replacing existing registered route; $(node.methods[j].method) => \"$(node.methods[j].path)\" route with new path = \"$(leaf.path)\""
+            node.methods[j] = leaf
         end
-    end)
-    # @show q
-    return q
+        return
+    end
+    segment = segments[i]
+    # @show segment, segment isa Variable
+    if segment isa Variable
+        # if we're inserting a variable segment, add variable name to leaf vars array
+        push!(leaf.variables, (i, segment.name))
+    end
+    # figure out which kind of node this segment is
+    if segment == "*" || (segment isa Variable && segment.pattern === nothing)
+        # wildcard node
+        if node.wildcard === nothing
+            node.wildcard = Node(segment)
+        end
+        return insert!(node.wildcard, leaf, segments, i + 1)
+    elseif segment == "**"
+        # double-star node
+        if node.doublestar === nothing
+            node.doublestar = Node(segment)
+        end
+        if i < length(segments)
+            error("/** double wildcard must be last segment in path")
+        end
+        return insert!(node.doublestar, leaf, segments, i + 1)
+    elseif segment isa Variable
+        # conditional node
+        # check if we've seen this exact conditional segment before
+        j = find(segment.pattern, node.conditional; by=x->x.segment.pattern)
+        if j === nothing
+            # new pattern
+            n = Node(segment)
+            push!(node.conditional, n)
+        else
+            n = node.conditional[j]
+        end
+        return insert!(n, leaf, segments, i + 1)
+    else
+        # exact node
+        @assert segment isa String
+        j = find(segment, node.exact; by=x->x.segment)
+        if j === nothing
+            # new exact match segment
+            n = Node(segment)
+            push!(node.exact, n)
+            sort!(node.exact; by=x->x.segment)
+            return insert!(n, leaf, segments, i + 1)
+        else
+            # existing exact match segment
+            return insert!(node.exact[j], leaf, segments, i + 1)
+        end
+    end
 end
 
-"""
-    HTTP.@register(r::Router, path, handler)
-    HTTP.@register(r::Router, method::String, path, handler)
-    HTTP.@register(r::Router, method::String, scheme::String, host::String, path, handler)
-
-Function to map request urls matching `path` and optional method, scheme, host to another `handler::HTTP.Handler`.
-URL paths are registered one at a time, and multiple urls can map to the same handler.
-The URL can be passed as a String. Requests can be routed based on: method, scheme, hostname, or path.
-The following examples show how various urls will direct how a request is routed by a server:
-
-- `"http://*"`: match all HTTP requests, regardless of path
-- `"https://*"`: match all HTTPS requests, regardless of path
-- `"/gmail"`: regardless of scheme or host, match any request with a path starting with "gmail"
-- `"/gmail/userId/*/inbox`: match any request matching the path pattern, "*" is used as a wildcard that matches any value between the two "/"
-
-Note that due to being a macro (and the internal routing functionality), routes can only be registered
-statically, i.e. at the top level of a module, and not dynamically, i.e. inside a function.
-"""
-:(@register)
-
-macro register(r, method, scheme, host, path, handler)
-    return generate_gethandler(r, method, scheme, host, path, handler)
+function Base.match(node::Node, params, method, segments, i)
+    # @show node.segment, i, segments
+    if i > length(segments)
+        if isempty(node.methods)
+            return nothing
+        end
+        j = find(method, node.methods; by=x->x.method, eq=(x, y) -> x == "*" || x == y)
+        if j === nothing
+            # we return missing here so we can return a 405 instead of 404
+            # i.e. we matched the route, but there wasn't a matching method
+            return missing
+        else
+            leaf = node.methods[j]
+            # @show leaf.variables, segments
+            if !isempty(leaf.variables)
+                # we have variables to fill in
+                for (i, v) in leaf.variables
+                    params[v] = segments[i]
+                end
+            end
+            return leaf.handler
+        end
+    end
+    segment = segments[i]
+    anymissing = false
+    # first check for exact matches
+    j = find(segment, node.exact; by=x->x.segment)
+    if j !== nothing
+        # found an exact match, recurse
+        m = match(node.exact[j], params, method, segments, i + 1)
+        anymissing = m === missing
+        m = coalesce(m, nothing)
+        # @show :exact, m
+        if m !== nothing
+            return m
+        end
+    end
+    # check for conditional matches
+    for node in node.conditional
+        # @show node.segment.pattern, segment
+        if match(node.segment.pattern, segment) !== nothing
+            # matched a conditional node, recurse
+            m = match(node, params, method, segments, i + 1)
+            anymissing = m === missing
+            m = coalesce(m, nothing)
+            if m !== nothing
+                return m
+            end
+        end
+    end
+    if node.wildcard !== nothing
+        m = match(node.wildcard, params, method, segments, i + 1)
+        anymissing = m === missing
+        m = coalesce(m, nothing)
+        if m !== nothing
+            return m
+        end
+    end
+    if node.doublestar !== nothing
+        m = match(node.doublestar, params, method, segments, length(segments) + 1)
+        anymissing = m === missing
+        m = coalesce(m, nothing)
+        if m !== nothing
+            return m
+        end
+    end
+    return anymissing ? missing : nothing
 end
-macro register(r, method, path, handler)
-    return generate_gethandler(r, method, "", "", path, handler)
-end
-macro register(r, path, handler)
-    return generate_gethandler(r, "", "", "", path, handler)
-end
 
-function gethandler(r::Router, req::Request)
-    # get the url/path of the request
-    m = Val(Symbol(req.method))
-    # get scheme, host, split path into strings and get Vals
-    uri = URI(req.target)
-    s = get(SCHEMES, uri.scheme, EMPTYVAL)
-    h = Val(Symbol(uri.host))
-    p = uri.path
-    segments = split(p, '/'; keepempty=false)
-    # dispatch to the most specific handler, given the path
-    vals = (get(r.segments, s, Val(Symbol(s))) for s in segments)
-    return gethandler(r, m, s, h, vals...)
+struct Router{T, S}
+    _404::T
+    _405::S
+    routes::Node
 end
 
-handle(r::Router, stream::Stream, args...) = handle(gethandler(r, stream.message), stream, args...)
-handle(r::Router, req::Request, args...) = handle(gethandler(r, req), req, args...)
+Router(_404=req -> Response(404), _405=req -> Response(405)) = Router(_404, _405, Node())
 
+function register!(r::Router, method, path, handler)
+    segments = map(segment, split(path, '/'; keepempty=false))
+    insert!(r.routes, Leaf(method, Tuple{Int, String}[], path, handler), segments, 1)
+    return
+end
+
+register!(r::Router, path, handler) = register!(r, "*", path, handler)
+
+const Params = Dict{String, String}
+
+function (r::Router)(req)
+    url = URI(req.target)
+    segments = split(url.path, '/'; keepempty=false)
+    params = Params()
+    handler = match(r.routes, params, req.method, segments, 1)
+    if handler === nothing
+        # didn't match a registered route
+        return r._404(req)
+    elseif handler === missing
+        # matched the path, but method not supported
+        return r._405(req)
+    else
+        if !isempty(params)
+            req.context[:params] = params
+        end
+        return handler(req)
+    end
+end
 
 end # module

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -1,82 +1,67 @@
-module TestHandlers
-
-using HTTP
-using Test
-import Base.==
-
-==(a::HTTP.Response,b::HTTP.Response) = (a.status  == b.status)    &&
-                                        (a.version == b.version)   &&
-                                        (a.headers == b.headers)   &&
-                                        (a.body    == b.body)
+using HTTP, Test
 
 @testset "Handlers" begin
-    @testset "FooRouter" begin
-        r = HTTP.Router()
-        f = HTTP.Handlers.RequestHandlerFunction((req) -> HTTP.Response(200))
-        HTTP.@register(r, "/test", f)
-        req = HTTP.Request()
-        req.target = "/test"
-        @test HTTP.handle(r, req) == HTTP.Response(200)
-    end
 
-    @testset "HTTP Router" begin
-        f = HTTP.Handlers.RequestHandlerFunction((req) -> HTTP.Response(200))
-        @test HTTP.handle(f, HTTP.Request()) == HTTP.Response(200)
+    r = HTTP.Router(_ -> 0, _ -> -1)
+    HTTP.register!(r, "/test", _ -> 1)
+    @test r(HTTP.Request("GET", "/test")) == 1
 
-        r = HTTP.Router()
-        @test isempty(r.routes)
-        @test HTTP.handle(r, HTTP.Request()) == HTTP.Response(404)
+    HTTP.register!(r, "/path/to/greatness", _ -> 2)
+    @test r(HTTP.Request("GET", "/path/to/greatness")) == 2
 
-        HTTP.@register(r, "/path/to/greatness", f)
-        req = HTTP.Request()
-        req.target = "/path/to/greatness"
-        @test HTTP.handle(r, req) == HTTP.Response(200)
+    HTTP.register!(r, "/next/path/to/greatness", _ -> 3)
+    @test r(HTTP.Request("GET", "/next/path/to/greatness")) == 3
 
-        f2 = HTTP.Handlers.RequestHandlerFunction((req) -> HTTP.Response(201))
-        HTTP.@register(r, "/next/path/to/greatness", f2)
-        req = HTTP.Request()
-        req.target = "/next/path/to/greatness"
-        @test HTTP.handle(r, req) == HTTP.Response(201)
+    HTTP.register!(r, "GET", "/sget", _ -> 4)
+    HTTP.register!(r, "POST", "/spost", _ -> 5)
+    HTTP.register!(r, "POST", "/tpost", _ -> 6)
+    HTTP.register!(r, "GET", "/tpost", _ -> 7)
+    @test r(HTTP.Request("GET", "/sget")) == 4
+    @test r(HTTP.Request("POST", "/sget")) == -1
+    @test r(HTTP.Request("GET", "/spost")) == -1
+    @test r(HTTP.Request("POST", "/spost")) == 5
+    @test r(HTTP.Request("POST", "/tpost")) == 6
+    @test r(HTTP.Request("GET", "/tpost")) == 7
 
-        r = HTTP.Router()
-        HTTP.@register(r, "GET", "/sget", f)
-        HTTP.@register(r, "POST", "/spost", f)
-        HTTP.@register(r, "POST", "/tpost", f)
-        req = HTTP.Request("GET", "/sget")
-        @test HTTP.handle(r, req) == HTTP.Response(200)
-        req = HTTP.Request("POST", "/sget")
-        @test HTTP.handle(r, req) == HTTP.Response(404)
-        req = HTTP.Request("GET", "/spost")
-        @test HTTP.handle(r, req) == HTTP.Response(404)
-        req = HTTP.Request("POST", "/spost")
-        @test HTTP.handle(r, req) == HTTP.Response(200)
-        req = HTTP.Request("GET", "/tpost")
-        @test HTTP.handle(r, req) == HTTP.Response(404)
-        req = HTTP.Request("POST", "/tpost")
-        @test HTTP.handle(r, req) == HTTP.Response(200)
+    HTTP.register!(r, "/test/*", _ -> 8)
+    HTTP.register!(r, "/test/sarv/ghotra", _ -> 9)
+    HTTP.register!(r, "/test/*/ghotra/seven", _ -> 10)
 
-        r = HTTP.Router()
-        HTTP.@register(r, "/test", f)
-        HTTP.@register(r, "/test/*", f2)
-        f3 = HTTP.Handlers.RequestHandlerFunction((req) -> HTTP.Response(202))
-        HTTP.@register(r, "/test/sarv/ghotra", f3)
-        f4 = HTTP.Handlers.RequestHandlerFunction((req) -> HTTP.Response(203))
-        HTTP.@register(r, "/test/*/ghotra/seven", f4)
+    @test r(HTTP.Request("GET", "/test/sarv")) == 8
+    @test r(HTTP.Request("GET", "/test/sarv/ghotra")) == 9
+    @test r(HTTP.Request("GET", "/test/sarv/ghotra/seven")) == 10
+    @test r(HTTP.Request("GET", "/test/foo")) == 8
 
-        req = HTTP.Request()
-        req.target = "/test"
-        @test HTTP.handle(r, req) == HTTP.Response(200)
+    HTTP.register!(r, "/api/widgets/{id}", req -> req.context[:params]["id"])
+    @test r(HTTP.Request("GET", "/api/widgets/11")) == "11"
 
-        req.target = "/test/sarv"
-        @test HTTP.handle(r, req) == HTTP.Response(201)
+    HTTP.register!(r, "/api/widgets/{name}", req -> req.context[:params]["name"])
+    @test r(HTTP.Request("GET", "/api/widgets/11")) == "11"
 
-        req.target = "/test/sarv/ghotra"
-        @test HTTP.handle(r, req) == HTTP.Response(202)
+    HTTP.register!(r, "/api/widgets/acme/{id:[a-z]+}", req -> req.context[:params]["id"])
+    @test r(HTTP.Request("GET", "/api/widgets/acme/11")) == 0
+    @test r(HTTP.Request("GET", "/api/widgets/acme/abc")) == "abc"
 
-        req.target = "/test/sar/ghotra/seven"
-        @test HTTP.handle(r, req) == HTTP.Response(203)
-    end
+    HTTP.register!(r, "/test/**", _ -> 11)
+    @test r(HTTP.Request("GET", "/test/sarv")) == 8
+    @test r(HTTP.Request("GET", "/test/sarv/ghotra")) == 9
+    @test r(HTTP.Request("GET", "/test/sarv/ghotra/seven")) == 10
+    @test r(HTTP.Request("GET", "/test/foo")) == 8
+    @test r(HTTP.Request("GET", "/test/foo/foobar")) == 11
+    @test r(HTTP.Request("GET", "/test/foo/foobar/baz")) == 11
+    @test r(HTTP.Request("GET", "/test/foo/foobar/baz/sailor")) == 11
+
+    @test_throws ErrorException HTTP.register!(r, "/test/**/foo", _ -> 11)
+
+    HTTP.register!(r, "/api/widgets/{name:[a-z]+}/subwidgetsbyname", _ -> 12)
+    HTTP.register!(r, "/api/widgets/{id:[0-9]+}/subwidgetsbyid", _ -> 13)
+    HTTP.register!(r, "/api/widgets/{id}", _ -> 14)
+    HTTP.register!(r, "/api/widgets/{subId}/subwidget", _ -> 15)
+    HTTP.register!(r, "/api/widgets/{subName}/subwidgetname", _ -> 16)
+    @test r(HTTP.Request("GET", "/api/widgets/abc/subwidgetsbyname")) == 12
+    @test r(HTTP.Request("GET", "/api/widgets/123/subwidgetsbyid")) == 13
+    @test r(HTTP.Request("GET", "/api/widgets/234")) == 14
+    @test r(HTTP.Request("GET", "/api/widgets/abc/subwidget")) == 15
+    @test r(HTTP.Request("GET", "/api/widgets/abc/subwidgetname")) == 16
 
 end
-
-end # module

--- a/test/server.jl
+++ b/test/server.jl
@@ -40,7 +40,7 @@ end
     server = Sockets.listen(ip"127.0.0.1", port)
     tsk = @async HTTP.listen(handler, "127.0.0.1", port; server=server)
 
-    handler2 = HTTP.Handlers.RequestHandlerFunction(req->HTTP.Response(200, req.body))
+    handler2 = req -> HTTP.Response(200, req.body)
 
     server2 = Sockets.listen(ip"127.0.0.1", port+100)
     tsk2 = @async HTTP.serve(handler2, "127.0.0.1", port+100; server=server2)


### PR DESCRIPTION
Ok, this is the start of the server-side overhaul that matches #789 which was client-side. The main changes here include:
  * Removing the abstract `Handler` type in the Handlers module
  * The middleware/handler interfaces now consists of the following, which match what we have on the client side:
    * `Handler`: a function of the form `req::Request -> resp::Response` (technically, there's also a "stream" handler interface of the form `stream::Stream -> Nothing`, but that's the more advanced form)
    * `Middleware`: a function of the form `handler::Handler -> handler::Handler`
    
  The key (and only current) example of a middleware we have right now is:
  ```julia
  function streamhandler(handler)
    return function(stream::Stream)
        request::Request = stream.message
        request.body = read(stream)
        closeread(stream)
        request.response::Response = handler(request)
        request.response.request = request
        startwrite(stream)
        write(stream, request.response.body)
        return
    end
end
  ```
which is a middleware that takes a _request_ handler and and returns a _stream_ handler that we wrap request handlers with by default in `HTTP.serve`. If the user passes `stream=true`, then we won't wrap, assuming they're passing their own stream handler.

  * For better or worse, this PR also overhauls the `HTTP.Router` type to a more traditional/standard approach. Routes can now be registered dynamically. They are parsed into a single trie-based structure. We allow [ant-style path patterns](https://gist.github.com/luanvuhlu/894a2194f8e67761cd1a4d11961cbf37) in paths, which means you can do things like `/*/` to wildcard match any segment (we already supported this previously), `/**` double wildcard as the final segment to match any length of path after the `**`, and named variable matching like `/{id}/`, which will be stored in the `req.context[:params]` in a `Dict` with the path variable name as key. You can also add a regex to conditionally match a variable, like `/{id:[0-9]+}/` to only match numbers. Note this doesn't _parse_ the argument, only does the regex match. The `Router` also supports 405 responses in addition to 404 (405 for when the path matches, but not the method).
  
  Planning to add some inline docs here.