### PR TITLE
Big update to cookie code

### DIFF
--- a/src/CookieRequest.jl
+++ b/src/CookieRequest.jl
@@ -6,14 +6,10 @@ using ..Cookies
 using ..Messages: Request, ascii_lc_isequal, header, setheader
 import ..@debug, ..DEBUG_LEVEL, ..access_threaded
 
-const default_cookiejar = Dict{String, Set{Cookie}}[]
+# default global cookie jar
+const COOKIEJAR = CookieJar()
 
-function __init__()
-    resize!(empty!(default_cookiejar), Threads.nthreads())
-    return
-end
-
-export cookielayer
+export cookielayer, COOKIEJAR
 
 """
     cookielayer(req) -> HTTP.Response
@@ -22,11 +18,10 @@ Add locally stored Cookies to the request headers.
 Store new Cookies found in the response headers.
 """
 function cookielayer(handler)
-    return function(req::Request; cookies=true, cookiejar::Dict{String, Set{Cookie}}=access_threaded(Dict{String, Set{Cookie}}, default_cookiejar), kw...)
+    return function(req::Request; cookies=true, cookiejar::CookieJar=COOKIEJAR, kw...)
         if cookies === true || (cookies isa AbstractDict && !isempty(cookies))
             url = req.url
-            hostcookies = get!(cookiejar, url.host, Set{Cookie}())
-            cookiestosend = getcookies(hostcookies, url)
+            cookiestosend = Cookies.getcookies!(cookiejar, url)
             if !(cookies isa Bool)
                 for (name, value) in cookies
                     push!(cookiestosend, Cookie(name, value))
@@ -34,11 +29,11 @@ function cookielayer(handler)
             end
             if !isempty(cookiestosend)
                 existingcookie = header(req.headers, "Cookie")
-                if existingcookie != "" && get(req.context, :includedCookies, nothing) !== nothing
+                if existingcookie != "" && haskey(req.context, :includedCookies)
                     # this is a redirect where we previously included cookies
                     # we want to filter those out to avoid duplicate cookie sending
                     # and the case where a cookie was set to expire from the 1st request
-                    previouscookies = Cookies.readcookies(req.headers, "")
+                    previouscookies = Cookies.cookies(req)
                     previouslyincluded = req.context[:includedCookies]
                     filtered = filter(x -> !(x.name in previouslyincluded), previouscookies)
                     existingcookie = stringify("", filtered)
@@ -47,43 +42,12 @@ function cookielayer(handler)
                 req.context[:includedCookies] = map(x -> x.name, cookiestosend)
             end
             res = handler(req; kw...)
-            setcookies(hostcookies, url.host, res.headers)
+            Cookies.setcookies!(cookiejar, url, res.headers)
             return res
         else
             # skip
             return handler(req; kw...)
         end
-    end
-end
-
-function getcookies(cookies, url)
-
-    tosend = Vector{Cookie}()
-    expired = Vector{Cookie}()
-
-    # Check if cookies should be added to outgoing request based on host...
-    for cookie in cookies
-        if Cookies.shouldsend(cookie, url.scheme == "https",
-                              url.host, url.path)
-            t = cookie.expires
-            if t != Dates.DateTime(1) && t < Dates.now(Dates.UTC)
-                @debug 1 "Deleting expired Cookie: $cookie.name"
-                push!(expired, cookie)
-            else
-                @debug 1 "Sending Cookie: $cookie.name to $url.host"
-                push!(tosend, cookie)
-            end
-        end
-    end
-    setdiff!(cookies, expired)
-    return tosend
-end
-
-function setcookies(cookies, host, headers)
-    for (k, v) in headers
-        ascii_lc_isequal(k, "set-cookie") || continue
-        @debug 1 "Set-Cookie: $v (from $host)"
-        push!(cookies, Cookies.readsetcookie(host, v))
     end
 end
 

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -183,7 +183,7 @@ Cookie options
 
  - `cookies::Union{Bool, Dict{<:AbstractString, <:AbstractString}} = false`, enable cookies, or alternatively,
         pass a `Dict{AbstractString, AbstractString}` of name-value pairs to manually pass cookies
- - `cookiejar::Dict{String, Set{Cookie}}=default_cookiejar`,
+ - `cookiejar::HTTP.CookieJar=HTTP.COOKIEJAR`: threadsafe cookie jar struct for keeping track of cookies per host
 
 
 Canonicalization options

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -10,6 +10,20 @@ Base.@deprecate escape escapeuri
 using Base64, Sockets, Dates
 using URIs
 
