### PR TITLE
Don't write headers if value is empty

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -76,6 +76,8 @@ println(String(r.body))
 `headers` can be any collection where
 `[string(k) => string(v) for (k,v) in headers]` yields `Vector{Pair}`.
 e.g. a `Dict()`, a `Vector{Tuple}`, a `Vector{Pair}` or an iterator.
+By convention, if a header _value_ is the empty string, it will not be written
+when sending a request.
 
 `body` can take a number of forms:
 

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -429,7 +429,9 @@ setheader(h::Headers, v::Pair) =
 Set header `value` in message for `key` if it is not already set.
 """
 function defaultheader!(m, v::Pair)
-    if header(m, first(v)) == ""
+    # return nothing as default to allow users passing "" as empty header
+    # and not being overwritten by default headers
+    if header(m, first(v), nothing) === nothing
         setheader(m, v)
     end
     return
@@ -514,7 +516,8 @@ a line for each "name: value" pair and a trailing blank line.
 function writeheaders(io::IO, m::Message)
     writestartline(io, m)
     for (name, value) in m.headers
-        write(io, "$name: $value\r\n")
+        # match curl convention of not writing empty headers
+        !isempty(value) && write(io, "$name: $value\r\n")
     end
     write(io, "\r\n")
     return

--- a/test/messages.jl
+++ b/test/messages.jl
@@ -190,6 +190,6 @@ using JSON
 
         # https://github.com/JuliaWeb/HTTP.jl/issues/828
         # don't include empty headers in request when writing
-        @test repr(Request("GET", "/", ["Accept" => ""])) == "HTTP.Messages.Request{Vector{UInt8}}:\n\"\"\"\nGET / HTTP/1.1\r\n\r\n\"\"\""
+        @test repr(Request("GET", "/", ["Accept" => ""])) == "Request{Vector{UInt8}}:\n\"\"\"\nGET / HTTP/1.1\r\n\r\n\"\"\""
     end
 end

--- a/test/messages.jl
+++ b/test/messages.jl
@@ -187,5 +187,9 @@ using JSON
 
         # don't display raw binary (non-Unicode) data:
         @test repr(Response(200, []; body=String([0xde,0xad,0xc1,0x71,0x1c]))) == "Response{Base.CodeUnits{UInt8, String}}:\n\"\"\"\nHTTP/1.1 200 OK\r\n\r\n\n⋮\n5-byte body\n\"\"\""
+
+        # https://github.com/JuliaWeb/HTTP.jl/issues/828
+        # don't include empty headers in request when writing
+        @test repr(Request("GET", "/", ["Accept" => ""])) == "HTTP.Messages.Request{Vector{UInt8}}:\n\"\"\"\nGET / HTTP/1.1\r\n\r\n\"\"\""
     end
 end


### PR DESCRIPTION
Fixes #828. This follows a convention curl uses where empty headers
aren't included when the request is sent. Pretty minimal changes here
which is nice that this is so easy to support.