### PR TITLE
proxy: islocalhost: ipv6 support

### DIFF
--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -4,12 +4,12 @@ using URIs, Sockets, Base64, LoggingExtras
 using MbedTLS: SSLContext, SSLConfig
 using ..Messages, ..IOExtras, ..ConnectionPool, ..Streams
 
-islocalhost(host) = host == "localhost" || host == "127.0.0.1" || host == "127.0.0.1"
+islocalhost(host::AbstractString) = host == "localhost" || host == "127.0.0.1" || host == "::1"
 
 # hasdotsuffix reports whether s ends in "."+suffix.
 hasdotsuffix(s, suffix) = endswith(s, "." * suffix)
 
-function isnoproxy(host)
+function isnoproxy(host::AbstractString)
     for x in NO_PROXY
         (hasdotsuffix(host, x) || (host == x)) && return true
     end

--- a/src/ConnectionRequest.jl
+++ b/src/ConnectionRequest.jl
@@ -4,7 +4,7 @@ using URIs, Sockets, Base64, LoggingExtras
 using MbedTLS: SSLContext, SSLConfig
 using ..Messages, ..IOExtras, ..ConnectionPool, ..Streams
 
-islocalhost(host::AbstractString) = host == "localhost" || host == "127.0.0.1" || host == "::1"
+islocalhost(host::AbstractString) = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "0000:0000:0000:0000:0000:0000:0000:0001" || host == "0:0:0:0:0:0:0:1"
 
 # hasdotsuffix reports whether s ends in "."+suffix.
 hasdotsuffix(s, suffix) = endswith(s, "." * suffix)


### PR DESCRIPTION
Follow-up of https://github.com/JuliaWeb/HTTP.jl/pull/833, I am guessing that this was the intended value for the third check.

I added two additional ways to format the same IPv6 address, is that enough?