### PR TITLE
don't add gz if we are given a local filepath

### DIFF
--- a/src/download.jl
+++ b/src/download.jl
@@ -58,8 +58,7 @@ determine_file(::Nothing, resp, hdrs) = determine_file(tempdir(), resp, hdrs)
 # ^ We want to the filename if possible because extension is useful for FileIO.jl
 
 function determine_file(path, resp, hdrs)
-    # get the name
-    name = if isdir(path)
+    if isdir(path)
         # we have been given a path to a directory
         # got to to workout what file to put there
         filename = something(
@@ -67,17 +66,19 @@ function determine_file(path, resp, hdrs)
                         try_get_filename_from_request(resp.request),
                         basename(tempname())  # fallback, basically a random string
                     )
+
+        
+        # get the extension, if we are going to save it in encoded form.
+        # unlike a web-browser we don't automatically decompress
+        if header(resp, "Content-Encoding") == "gzip"
+            filename *= ".gz"
+        end
+        
         safer_joinpath(path, filename)
     else
         # We have been given a full filepath
         path
     end
-
-    # get the extension, if we are going to save it in encoded form.
-    if header(resp, "Content-Encoding") == "gzip"
-        name *= ".gz"
-    end
-    name
 end
 
 """

--- a/test/download.jl
+++ b/test/download.jl
@@ -65,8 +65,19 @@ using HTTP
     end
 
     @testset "Content-Encoding" begin
+        # Add gz extension if we are determining the filename
         gzip_content_encoding_fn = HTTP.download("https://httpbin.org/gzip")
         @test isfile(gzip_content_encoding_fn)
         @test last(splitext(gzip_content_encoding_fn)) == ".gz"
+
+        # But not if the local name is fully given. HTTP#573
+        mktempdir() do dir
+            name = joinpath(dir, "foo")
+            downloaded_name = HTTP.download(
+                "https://pkg.julialang.org/registry/23338594-aafe-5451-b93e-139f81909106/7858451b7a520344eb60354f69809d30a44e7dae",
+                name,
+            )
+            @test name == downloaded_name
+        end
     end
 end


### PR DESCRIPTION
Closes https://github.com/JuliaWeb/HTTP.jl/issues/573
I am not sure if this is actually the correct thing to do though.
The content-encoding if gzipped, but i am not sure that it is correct that the file that is downloaded should just ende up gzipped.

I think the real solution is we should probably be decompressing it inside of HTTP.jl?
Not sure
If I open https://httpbin.org/gzip with my browser it is displayed in nongzipped form
OTOH if i open  https://pkg.julialang.org/registry/23338594-aafe-5451-b93e-139f81909106/7858451b7a520344eb60354f69809d30a44e7dae
then a file id downloaded that is gzipped

`curl` doesn't seem to uncompress either (at least by default)