### PR TITLE
Allow requests to be retried with request/response streams that suppo…

### DIFF
--- a/src/RedirectRequest.jl
+++ b/src/RedirectRequest.jl
@@ -22,10 +22,10 @@ function redirectlayer(handler)
             # Verify the url before making the request. Verification is done in
             # the redirect loop to also catch bad redirect URLs.
             verify_url(req.url)
-            res = handler(req; redirect_limit=redirect_limit, kw...)
+            res = handler(req; kw...)
 
-            if (count == redirect_limit ||  !isredirect(res)
-                ||  (location = header(res, "Location")) == "")
+            if (count == redirect_limit || !isredirect(res)
+                || (location = header(res, "Location")) == "")
                 return res
             end
 
@@ -54,6 +54,9 @@ function redirectlayer(handler)
             end
             @debugv 1 "➡️  Redirect: $url"
             count += 1
+            if count == redirect_limit
+                req.context[:redirectlimitreached] = true
+            end
         end
         @assert false "Unreachable!"
     end

--- a/src/RetryRequest.jl
+++ b/src/RetryRequest.jl
@@ -24,28 +24,31 @@ function retrylayer(handler)
             # no retry
             return handler(req; kw...)
         end
+        if retry_non_idempotent
+            req.context[:retry_non_idempotent] = true
+        end
         req_body_is_marked = false
-        if req.body isa IO && applicable(mark, req.body)
+        if req.body isa IO && supportsmark(req.body)
+            @debugv 2 "Marking request body stream"
             req_body_is_marked = true
             mark(req.body)
         end
-        resp_body_is_marked = false
-        if req.response.body isa IO && applicable(mark, req.response.body)
-            resp_body_is_marked = true
-            mark(req.response.body)
-        end
+        retrycount = Ref(0)
         retry_request = Base.retry(handler,
             delays=ExponentialBackOff(n = retries),
             check=(s, ex) -> begin
-                retry = isrecoverable(ex, req, retry_non_idempotent, get(req.context, :retrycount, 0), req_body_is_marked, resp_body_is_marked)
+                retrycount[] += 1
+                retry = isrecoverable(ex) && retryable(req)
+                if retrycount[] == retries
+                    req.context[:retrylimitreached] = true
+                end
                 if retry
                     @debugv 1 "🔄  Retry $ex: $(sprintcompact(req))"
                     reset!(req.response)
                     if req_body_is_marked
+                        @debugv 2 "Resetting request body stream"
                         reset(req.body)
-                    end
-                    if resp_body_is_marked
-                        reset(req.response.body)
+                        mark(req.body)
                     end
                 else
                     @debugv 1 "🚷  No Retry: $(no_retry_reason(ex, req))"
@@ -57,23 +60,16 @@ function retrylayer(handler)
     end
 end
 
+supportsmark(x) = false
+supportsmark(x::T) where {T <: IO} = length(Base.methods(mark, Tuple{T}, parentmodule(T))) > 0 || hasfield(T, :mark)
+
 isrecoverable(e) = false
 isrecoverable(e::Union{Base.EOFError, Base.IOError, MbedTLS.MbedException}) = true
 isrecoverable(e::ArgumentError) = e.msg == "stream is closed or unusable"
 isrecoverable(e::Sockets.DNSError) = true
 isrecoverable(e::ConnectError) = true
 isrecoverable(e::RequestError) = isrecoverable(e.error)
-isrecoverable(e::StatusError) = e.status == 403 || # Forbidden
-                                     e.status == 408 || # Timeout
-                                     e.status >= 500    # Server Error
-
-isrecoverable(e, req, retry_non_idempotent, retrycount, req_body_is_marked, resp_body_is_marked) =
-    isrecoverable(e) &&
-    (isbytes(req.body) || req_body_is_marked) &&
-    (isbytes(req.response.body) || resp_body_is_marked) &&
-    (retry_non_idempotent || retrycount == 0 || isidempotent(req))
-    # "MUST NOT automatically retry a request with a non-idempotent method"
-    # https://tools.ietf.org/html/rfc7230#section-6.3.1
+isrecoverable(e::StatusError) = retryable(e.status)
 
 function no_retry_reason(ex, req)
     buf = IOBuffer()

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -326,6 +326,9 @@ function isaborted(http::Stream{<:Response})
     return false
 end
 
+Messages.isredirect(http::Stream{<:Response}) = isredirect(http.message) && isredirect(http.message.request)
+Messages.retryable(http::Stream{<:Response}) = retryable(http.message) && retryable(http.message.request)
+
 incomplete(http::Stream) =
     http.ntoread > 0 && (http.readchunked || http.ntoread != unknown_length)
 


### PR DESCRIPTION
…rt mark/reset

Previously, we strictly didn't allow requests to be retried if the request or response
had stream bodies. This PR proposes using the `mark`/`reset` API for `IO` objects
in order to retry requests appropriately with streaming bodies.

Planning to add tests.