+if !isdefined(Base, Symbol("@lock"))
+    macro lock(l, expr)
+        quote
+            temp = $(esc(l))
+            lock(temp)
+            try
+                $(esc(expr))
+            finally
+                unlock(temp)
+            end
+        end
+    end
+end
+
 function access_threaded(f, v::Vector)
     tid = Threads.threadid()
     0 < tid <= length(v) || _length_assert()

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -10,20 +10,6 @@ Base.@deprecate escape escapeuri
 using Base64, Sockets, Dates
 using URIs
 
-if !isdefined(Base, Symbol("@lock"))
-    macro lock(l, expr)
-        quote
-            temp = $(esc(l))
-            lock(temp)
-            try
-                $(esc(expr))
-            finally
-                unlock(temp)
-            end
-        end
-    end
-end
-
 function access_threaded(f, v::Vector)
     tid = Threads.threadid()
     0 < tid <= length(v) || _length_assert()

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -391,7 +391,9 @@ header(h::Headers, k::AbstractString, d="") =
 
 "get all headers with key `k` or empty if none"
 headers(h::Headers, k::AbstractString) =
-    filter(x -> field_name_isequal(x[1], k), h)
+    map(x -> x[2], filter(x -> field_name_isequal(x[1], k), h))
+headers(m::Message, k::AbstractString) =
+    headers(headers(m), k)
 
 """
     hasheader(::Message, key) -> Bool

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -389,6 +389,10 @@ header(m::Message, k, d="") = header(m.headers, k, d)
 header(h::Headers, k::AbstractString, d="") =
     getbyfirst(h, k, k => d, field_name_isequal)[2]
 
+"get all headers with key `k` or empty if none"
+headers(h::Headers, k::AbstractString) =
+    filter(x -> field_name_isequal(x[1], k), h)
+
 """
     hasheader(::Message, key) -> Bool
 

