### PR TITLE
IODebug.jl: remove stale code

### DIFF
--- a/src/IODebug.jl
+++ b/src/IODebug.jl
@@ -1,29 +1,12 @@
-const live_mode = true
 
 import ..debug_header
 
-@static if live_mode
-
-    struct IODebug{T <: IO} <: IO
-        io::T
-    end
-
-    logwrite(iod::IODebug, f, x) = show_io_debug(stdout, "➡️ ", f, x)
-    logread(iod::IODebug, f, x) = show_io_debug(stdout, "⬅️ ", f, x)
-
-else
-
-    struct IODebug{T <: IO} <: IO
-        io::T
-        log::Vector{Tuple{String,String}}
-    end
-
-    IODebug(io::T) where T <: IO = IODebug{T}(io, [])
-
-    logwrite(iod::IODebug, f, x) = push!(iod.log, ("➡️ ", f, x))
-    logread(iod::IODebug, f, x) = push!(iod.log, ("⬅️ ", f, x))
-
+struct IODebug{T <: IO} <: IO
+    io::T
 end
+
+logwrite(iod::IODebug, f, x) = show_io_debug(stdout, "➡️ ", f, x)
+logread(iod::IODebug, f, x) = show_io_debug(stdout, "⬅️ ", f, x)
 
 Base.wait_close(iod::IODebug) = Base.wait_close(iod.io)
 


### PR DESCRIPTION
Fix #800 

as pointed out in #800, this code can not run (the tuple types don't match), so let's just delete it.