### PR TITLE
Allow `HTTP.header` default to be anything

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -386,7 +386,7 @@ field_name_isequal(a, b) = ascii_lc_isequal(a, b)
 Get header value for `key` (case-insensitive).
 """
 header(m::Message, k, d="") = header(m.headers, k, d)
-header(h::Headers, k::AbstractString, d::AbstractString="") =
+header(h::Headers, k::AbstractString, d="") =
     getbyfirst(h, k, k => d, field_name_isequal)[2]
 
 """

--- a/test/messages.jl
+++ b/test/messages.jl
@@ -83,6 +83,12 @@ using JSON
         @test filter(x->first(x) == "Set-Cookie", req.headers) == ["Set-Cookie" => "A", "Set-Cookie" => "B"]
     end
 
+    @testset "Header default" begin
+        @test !hasheader(req, "Null")
+        @test header(req, "Null") == ""
+        @test header(req, "Null", nothing) === nothing
+    end
+
     @testset "HTTP Version" begin
         @test Messages.httpversion(req) == "HTTP/1.1"
         @test Messages.httpversion(res) == "HTTP/1.1"


### PR DESCRIPTION
I wanted to be able to set the default to `nothing` to be able to distinguish from header which is set to the empty string.