--- a/src/cookiejar.jl
+++ b/src/cookiejar.jl
@@ -1,0 +1,312 @@
+
+struct CookieJar
+    lock::ReentrantLock
+    # map of host to cookies mapped by id(::Cookie)
+    entries::Dict{String, Dict{String, Cookie}}
+end
+
+CookieJar() = CookieJar(ReentrantLock(), Dict{String, Dict{String, Cookie}}())
+Base.empty!(c::CookieJar) = lock(() -> empty!(c.entries), c.lock)
+
+# shouldsend determines whether e's cookie qualifies to be included in a
+# request to host/path. It is the caller's responsibility to check if the
+# cookie is expired.
+function shouldsend(cookie::Cookie, https::Bool, host, path)
+    return domainmatch(cookie, host) && pathmatch(cookie, path) && (https || !cookie.secure)
+end
+
+# domainMatch implements "domain-match" of RFC 6265 section 5.1.3.
+function domainmatch(cookie::Cookie, host)
+    cookie.domain == host && return true
+    return !cookie.hostonly && hasdotsuffix(host, cookie.domain)
+end
+
+# hasdotsuffix reports whether s ends in "."+suffix.
+function hasdotsuffix(s, suffix)
+    return length(s) > length(suffix) && s[length(s)-length(suffix)] == '.' && s[(length(s)-length(suffix)+1):end] == suffix
+end
+
+# pathMatch implements "path-match" according to RFC 6265 section 5.1.4.
+function pathmatch(cookie::Cookie, requestpath)
+    requestpath == cookie.path && return true
+    if startswith(requestpath, cookie.path)
+        if length(cookie.path) > 0 && cookie.path[end] == '/'
+            return true # The "/any/" matches "/any/path" case.
+        elseif length(requestpath) >= length(cookie.path) + 1 && requestpath[length(cookie.path)+1] == '/'
+            return true # The "/any" matches "/any/path" case.
+        end
+    end
+    return false
+end
+
+function getcookies!(jar::CookieJar, url::URI, now::DateTime=Dates.now(Dates.UTC))::Vector{Cookie}
+    cookies = Cookie[]
+    if url.scheme != "http" && url.scheme != "https"
+        return cookies
+    end
+    host = canonicalhost(url.host)
+    host == "" && return cookies
+    @lock jar.lock begin
+        !haskey(jar.entries, host) && return cookies
+        entries = jar.entries[host]
+        https = url.scheme == "https"
+        path = url.path
+        if path == ""
+            path = "/"
+        end
+        modified = false
+        expired = Cookie[]
+        for (id, e) in entries
+            if e.persistent && e.expires != DateTime(1) && e.expires < now
+                @debug 1 "Deleting expired cookie: $(e.name)"
+                push!(expired, e)
+                continue
+            end
+            if !shouldsend(e, https, host, path)
+                continue
+            end
+            e.lastaccess = now
+            @debug 1 "Including cookie in request: $(e.name) to $(url.host)"
+            push!(cookies, e)
+        end
+        for c in expired
+            delete!(entries, id(c))
+        end
+    end
+    sort!(cookies; lt=(x, y) -> begin
+        if length(x.path) != length(y.path)
+            return length(x.path) > length(y.path)
+        end
+        if x.creation != y.creation
+            return x.creation < y.creation
+        end
+        return x.name < y.name
+    end)
+    return cookies
+end
+
+function setcookies!(jar::CookieJar, url::URI, headers::Headers)
+    cookies = readsetcookies(headers)
+    isempty(cookies) && return
+    if url.scheme != "http" && url.scheme != "https"
+        return
+    end
+    host = canonicalhost(url.host)
+    host == "" && return
+    defPath = defaultPath(url.path)
+    now = Dates.now(Dates.UTC)
+    @lock jar.lock begin
+        entries = get!(() -> Dict{String, Cookie}(), jar.entries, host)
+        for c in cookies
+            if c.path == "" || c.path[1] != '/'
+                c.path = defPath
+            end
+            domainAndType!(jar, c, host) || continue
+            cid = id(c)
+            if c.maxage < 0
+                @goto remove
+            elseif c.maxage > 0
+                c.expires = now + Dates.Second(c.maxage)
+                c.persistent = true
+            else
+                if c.expires == DateTime(1)
+                    c.expires = endOfTime
+                    c.persistent = false
+                else
+                    if c.expires < now
+                        @debug 1 "Cookie expired: $(c.name)"
+                        @goto remove
+                    end
+                    c.persistent = true
+                end
+            end
+            if haskey(entries, cid)
+                old = entries[cid]
+                c.creation = old.creation
+            else
+                c.creation = now
+            end
+            c.lastaccess = now
+            entries[cid] = c
+            continue
+@label remove
+            delete!(entries, cid)
+        end
+    end
+    return
+end
+
+function canonicalhost(host)
+    if hasport(host)
+        host, _, err = splithostport(host)
+        err && return ""
+    end
+    if host[end] == '.'
+        host = chop(host)
+    end
+    return isascii(host) ? lowercase(host) : ""
+end
+
+function hasport(host)
+    colons = count(":", host)
+    colons == 0 && return false
+    colons == 1 && return true
+    return host[1] == '[' && contains(host, "]:")
+end
+
+function defaultPath(path)
+    if isempty(path) || path[1] != '/'
+        return "/"
+    end
+    i = findlast('/', path)
+    if i === nothing || i == 1
+        return "/"
+    end
+    return path[1:i]
+end
+
+const endOfTime = DateTime(9999, 12, 31, 23, 59, 59, 0)
+
+function domainAndType!(jar::CookieJar, c::Cookie, host::String)
+    domain = c.domain
+    if domain == ""
+        # No domain attribute in the SetCookie header indicates a
+        # host cookie.
+        c.domain = host
+        c.hostonly = true
+        return true
+    end
+    if isIP(host)
+        # RFC 6265 is not super clear here, a sensible interpretation
+        # is that cookies with an IP address in the domain-attribute
+        # are allowed.
+
+        # RFC 6265 section 5.2.3 mandates to strip an optional leading
+        # dot in the domain-attribute before processing the cookie.
+        #
+        # Most browsers don't do that for IP addresses, only curl
+        # version 7.54) and and IE (version 11) do not reject a
+        #     Set-Cookie: a=1; domain=.127.0.0.1
+        # This leading dot is optional and serves only as hint for
+        # humans to indicate that a cookie with "domain=.bbc.co.uk"
+        # would be sent to every subdomain of bbc.co.uk.
+        # It just doesn't make sense on IP addresses.
+        # The other processing and validation steps in RFC 6265 just
+        # collaps to:
+        if host != domain
+            c.domain = ""
+            c.hostonly = false
+            return false
+        end
+
+        # According to RFC 6265 such cookies should be treated as
+        # domain cookies.
+        # As there are no subdomains of an IP address the treatment
+        # according to RFC 6265 would be exactly the same as that of
+        # a host-only cookie. Contemporary browsers (and curl) do
+        # allows such cookies but treat them as host-only cookies.
+        # So do we as it just doesn't make sense to label them as
+        # domain cookies when there is no domain; the whole notion of
+        # domain cookies requires a domain name to be well defined.
+        c.domain = host
+        c.hostonly = true
+        return true
+    end
+    # From here on: If the cookie is valid, it is a domain cookie (with
+    # the one exception of a public suffix below).
+    # See RFC 6265 section 5.2.3.
+    if domain[1] == '.'
+        domain = chop(domain; head=1, tail=0)
+    end
+
+    if length(domain) == 0 || domain[1] == '.'
+        # Received either "Domain=." or "Domain=..some.thing",
+        # both are illegal.
+        c.domain = ""
+        c.hostonly = false
+        return false
+    end
+
+    if !isascii(domain)
+        # Received non-ASCII domain, e.g. "perché.com" instead of "xn--perch-fsa.com"
+        c.domain = ""
+        c.hostonly = false
+        return false
+    end
+    domain = lowercase(domain)
+    if domain[end] == '.'
+        # We received stuff like "Domain=www.example.com.".
+        # Browsers do handle such stuff (actually differently) but
+        # RFC 6265 seems to be clear here (e.g. section 4.1.2.3) in
+        # requiring a reject.  4.1.2.3 is not normative, but
+        # "Domain Matching" (5.1.3) and "Canonicalized Host Names"
+        # (5.1.2) are.
+        c.domain = ""
+        c.hostonly = false
+        return false
+    end
+    # The domain must domain-match host: www.mycompany.com cannot
+    # set cookies for .ourcompetitors.com.
+    if host != domain && !hasdotsuffix(host, domain)
+        c.domain = ""
+        c.hostonly = false
+        return false
+    end
+    c.domain = domain
+    c.hostonly = false
+    return true
+end
+
+# SplitHostPort splits a network address of the form "host:port",
+# "host%zone:port", "[host]:port" or "[host%zone]:port" into host or
+# host%zone and port.
+#
+# A literal IPv6 address in hostport must be enclosed in square
+# brackets, as in "[::1]:80", "[::1%lo0]:80".
+#
+# See func Dial for a description of the hostport parameter, and host
+# and port results.
+function splithostport(hostport)
+    j = k = 1
+
+    # The port starts after the last colon.
+    i = findlast(':', hostport)
+    if i === nothing
+        return "", "", true
+    end
+
+    if hostport[1] == '['
+        # Expect the first ']' just before the last ':'.
+        z = findfirst(']', hostport)
+        if z === nothing
+            return "", "", true
+        end
+        if z == length(hostport)
+            return "", "", true
+        elseif (z + 1) == i
+            # expected
+        else
+            # Either ']' isn't followed by a colon, or it is
+            # followed by a colon that is not the last one.
+            return "", "", true
+        end
+        host = SubString(hostport, 2:(z-1))
+        j = 2
+        k = z + 1 # there can't be a '[' resp. ']' before these positions
+    else
+        host = SubString(hostport, 1:i-1)
+        if contains(host, ":")
+            return "", "", true
+        end
+    end
+    len = length(hostport)
+    if findfirst('[', SubString(hostport, j:len)) !== nothing
+        return "", "", true
+    end
+    if findfirst(']', SubString(hostport, k:len)) !== nothing
+        return "", "", true
+    end
+
+    port = SubString(hostport, (i+1):len)
+    return host, port, false
+end

