### PR TITLE
Refine how redirect method is set

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -149,6 +149,11 @@ Redirect options
 
  - `redirect = true`, follow 3xx redirect responses.
  - `redirect_limit = 3`, number of times to redirect.
+ - `redirect_method = nothing`, the method to use for the redirected request; by default,
+    GET will be used, only responses with 307/308 will use the same original request method.
+    Pass `:same` to pass the same method as the orginal request though note that some servers
+    may not response/accept the same method. It's also valid to pass the exact method to use
+    as a string, like `redirect_method="PUT"`.
  - `forwardheaders = true`, forward original headers on redirect.
 
 

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -71,7 +71,7 @@ using ..Pairs
 using ..IOExtras
 using ..Parsers
 import ..@require, ..precondition_error
-import ..bytes
+import ..bytes, ..Form
 
 include("ascii.jl")
 
@@ -597,6 +597,12 @@ body_show_max = 1000
 The first chunk of the Message Body (for display purposes).
 """
 bodysummary(body) = isbytes(body) ? view(bytes(body), 1:min(nbytes(body), body_show_max)) : "[Message Body was streamed]"
+function bodysummary(body::Form)
+    if length(body.data) == 1 && isa(body.data[1], IOBuffer)
+        return body.data[1].data[1:body.data[1].ptr-1]
+    end
+    return "[Message Body was streamed]"
+end
 
 function compactstartline(m::Message)
     b = IOBuffer()


### PR DESCRIPTION
Fixes #825. TIL: not all redirects should use the same method as
the original request, and in fact, most http client implementations
will default the new request method to GET. I included links to
a few useful discussions/references, but essentially the behavior
we now support is:
  * For 307/308 response status, use original request method; these
    statuses are specifically for indicating the original method is ok
  * For 303 response status, must use GET method
  * For other 3xx responses, it's actually legal to use the original
    method, but most client implementations will switch to GET,
    which means most servers have adapted to expect this and may even
    error if the original request method is used (as is the case in
    the originally reported issue). We now follow this behavior, though,
    like curl, allow overriding this behavior by a new `redirect_method`
    keyword arg to allow specifying the redirect method behavior.