--- a/src/cookiejar.jl
+++ b/src/cookiejar.jl
@@ -46,7 +46,7 @@ function getcookies!(jar::CookieJar, url::URI, now::DateTime=Dates.now(Dates.UTC
     end
     host = canonicalhost(url.host)
     host == "" && return cookies
-    @lock jar.lock begin
+    Base.@lock jar.lock begin
         !haskey(jar.entries, host) && return cookies
         entries = jar.entries[host]
         https = url.scheme == "https"
@@ -95,7 +95,7 @@ function setcookies!(jar::CookieJar, url::URI, headers::Headers)
     host == "" && return
     defPath = defaultPath(url.path)
     now = Dates.now(Dates.UTC)
-    @lock jar.lock begin
+    Base.@lock jar.lock begin
         entries = get!(() -> Dict{String, Cookie}(), jar.entries, host)
         for c in cookies
             if c.path == "" || c.path[1] != '/'

--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -40,20 +40,6 @@ using ..Messages: Request, Response, mkheaders, hasheader, header, headers
 
 import ..IPAddr
 
-if !isdefined(Base, Symbol("@lock"))
-    macro lock(l, expr)
-        quote
-            temp = $(esc(l))
-            lock(temp)
-            try
-                $(esc(expr))
-            finally
-                unlock(temp)
-            end
-        end
-    end
-end
-
 @enum SameSite SameSiteDefaultMode=1 SameSiteLaxMode SameSiteStrictMode SameSiteNoneMode
 
 """
@@ -294,7 +280,7 @@ cookies(r::Request) = readcookies(r.headers, "")
 # readCookies parses all "Cookie" values from the header h and
 # returns the successfully parsed Cookies.
 # if filter isn't empty, only cookies of that name are returned
-function readcookies(h::Headers, filter::String)
+function readcookies(h::Headers, filter::String="")
     result = Cookie[]
     for (_, line) in headers(h, "Cookie")
         for part in split(strip(line), ';'; keepempty=false)

--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -40,6 +40,20 @@ using ..Messages: Request, Response, mkheaders, hasheader, header, headers
 
 import ..IPAddr
 
+if !isdefined(Base, Symbol("@lock"))
+    macro lock(l, expr)
+        quote
+            temp = $(esc(l))
+            lock(temp)
+            try
+                $(esc(expr))
+            finally
+                unlock(temp)
+            end
+        end
+    end
+end
+
 @enum SameSite SameSiteDefaultMode=1 SameSiteLaxMode SameSiteStrictMode SameSiteNoneMode
 
 """

--- a/test/client.jl
+++ b/test/client.jl
@@ -41,7 +41,7 @@ end
     end
 
     @testset "Cookie Requests" begin
-        empty!(HTTP.access_threaded(Dict{String, Set{HTTP.Cookie}}, HTTP.CookieRequest.default_cookiejar))
+        empty!(HTTP.COOKIEJAR)
         r = HTTP.get("$sch://httpbin.org/cookies", cookies=true)
 
         body = String(r.body)
@@ -168,12 +168,12 @@ end
     end
 
     @testset "Client Redirect Following - $read_method" for read_method in ["GET", "HEAD"]
-        @test_skip status(HTTP.request(read_method, "$sch://httpbin.org/redirect/1")) ==200
-        @test_skip status(HTTP.request(read_method, "$sch://httpbin.org/redirect/1", redirect=false)) == 302
-        @test_skip status(HTTP.request(read_method, "$sch://httpbin.org/redirect/6")) == 302 #over max number of redirects
-        @test_skip status(HTTP.request(read_method, "$sch://httpbin.org/relative-redirect/1")) == 200
-        @test_skip status(HTTP.request(read_method, "$sch://httpbin.org/absolute-redirect/1")) == 200
-        @test_skip status(HTTP.request(read_method, "$sch://httpbin.org/redirect-to?url=http%3A%2F%2Fgoogle.com")) == 200
+        @test status(HTTP.request(read_method, "$sch://httpbin.org/redirect/1")) ==200
+        @test status(HTTP.request(read_method, "$sch://httpbin.org/redirect/1", redirect=false)) == 302
+        @test status(HTTP.request(read_method, "$sch://httpbin.org/redirect/6")) == 302 #over max number of redirects
+        @test status(HTTP.request(read_method, "$sch://httpbin.org/relative-redirect/1")) == 200
+        @test status(HTTP.request(read_method, "$sch://httpbin.org/absolute-redirect/1")) == 200
+        @test status(HTTP.request(read_method, "$sch://httpbin.org/redirect-to?url=http%3A%2F%2Fgoogle.com")) == 200
     end
 
     @testset "Client Basic Auth" begin

--- a/test/cookies.jl
+++ b/test/cookies.jl
@@ -29,11 +29,11 @@ using Sockets, Test
 
         # The "special" cookies have values containing commas or spaces which
         # are disallowed by RFC 6265 but are common in the wild.
-        (HTTP.Cookie("special-1", "a z"), "special-1=a z"),
+        (HTTP.Cookie("special-1", "a z"), "special-1=\"a z\""),
         (HTTP.Cookie("special-2", " z"), "special-2=\" z\""),
         (HTTP.Cookie("special-3", "a "), "special-3=\"a \""),
         (HTTP.Cookie("special-4", " "), "special-4=\" \""),
-        (HTTP.Cookie("special-5", "a,z"), "special-5=a,z"),
+        (HTTP.Cookie("special-5", "a,z"), "special-5=\"a,z\""),
         (HTTP.Cookie("special-6", ",z"), "special-6=\",z\""),
         (HTTP.Cookie("special-7", "a,"), "special-7=\"a,\""),
         (HTTP.Cookie("special-8", ","), "special-8=\",\""),
@@ -56,43 +56,48 @@ using Sockets, Test
 
     @testset "readsetcookies" begin
         cookietests = [
-            (Dict(["Set-Cookie"=> "Cookie-1=v\$1"]), [HTTP.Cookie("Cookie-1", "v\$1")]),
-            (Dict(["Set-Cookie"=> "NID=99=YsDT5i3E-CXax-; expires=Wed, 23-Nov-2011 01:05:03 GMT; path=/; domain=.google.ch; HttpOnly"]),
-            [HTTP.Cookie("NID", "99=YsDT5i3E-CXax-"; path="/", domain="google.ch", httponly=true, expires=HTTP.Dates.DateTime(2011, 11, 23, 1, 5, 3, 0))]),
-            (Dict(["Set-Cookie"=> ".ASPXAUTH=7E3AA; expires=Wed, 07-Mar-2012 14:25:06 GMT; path=/; HttpOnly"]),
+            (["Set-Cookie" => "Cookie-1=v\$1"], [HTTP.Cookie("Cookie-1", "v\$1")]),
+            (["Set-Cookie" => "NID=99=YsDT5i3E-CXax-; expires=Wed, 23-Nov-2011 01:05:03 GMT; path=/; domain=.google.ch; HttpOnly"],
+            [HTTP.Cookie("NID", "99=YsDT5i3E-CXax-"; path="/", domain=".google.ch", httponly=true, expires=HTTP.Dates.DateTime(2011, 11, 23, 1, 5, 3, 0))]),
+            (["Set-Cookie" => ".ASPXAUTH=7E3AA; expires=Wed, 07-Mar-2012 14:25:06 GMT; path=/; HttpOnly"],
             [HTTP.Cookie(".ASPXAUTH", "7E3AA"; path="/", expires=HTTP.Dates.DateTime(2012, 3, 7, 14, 25, 6, 0), httponly=true)]),
-            (Dict(["Set-Cookie"=> "ASP.NET_SessionId=foo; path=/; HttpOnly"]),
+            (["Set-Cookie" => "ASP.NET_SessionId=foo; path=/; HttpOnly"],
             [HTTP.Cookie("ASP.NET_SessionId", "foo"; path="/", httponly=true)]),
-            (Dict(["Set-Cookie"=> "special-1=a z"]),  [HTTP.Cookie("special-1", "a z")]),
-            (Dict(["Set-Cookie"=> "special-2=\" z\""]), [HTTP.Cookie("special-2", " z")]),
-            (Dict(["Set-Cookie"=> "special-3=\"a \""]), [HTTP.Cookie("special-3", "a ")]),
-            (Dict(["Set-Cookie"=> "special-4=\" \""]),  [HTTP.Cookie("special-4", " ")]),
-            (Dict(["Set-Cookie"=> "special-5=a,z"]),  [HTTP.Cookie("special-5", "a,z")]),
-            (Dict(["Set-Cookie"=> "special-6=\",z\""]), [HTTP.Cookie("special-6", ",z")]),
-            (Dict(["Set-Cookie"=> "special-7=a,"]),   [HTTP.Cookie("special-7", "a,")]),
-            (Dict(["Set-Cookie"=> "special-8=\",\""]),  [HTTP.Cookie("special-8", ",")]),
+            (["Set-Cookie" => "samesitedefault=foo; SameSite"], [HTTP.Cookie("samesitedefault", "foo"; samesite=HTTP.Cookies.SameSiteDefaultMode)]),
+            (["Set-Cookie" => "samesiteinvalidisdefault=foo; SameSite=invalid"], [HTTP.Cookie("samesiteinvalidisdefault", "foo"; samesite=HTTP.Cookies.SameSiteDefaultMode)]),
+            (["Set-Cookie" => "samesitelax=foo; SameSite=Lax"], [HTTP.Cookie("samesitelax", "foo"; samesite=HTTP.Cookies.SameSiteLaxMode)]),
+            (["Set-Cookie" => "samesitestrict=foo; SameSite=Strict"], [HTTP.Cookie("samesitestrict", "foo"; samesite=HTTP.Cookies.SameSiteStrictMode)]),
+            (["Set-Cookie" => "samesitenone=foo; SameSite=None"], [HTTP.Cookie("samesitenone", "foo"; samesite=HTTP.Cookies.SameSiteNoneMode)]),
+            (["Set-Cookie" => "special-1=a z"],  [HTTP.Cookie("special-1", "a z")]),
+            (["Set-Cookie" => "special-2=\" z\""], [HTTP.Cookie("special-2", " z")]),
+            (["Set-Cookie" => "special-3=\"a \""], [HTTP.Cookie("special-3", "a ")]),
+            (["Set-Cookie" => "special-4=\" \""],  [HTTP.Cookie("special-4", " ")]),
+            (["Set-Cookie" => "special-5=a,z"],  [HTTP.Cookie("special-5", "a,z")]),
+            (["Set-Cookie" => "special-6=\",z\""], [HTTP.Cookie("special-6", ",z")]),
+            (["Set-Cookie" => "special-7=a,"],   [HTTP.Cookie("special-7", "a,")]),
+            (["Set-Cookie" => "special-8=\",\""],  [HTTP.Cookie("special-8", ",")]),
         ]
 
         for (h, c) in cookietests
-            @test HTTP.Cookies.readsetcookies("", [Dict(h)["Set-Cookie"]]) == c
+            @test HTTP.Cookies.readsetcookies(h) == c
         end
     end
 
     @testset "SetCookieDoubleQuotes" begin
         cookiestrings = [
-            "quoted0=none; max-age=30",
-            "quoted1=\"cookieValue\"; max-age=31",
-            "quoted2=cookieAV; max-age=\"32\"",
-            "quoted3=\"both\"; max-age=\"33\"",
+            ["Set-Cookie" => "quoted0=none; max-age=30"],
+            ["Set-Cookie" => "quoted1=\"cookieValue\"; max-age=31"],
+            ["Set-Cookie" => "quoted2=cookieAV; max-age=\"32\""],
+            ["Set-Cookie" => "quoted3=\"both\"; max-age=\"33\""],
         ]
 
         want = [
-            HTTP.Cookie("quoted0", "none", maxage=30),
-            HTTP.Cookie("quoted1", "cookieValue", maxage=31),
-            HTTP.Cookie("quoted2", "cookieAV"),
-            HTTP.Cookie("quoted3", "both"),
+            [HTTP.Cookie("quoted0", "none", maxage=30)],
+            [HTTP.Cookie("quoted1", "cookieValue", maxage=31)],
+            [HTTP.Cookie("quoted2", "cookieAV")],
+            [HTTP.Cookie("quoted3", "both")],
         ]
-        @test all(HTTP.Cookies.readsetcookies("", cookiestrings) .== want)
+        @test all(HTTP.Cookies.readsetcookies.(cookiestrings) .== want)
     end
 
     @testset "Cookie sanitize value" begin
@@ -103,9 +108,12 @@ using Sockets, Test
             "foo\"bar" => "foobar",
             String(UInt8[0x00, 0x7e, 0x7f, 0x80]) => String(UInt8[0x7e]),
             "\"withquotes\"" => "withquotes",
-            "a z" => "a z",
+            "a z" => "\"a z\"",
             " z" => "\" z\"",
             "a " => "\"a \"",
+            "a,z" => "\"a,z\"",
+            ",z" => "\",z\"",
+            "a," => "\"a,\"",
         )
 
         for (k, v) in values
@@ -138,6 +146,7 @@ using Sockets, Test
             @test HTTP.Cookies.readcookies(h, filter) == cookies
         end
     end
+
     @testset "Set-Cookie casing" begin
         server = Sockets.listen(Sockets.localhost, 8080)
         tsk = @async HTTP.listen(Sockets.localhost, 8080; server=server) do http
@@ -157,7 +166,7 @@ using Sockets, Test
             HTTP.startwrite(http)
         end
 
-        cookiejar = Dict{String,Set{HTTP.Cookies.Cookie}}()
+        cookiejar = HTTP.Cookies.CookieJar()
         HTTP.get("http://localhost:8080/set-cookie"; cookies=true, cookiejar=cookiejar)
         r = HTTP.get("http://localhost:8080/cookie"; cookies=true, cookiejar=cookiejar)
         @test HTTP.header(r, "X-Cookie") == "cookie=lc_cookie"
@@ -176,6 +185,72 @@ using Sockets, Test
         close(server)
         try; wait(tsk); catch e; end
         @test istaskdone(tsk)
+    end
+
+    @testset "splithostport" begin
+        testcases = [
+        # Host name
+        ("localhost:http", "localhost", "http"),
+        ("localhost:80", "localhost", "80"),
+
+        # Go-specific host name with zone identifier
+        ("localhost%lo0:http", "localhost%lo0", "http"),
+        ("localhost%lo0:80", "localhost%lo0", "80"),
+        ("[localhost%lo0]:http", "localhost%lo0", "http"), # Go 1 behavior
+        ("[localhost%lo0]:80", "localhost%lo0", "80"),     # Go 1 behavior
+
+        # IP literal
+        ("127.0.0.1:http", "127.0.0.1", "http"),
+        ("127.0.0.1:80", "127.0.0.1", "80"),
+        ("[::1]:http", "::1", "http"),
+        ("[::1]:80", "::1", "80"),
+
+        # IP literal with zone identifier
+        ("[::1%lo0]:http", "::1%lo0", "http"),
+        ("[::1%lo0]:80", "::1%lo0", "80"),
+
+        # Go-specific wildcard for host name
+        (":http", "", "http"), # Go 1 behavior
+        (":80", "", "80"),     # Go 1 behavior
+
+        # Go-specific wildcard for service name or transport port number
+        ("golang.org:", "golang.org", ""), # Go 1 behavior
+        ("127.0.0.1:", "127.0.0.1", ""),   # Go 1 behavior
+        ("[::1]:", "::1", ""),             # Go 1 behavior
+
+        # Opaque service name
+        ("golang.org:https%foo", "golang.org", "https%foo"), # Go 1 behavior
+        ]
+        for (hostport, host, port) in testcases
+            @test HTTP.Cookies.splithostport(hostport) == (host, port, false)
+        end
+        errorcases = [
+            ("golang.org", "missing port in address"),
+            ("127.0.0.1", "missing port in address"),
+            ("[::1]", "missing port in address"),
+            ("[fe80::1%lo0]", "missing port in address"),
+            ("[localhost%lo0]", "missing port in address"),
+            ("localhost%lo0", "missing port in address"),
+
+            ("::1", "too many colons in address"),
+            ("fe80::1%lo0", "too many colons in address"),
+            ("fe80::1%lo0:80", "too many colons in address"),
+
+            # Test cases that didn't fail in Go 1
+            ("[foo:bar]", "missing port in address"),
+            ("[foo:bar]baz", "missing port in address"),
+            ("[foo]bar:baz", "missing port in address"),
+
+            ("[foo]:[bar]:baz", "too many colons in address"),
+
+            ("[foo]:[bar]baz", "unexpected '[' in address"),
+            ("foo[bar]:baz", "unexpected '[' in address"),
+
+            ("foo]bar:baz", "unexpected ']' in address"),
+        ]
+        for (hostport, err) in errorcases
+            @test HTTP.Cookies.splithostport(hostport) == ("", "", true)
+        end
     end
 end
 

--- a/test/cookies.jl
+++ b/test/cookies.jl
@@ -252,6 +252,20 @@ using Sockets, Test
             @test HTTP.Cookies.splithostport(hostport) == ("", "", true)
         end
     end
+
+    @testset "addcookie!" begin
+        r = HTTP.Request("GET", "/")
+        c = HTTP.Cookie("NID", "99=YsDT5i3E-CXax-"; path="/", domain=".google.ch", httponly=true, expires=HTTP.Dates.DateTime(2011, 11, 23, 1, 5, 3, 0))
+        HTTP.addcookie!(r, c)
+        @test HTTP.header(r, "Cookie") == "NID=99=YsDT5i3E-CXax-"
+        HTTP.addcookie!(r, c)
+        @test HTTP.header(r, "Cookie") == "NID=99=YsDT5i3E-CXax-; NID=99=YsDT5i3E-CXax-"
+        r = HTTP.Response(200)
+        HTTP.addcookie!(r, c)
+        @test HTTP.header(r, "Set-Cookie") == "NID=99=YsDT5i3E-CXax-; Path=/; Domain=google.ch; Expires=Wed, 23 Nov 2011 01:05:03 GMT; HttpOnly"
+        HTTP.addcookie!(r, c)
+        @test HTTP.headers(r, "Set-Cookie") == ["NID=99=YsDT5i3E-CXax-; Path=/; Domain=google.ch; Expires=Wed, 23 Nov 2011 01:05:03 GMT; HttpOnly", "NID=99=YsDT5i3E-CXax-; Path=/; Domain=google.ch; Expires=Wed, 23 Nov 2011 01:05:03 GMT; HttpOnly"]
+    end
 end
 
 end # module


### PR DESCRIPTION
Our cookie code was originally ported from the golang stdlib
implementation and this represents a (slightly overdue) update
from the original source code. The biggest changes are a more
solidified cookiejar implementation that is threadsafe and includes
all the "getcookies!" and "setcookies!" implementations that we
were hand-rolling previously. I also ported over some udpated tests.

All in all, this seems like a great improvement IMO, and I'm going
to go thru open cookie-related issues and make sure we get everything
fixed.