### PR TITLE
Start filling out client.md, websockets.md, and server.md doc guides

### DIFF
--- a/.github/workflows/previews-cleanup.yml
+++ b/.github/workflows/previews-cleanup.yml
@@ -1,0 +1,28 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Delete preview and history
+        run: |
+            git config user.name "Documenter.jl"
+            git config user.email "documenter@juliadocs.github.io"
+            git rm -rf "previews/PR$PRNUM"
+            git commit -m "delete preview"
+            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+        env:
+            PRNUM: ${{ github.event.number }}
+
+      - name: Push changes
+        run: |
+            git push --force origin gh-pages-new:gh-pages

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -78,6 +78,7 @@ makedocs(
         "Home" => "index.md",
         "client.md",
         "server.md",
+        "websockets.md",
         "reference.md",
         "examples.md",
     ],

--- a/docs/src/client.md
+++ b/docs/src/client.md
@@ -35,7 +35,7 @@ The `headers` argument is an optional list of header name-value pairs to be incl
 ### Body
 
 The optional `body` argument makes up the "body" of the sent request and is only used for HTTP methods that expect a body, like POST and PUT. A variety of objects are supported:
-  * a `Dict` or `Vector{Pair{String, String}}` to be serialized as the "application/x-www-form-urlencoded" content type, so `Dict("nm" => "val")` will be sent in the request body like `nm=val`
+  * a `Dict` or `NamedTuple` to be serialized as the "application/x-www-form-urlencoded" content type, so `Dict("nm" => "val")` will be sent in the request body like `nm=val`
   * any `AbstractString` or `AbstractVector{UInt8}` which will be sent "as is" for the request body
   * a readable `IO` stream or any `IO`-like type `T` for which `eof(T)` and `readavailable(T)` are defined. This stream will be read and sent until `eof` is `true`. This object should support the `mark`/`reset` methods if request retires are desired (if not, no retries will be attempted).
   * Any collection or iterable of the above (`Dict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`) which will result in a "Transfer-Encoding=chunked" request body, where each iterated element will be sent as a separate chunk

--- a/docs/src/client.md
+++ b/docs/src/client.md
@@ -1,0 +1,275 @@
+# HTTP Client Functionality
+
+HTTP.jl provides a wide range of HTTP client functionality, mostly exposed through the [`HTTP.request`](@ref) family of functions. This document aims to walk through the various ways requests can be configured to accomplish whatever your goal may be.
+
+## Basic Usage
+
+The standard form for making requests is:
+
+```julia
+HTTP.request(method, url [, headers [, body]]; <keyword arguments>]) -> HTTP.Response
+```
+
+First, let's walk through the positional arguments.
+
+### Method
+
+`method` refers to the HTTP method (sometimes known as "verb"), including GET, POST, PUT, DELETE, PATCH, TRACE, etc. It can be provided either as a `String` like `HTTP.request("GET", ...)`, or a `Symbol` like `HTTP.request(:GET, ...)`. There are also convenience methods for the most common methods, including:
+  * `HTTP.get(...)`
+  * `HTTP.post(...)`
+  * `HTTP.put(...)`
+  * `HTTP.delete(...)`
+  * `HTTP.patch(...)`
+  * `HTTP.head(...)`
+
+These methods operate identically to `HTTP.request`, except the `method` argument is "builtin" via function name.
+
+### Url
+
+For the request `url` argument, the [URIs.j](https://github.com/JuliaWeb/URIs.jl) package is used parse this `String` argument into a `URI` object, which detects the HTTP scheme, user info, host, port (if any), path, query parameters, fragment, etc. The host and port will be used to actually make a connection to the remote server and send data to and receive data from. Query parameters can be included in the `url` `String` itself, or passed as a separate [`query`](@ref) keyword argument to `HTTP.request`, which will be discussed in more detail later.
+
+### Headers
+
+The `headers` argument is an optional list of header name-value pairs to be included in the request. They can be provided as a `Vector` of `Pair`s, like `["header1" => "value1", "header2" => "value2"]`, or a `Dict`, like `Dict("header1" => "value1", "header2" => "value2")`. Header names do not have to be unique, so any argument passed will be converted to `Vector{Pair}`. By default, `HTTP.request` will include a few headers automatically, including `"Host" => url.host`, `"Accept" => "*/*"`, `"User-Agent" => "HTTP.jl/1.0"`, and `"Content-Length" => body_length`. These can be overwritten by providing them yourself, like `HTTP.get(url, ["Accept" => "application/json"])`, or you can prevent the header from being included by default by including it yourself with an empty string as value, like `HTTP.get(url, ["Accept" => ""])`, following the curl convention. There are keyword arguments that control the inclusion/setting of other headers, like `basicauth`, `detect_content_type`, `cookies`, etc. that will be discussed in more detail later.
+
+### Body
+
+The optional `body` argument makes up the "body" of the sent request and is only used for HTTP methods that expect a body, like POST and PUT. A variety of objects are supported:
+  * a `Dict` or `Vector{Pair{String, String}}` to be serialized as the "application/x-www-form-urlencoded" content type, so `Dict("nm" => "val")` will be sent in the request body like `nm=val`
+  * any `AbstractString` or `AbstractVector{UInt8}` which will be sent "as is" for the request body
+  * a readable `IO` stream or any `IO`-like type `T` for which `eof(T)` and `readavailable(T)` are defined. This stream will be read and sent until `eof` is `true`. This object should support the `mark`/`reset` methods if request retires are desired (if not, no retries will be attempted).
+  * Any collection or iterable of the above (`Dict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`)
+   which will result in a "Transfer-Encoding=chunked" request body, where each iterated element will be sent as a separate chunk
+  * a [`HTTP.Form`](@ref), which will be serialized as the "multipart/form-data" content-type
+
+### Response
+
+Upon successful completion, `HTTP.request` returns a [`HTTP.Response`](@ref) object. It includes the following fields:
+  * `status`: the HTTP status code of the response, e.g. `200` for normal response
+  * `headers`: a `Vector` of `String` `Pair`s for each name=value pair in the response headers. Convenience methods for working with headers include: `HTTP.hasheader(resp, key)` to check if header exists; `HTTP.header(resp, key)` retrive the value of a header with name `key`; `HTTP.headers(resp, key)` retrieve a list of all the headers with name `key`, since headers can have duplicate names
+  * `body`: a `Vector{UInt8}` of the response body bytes. Alternatively, an `IO` object can be provided via the [`response_stream`](@ref) keyword argument to have the response body streamed as it is received.
+
+## Keyword Arguments
+
+A number of keyword arguments are provided to give fine-tuned control over the request process.
+
+### `query`
+
+Query parameters are included in the url of the request like `http://httpbin.org/anything?q1=v1&q2=v2`, where the string `?q1=v1&q2=v2` after the question mark represent the "query parameters". They are essentially a list of key-value pairs. Query parameters can be included in the url itself when calling `HTTP.request`, like `HTTP.request(:GET, "http://httpbin.org/anything?q1=v1&q2=v2")`, but oftentimes, it's convenient to generate and pass them programmatically. To do this, pass an object that iterates `String` `Pair`s to the `query` keyword argument, like the following examples:
+  * `HTTP.get(url; query=Dict("x1" => "y1", "x2" => "y2")`
+  * `HTTP.get(url; query=["x1" => "y1", "x1" => "y2"]`: this form allows duplicate key values
+  * `HTTP.get(url; query=[("x1", "y1)", ("x2", "y2")]`
+
+### `response_stream`
+
+By default, the `HTTP.Response` body is returned as a `Vector{UInt8}`. There may be scenarios, however, where more control is desired, like downloading large files, where it's preferrable to stream the response body directly out to file or into some other `IO` object. By passing a writeable `IO` object to the `response_stream` keyword argument, the response body will not be fully materialized and will be written to as it is received from the remote connection. Note that in the presense of request redirects and retries, multiple requests end up being made in a single call to `HTTP.request` by default (configurable via the [`redirects`](@ref) and [`retry`](@ref) keyword arguments). If `response_stream` is provided and a request is redirected or retried, the `response_stream` is not written to until the *final* request is completed (either the redirect is successfully followed, or the request doesn't need to be retried, etc.).
+
+#### Examples
+
+Stream body to file:
+```julia
+io = open("get_data.txt", "w")
+r = HTTP.request("GET", "http://httpbin.org/get", response_stream=io)
+close(io)
+println(read("get_data.txt", String))
+```
+
+Stream body through buffer:
+```julia
+r = HTTP.get("http://httpbin.org/get", response_stream=IOBuffer())
+println(String(take!(r.body)))
+```
+
+### `verbose`
+
+HTTP requests can be a pain sometimes. We get it. It can be tricky to get the headers, query parameters, or expected body in just the right format. For convenience, the `verbose` keyword argument is provided to enable debug logging for the duration of the call to `HTTP.request`. This can be helpful to "peek under the hood" of what all goes on in the process of making request: are redirects returned and followed? Is the connection not getting made to the right host? Is some error causing the request to be retried unexpectedly? Currently, the `verbose` keyword argument supports passing increasing levels to enable more and more verbose logging, from `0` (no debug logging, the default), up to `3` (most verbose, probably too much for anyone but package developers).
+
+If you're running into a real head-scratcher, don't hesitate to [open an issue](https://github.com/JuliaWeb/HTTP.jl/issues/new) and include the problem you're running into; it's most helpful when you can include the output of passing `verbose=3`, so package maintainers can see a detailed view of what's going on.
+
+### Connection keyword arguments
+
+#### `connect_timeout`
+
+When a connection is attempted to a remote host, sometimes the connection is unable to be established for whatever reason. Passing a non-zero `connect_timetout` value will cause `HTTP.request` to wait that many seconds before giving up and throwing an error.
+
+#### `connection_limit`
+
+Many remote web services/APIs have rate limits or throttling in place to avoid bad actors from abusing their service. They may prevent too many requests over a time period or they may prevent too many connections being simultaneously open from the same client. By default, when `HTTP.request` opens a remote connection, it remembers the exact host:port combination and will keep the connection open to be reused by subsequent requests to the same host:port. The `connection_limit` keyword argument controls how many concurrent connections are allowed to a single remote host.
+
+#### `readtimeout`
+
+After a connection is established and a request is sent, a response is expected. If a non-zero value is passed to the `readtimeout` keyword argument, `HTTP.request` will wait to receive a response that many seconds before throwing an error. Note that for chunked or streaming responses, each chunk/packet of bytes received causes the timeout to reset. Passing `readtimeout = 0` disables any timeout checking and is the default.
+
+### `status_exception`
+
+When a non-2XX HTTP status code is received in a response, this is meant to convey some error condition. 3XX responses typically deal with "redirects" where the request should actually try a different url (these are followed automatically by default in `HTTP.request`, though up to a limit; see [`redirect`](@ref)). 4XX status codes typically mean the remote server thinks something is wrong in how the request is made. 5XX typically mean something went wrong on the server-side when responding. By default, as mentioned previously, `HTTP.request` will attempt to follow redirect responses, and retry "retryable" requests (where the status code and original request method allow). If, after redirects/retries, a response still has a non-2XX response code, the default behavior is to throw an `HTTP.StatusError` exception to signal that the request didn't succeed. This behavior can be disabled by passing `status_exception=false`, where the `HTTP.Response` object will be returned with the non-2XX status code intact.
+
+### `basicauth`
+
+By default, if "user info" is detected in the request url, like `http://user:password@host`, the `Authorization: Basic` header will be added to the request headers before the request is sent. While not very common, some APIs use this form of authentication to verify requests. This automatic adding of the header can be disabled by passing `basicauth=false`.
+
+### `canonicalize_headers`
+
+In the HTTP specification, header names are case insensitive, yet it is sometimes desirable to send/receive headers in a more predictable format. Passing `canonicalize_headers=true` (false by default) will reformat all request *and* response headers to use the Canonical-Camel-Dash-Format.
+
+### `proxy`
+
+In certain network environments, connections to a proxy must first be made and external requests are then sent "through" the proxy. `HTTP.request` supports this workflow by allowing the passing of a proxy url via the `proxy` keyword argument. Alternatively, it's a common pattern for HTTP libraries to check for the `http_proxy`, `HTTP_PROXY`, `https_proxy`, `HTTPS_PROXY`, and `no_proxy` environment variables and, if present, be used for these kind of proxied requests. Note that environment variables typically should be set prior to starting the Julia process; alternatively, the `withenv` Julia function can be used to temporarily modify the current process environment variables, so it could be used like:
+
+```julia
+resp = withenv("http_proxy" => proxy_url) do
+    HTTP.request(:GET, url)
+end
+```
+
+The `no_proxy` argument is typically a comma-separated list of urls that should *not* use the proxy, and is parsed when the HTTP.jl package is loaded, and thus won't work with the `withenv` method mentioned.
+
+### `detect_content_type`
+
+By default, the `Content-Type` header is not included by `HTTP.request`. To automatically detect various content types (html, xml, pdf, images, zip, gzip, JSON) and set this header, pass `detect_content_type=true`.
+
+### `decompress`
+
+By default, when the response includes the `Content-Encoding: gzip` header, the response body will be decompressed. To avoid this behavior, pass `decompress=false`. This keyword also controls the automatic inclusion of the `Accept-Encoding: gzip` header in the request being sent.
+
+### Retry arguments
+
+#### `retry`
+
+Controls overall whether requests will be retried at all; pass `retry=false` to disable all retries.
+
+#### `retries`
+
+Controls the total number of retries that will be attempted. Can also disable all retries by passing `retries = 0`. Note that for a request to be retried, in addition to the `retry` and `retries` keyword arguments, must be "retryable", which includes the following requirements:
+  * Request body must be static (string or bytes) or an `IO` the supports the `mark`/`reset` interface
+  * The request method must be idempotent as defined by RFC-7231, which includes GET, HEAD, OPTIONS, TRACE, PUT, and DELETE (not POST or PATCH).
+  * If the method _isn't_ idempotent, can pass `retry_non_idempotent=true` keyword argument to retry idempotent requests
+  * The retry limit hasn't been reached, as specified by `retries` keyword argument
+  * The "failed" response must have one of the following status codes: 403, 408, 409, 429, 500, 502, 503, 504, 599.
+
+#### `retry_non_idempotent`
+
+By default, this keyword argument is `false`, which controls whether non-idempotent requests will be retried (POST or PATCH requests).
+
+### Redirect Arguments
+
+#### `redirect`
+
+This keyword argument controls whether responses that specify a redirect (via 3XX status code + `Location` header) will be "followed" by issuing a follow up request to the specified `Location`. There are certain rules/logic that are followed when deciding whether to redirect and _how_ the redirected request will be made:
+  * The `Location` redirect url must be "valid" with an appropriate scheme and host; if the new location is relative to the original request url, the new url is resolved by calling `URIs.resolvereference`
+  * The response status code is one of: 301, 302, 307, or 308
+  * The method of the redirected request may change: 307 or 308 status codes will _not_ change the method, 303 means only a GET request is allowed, otherwise, if the `redirect_method` keyword argument is provided, it will be used. If not provided, the redirected request will default to a GET request.
+  * We'll only make a redirect request if we haven't made too many redirect attempts already, as controlled by the `redirect_limit` keyword argument (default 3)
+  * The original request headers will, by default, be forwarded in the redirected request, unless the new url is an entirely new host, then `Cookie` and `Authorization` headers will be removed.
+
+#### `redirect_limit`
+
+Controls how many redirects will be "followed" by making additional requests in the case of a redirected response url recursively returning redirect responses and so on. In addition to `redirect=false`, passing `redirect_limit=0` will also disable any redirect behavior all together.
+
+#### `redirect_method`
+
+May control the method that will be used in the redirected request. For 307 or 308 status codes, the same method will be used by default. For 303, only GET requests are allowed. For other status codes (301, 302), this keyword argument will be used to determine what the redirect request method will be. Passing `redirect_method=:same` will result in the same method as the original request. Otherwise, passing `redirect_method=:GET`, or any other valid method as `String` or `Symbol`, will result in that method for the redirected request.
+
+#### `forwardheaders`
+
+Controls whether original request headers will be included in the redirected request. `true` by default. Pass `forwardheaders=false` to disable headers being used in redirected requests. By design, if the new redirect location url is a different host than the original host, "sensitive" headers will not be forwarded, including `Cookie` and `Authorization` headers.
+
+### SSL Arguments
+
+#### `require_ssl_verification`
+
+Controls whether the SSL configuration for a secure connection is verified in the handshake process. `true` by default. Should only be set to `false` if developing against a local server that can be completely trusted.
+
+#### `sslconfig`
+
+Allows specifying a custom `MbedTLS.SSLConfig` configuration to be used in the secure connection handshake process to verify the connection. A custom cert and key file can be passed to construct a custom `SSLConfig` like `MbedTLS.SSLConfig(cert_file, key_file)`.
+
+### Cookie Arguments
+
+#### `cookies`
+
+Controls if and how a request `Cookie` header is set for a request. By default, `cookies` is `true`, which means the `cookiejar` (an internal global by default) will be checked for previously received `Set-Cookie` headers from past responses for the request domain and, if found, will be included in the outgoing request. Passing `cookies=false` will disable any automatic cookie tracking/setting. For more granular control, the `Cookie` header can be set manually in the `headers` request argument and `cookies=false` is passed. Otherwise, a `Dict{String, String}` can be passed in the `cookies` argument, which should be cookie name-value pairs to be serialized into the `Cookie` header for the current request. If `cookies=false` or an empty `Dict` is passed in the `cookies` keyword argument, no `Set-Cookie` response headers will be parsed and stored for use in future requests. In the automatic case of including previously received cookies, verification is done to ensure the cookie hasn't expired, matches the correct domain, etc.
+
+#### `cookiejar`
+
+If cookies are "enabled" (either by passing `cookies=true` or passing a non-empty `Dict` via `cookies` keyword argument), this keyword argument specifies the `HTTP.CookieJar` object that should be used to store received `Set-Cookie` cookie name-value pairs from responses. Cookies are stored for the appropriate host/domain and will, by default, be included in future requests when the host/domain match and other conditions are met (cookie hasn't expired, etc.). By default, a single global `CookieJar` is used, which is threadsafe. To pass a custom `CookieJar`, first create one: `jar = HTTP.CookieJar()`, then pass like `HTTP.get(...; cookiejar=jar)`.
+
+## Streaming Requests
+
+### `HTTP.open`
+
+Allows a potentially more convenient API when the request and/or response bodies need to be streamed. Works like:
+
+```julia
+HTTP.open(method, url, [,headers]; kw...) do io
+    write(io, body)
+    [startread(io) -> HTTP.Response]
+    while !eof(io)
+        readavailable(io) -> AbstractVector{UInt8}
+    end
+end -> HTTP.Response
+```
+
+Where the `io` argument provided to the function body is an `HTTP.Stream` object, a custom `IO` that represents an open connection that is ready to be written to in order to send the request body, and/or read from to recieve the response body. Note that `startread(io)` should be called before calling `readavailable` to ensure the response statu line and headers are received and parsed appropriately. Calling `eof(io)` will return true until the response body has been completely received. Note that the returned `HTTP.Response` from `HTTP.open` will _not_ have a `.body` field since the body was read in the function body.
+
+### `HTTP.download`
+
+```@docs
+HTTP.download
+```
+
+## Client-side Middleware (Layers)
+
+An `HTTP.Layer` is an abstract type to represent a client-side middleware.
+A layer is any function of the form `f(::Handler) -> Handler`, where [`Handler`](@ref) is
+a function of the form `f(::Request) -> Response`. Note that this `Handler` definition is the same from
+the server-side documentation. It may also be apparent
+that a `Layer` is the same as the [`Middleware`](@ref) interface from server-side, which is true, but
+we define `Layer` to clarify the client-side distinction and its unique usage.
+
+Creating custom layers can be a convenient way to "enhance" the `HTTP.request` process with custom functionality. It might be a layer that computes a special authorization header, or modifies the body in some way, or treats the response specially. Oftentimes, layers are application or domain-specific, where certain domain knowledge can be used to improve or simplify the request process. Layers can also be used to enforce the usage of certain keyword arguments if desired.
+
+Custom layers can be deployed in one of two ways:
+  * [`HTTP.@client`](@ref): Create a custom "client" with shorthand verb definitions, but which
+    include custom layers; only these new verb methods will use the custom layers.
+  * [`HTTP.pushlayer!`](@ref)/[`HTTP.poplayer!`](@ref): Allows globally adding and removing
+    layers from the default HTTP.jl layer stack; *all* http requests will then use the custom layers
+
+### Quick Examples
+```julia
+module Auth
+
+using HTTP
+
+function auth_layer(handler)
+    # returns a `Handler` function; check for a custom keyword arg `authcreds` that
+    # a user would pass like `HTTP.get(...; authcreds=creds)`.
+    # We also accept trailing keyword args `kw...` and pass them along later.
+    return function(req; authcreds=nothing, kw...)
+        # only apply the auth layer if the user passed `authcreds`
+        if authcreds !== nothing
+            # we add a custom header with stringified auth creds
+            HTTP.setheader(req, "X-Auth-Creds" => string(authcreds))
+        end
+        # pass the request along to the next layer by calling `auth_layer` arg `handler`
+        # also pass along the trailing keyword args `kw...`
+        return handler(req; kw...)
+    end
+end
+
+# Create a new client with the auth layer added
+HTTP.@client [auth_layer]
+
+end # module
+
+# Can now use custom client like:
+Auth.get(url; authcreds=creds) # performs GET request with auth_layer layer included
+
+# Or can include layer globally in all HTTP.jl requests
+HTTP.pushlayer!(Auth.auth_layer)
+
+# Now can use normal HTTP.jl methods and auth_layer will be included
+HTTP.get(url; authcreds=creds)
+```
+
+For more ideas or examples on how client-side layers work, it can be useful to see how `HTTP.request` is built on layers internally, in the [`/src/clientlayers`](https://github.com/JuliaWeb/HTTP.jl/tree/master/src/clientlayers) source code directory.

--- a/docs/src/client.md
+++ b/docs/src/client.md
@@ -213,9 +213,7 @@ Where the `io` argument provided to the function body is an `HTTP.Stream` object
 
 ### Download
 
-```@docs
-HTTP.download
-```
+A [`download`](@ref) function is provided for similar functionality to `Downloads.download`.
 
 ## Client-side Middleware (Layers)
 

--- a/docs/src/client.md
+++ b/docs/src/client.md
@@ -1,4 +1,4 @@
-# HTTP Client Functionality
+# Client
 
 HTTP.jl provides a wide range of HTTP client functionality, mostly exposed through the [`HTTP.request`](@ref) family of functions. This document aims to walk through the various ways requests can be configured to accomplish whatever your goal may be.
 

--- a/docs/src/client.md
+++ b/docs/src/client.md
@@ -26,7 +26,7 @@ These methods operate identically to `HTTP.request`, except the `method` argumen
 
 ### Url
 
-For the request `url` argument, the [URIs.j](https://github.com/JuliaWeb/URIs.jl) package is used parse this `String` argument into a `URI` object, which detects the HTTP scheme, user info, host, port (if any), path, query parameters, fragment, etc. The host and port will be used to actually make a connection to the remote server and send data to and receive data from. Query parameters can be included in the `url` `String` itself, or passed as a separate [`query`](@ref) keyword argument to `HTTP.request`, which will be discussed in more detail later.
+For the request `url` argument, the [URIs.j](https://github.com/JuliaWeb/URIs.jl) package is used to parse this `String` argument into a `URI` object, which detects the HTTP scheme, user info, host, port (if any), path, query parameters, fragment, etc. The host and port will be used to actually make a connection to the remote server and send data to and receive data from. Query parameters can be included in the `url` `String` itself, or passed as a separate [`query`](@ref) keyword argument to `HTTP.request`, which will be discussed in more detail later.
 
 ### Headers
 
@@ -38,8 +38,7 @@ The optional `body` argument makes up the "body" of the sent request and is only
   * a `Dict` or `Vector{Pair{String, String}}` to be serialized as the "application/x-www-form-urlencoded" content type, so `Dict("nm" => "val")` will be sent in the request body like `nm=val`
   * any `AbstractString` or `AbstractVector{UInt8}` which will be sent "as is" for the request body
   * a readable `IO` stream or any `IO`-like type `T` for which `eof(T)` and `readavailable(T)` are defined. This stream will be read and sent until `eof` is `true`. This object should support the `mark`/`reset` methods if request retires are desired (if not, no retries will be attempted).
-  * Any collection or iterable of the above (`Dict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`)
-   which will result in a "Transfer-Encoding=chunked" request body, where each iterated element will be sent as a separate chunk
+  * Any collection or iterable of the above (`Dict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`) which will result in a "Transfer-Encoding=chunked" request body, where each iterated element will be sent as a separate chunk
   * a [`HTTP.Form`](@ref), which will be serialized as the "multipart/form-data" content-type
 
 ### Response
@@ -212,7 +211,7 @@ end -> HTTP.Response
 
 Where the `io` argument provided to the function body is an `HTTP.Stream` object, a custom `IO` that represents an open connection that is ready to be written to in order to send the request body, and/or read from to recieve the response body. Note that `startread(io)` should be called before calling `readavailable` to ensure the response statu line and headers are received and parsed appropriately. Calling `eof(io)` will return true until the response body has been completely received. Note that the returned `HTTP.Response` from `HTTP.open` will _not_ have a `.body` field since the body was read in the function body.
 
-### `HTTP.download`
+### Download
 
 ```@docs
 HTTP.download

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-HTTP.jl provides both client and server functionality for the [http](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) protocol. As a client, it provides the ability to make a wide range of
-request, including GET, POST, websocket upgrades, form data, multipart, chunking, and cookie handling.
+HTTP.jl provides both client and server functionality for the [http](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) and [websocket](https://en.wikipedia.org/wiki/WebSocket) protocols. As a client, it provides the ability to make a wide range of
+requests, including GET, POST, websocket upgrades, form data, multipart, chunking, and cookie handling. There is also advanced functionality to provide client-side middleware and generate your own customized HTTP client.
 On the server side, it provides the ability to listen, accept, and route http requests, with middleware and
 handler interfaces to provide flexibility in processing responses.
 
@@ -23,9 +23,24 @@ println(String(resp.body))
 # make a POST request, sending data via `body` keyword argument
 resp = HTTP.post("http://httpbin.org/body"; body="request body")
 
+# make a POST request, sending form-urlencoded body
+resp = HTTP.post("http://httpbin.org/body"; body=Dict("nm" => "val"))
+
 # include query parameters in a request
 # and turn on verbose logging of the request/response process
 resp = HTTP.get("http://httpbin.org/anything"; query=["hello" => "world"], verbose=2)
+
+# simple websocket client
+WebSockets.open("ws://websocket.org") do ws
+    # we can iterate the websocket
+    # where each iteration yields a received message
+    # iteration finishes when the websocket is closed
+    for msg in ws
+        # do stuff with msg
+        # send back message as String, Vector{UInt8}, or iterable of either
+        send(ws, resp)
+    end
+end
 ```
 
 ### Handling requests (server)
@@ -59,15 +74,23 @@ end
 # requests will first be handled by teh auth middleware before being passed to the `handler`
 # request handler function
 HTTP.serve(auth(handler))
+
+# websocket server is very similar to client usage
+WebSockets.listen("0.0.0.0", 8080) do ws
+    for msg in ws
+        # simple echo server
+        send(ws, msg)
+    end
+end
 ```
 
 ## Further Documentation
 
-Check out the client and server-specific documentation pages for more in-depth discussions
+Check out the client, server, and websocket-specific documentation pages for more in-depth discussions
 and examples for the many configurations available.
 
 ```@contents
-Pages = ["client.md", "server.md", "reference.md"]
+Pages = ["client.md", "server.md", "websockets.md", "reference.md"]
 ```
 
 # manual

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ end
 
 ### Handling requests (server)
 
-`HTTP.serve`(@ref) allows specifying middleware + handlers for how incoming requests should be processed.
+[`HTTP.serve`](@ref) allows specifying middleware + handlers for how incoming requests should be processed.
 
 ```julia
 # authentication middleware to ensure property security
@@ -92,13 +92,3 @@ and examples for the many configurations available.
 ```@contents
 Pages = ["client.md", "server.md", "websockets.md", "reference.md"]
 ```
-
-# manual
-  # client
-    # making requests
-    # sections for keyword args + links to examples
-    # utilities
-  # server
-    # running basic server
-    # middleware/handlers framework
-    # logfmt"..."

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,7 +1,7 @@
 # API Reference
 
 ```@contents
-Depth = 4
+Depth = 3
 ```
 
 ## Client Requests

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -25,7 +25,7 @@ HTTP.download
 HTTP.Request
 HTTP.Response
 HTTP.Stream
-HTTP.WebSocket
+HTTP.WebSockets.WebSocket
 HTTP.Messages.header
 HTTP.Messages.headers
 HTTP.Messages.hasheader

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -83,7 +83,7 @@ HTTP.WebSockets.receive
 HTTP.WebSockets.close
 HTTP.WebSockets.ping
 HTTP.WebSockets.pong
-HTTP.WebSockets.iterate(::WebSocket, st)
+HTTP.WebSockets.iterate(::HTTP.WebSockets.WebSocket, st)
 HTTP.WebSockets.isclosed
 HTTP.WebSockets.isok
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -78,9 +78,9 @@ HTTP.Cookies.cookies
 ### WebSockets
 
 ```@docs
-HTTP.WebSockets.send
+HTTP.WebSockets.send(::HTTP.WebSockets.WebSocket, msg)
 HTTP.WebSockets.receive
-HTTP.WebSockets.close
+HTTP.WebSockets.close(::HTTP.WebSockets.WebSocket, body)
 HTTP.WebSockets.ping
 HTTP.WebSockets.pong
 HTTP.WebSockets.iterate(::HTTP.WebSockets.WebSocket, st)
@@ -91,7 +91,6 @@ HTTP.WebSockets.isok
 ## Utilities
 
 ```@docs
-HTTP.parse(::Type{HTTP.Request}, str)
 HTTP.sniff
 HTTP.Strings.escapehtml
 HTTP.Strings.tocameldash

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,6 +1,7 @@
 # API Reference
 
 ```@contents
+Pages = ["reference.md"]
 Depth = 3
 ```
 
@@ -82,7 +83,7 @@ HTTP.WebSockets.receive
 HTTP.WebSockets.close
 HTTP.WebSockets.ping
 HTTP.WebSockets.pong
-HTTP.WebSockets.iterate
+HTTP.WebSockets.iterate(::WebSocket, st)
 HTTP.WebSockets.isclosed
 HTTP.WebSockets.isok
 ```
@@ -90,7 +91,7 @@ HTTP.WebSockets.isok
 ## Utilities
 
 ```@docs
-parse(::Type{<:HTTP.Message}, str::AbstractString)
+HTTP.parse(::Type{HTTP.Request}, str)
 HTTP.sniff
 HTTP.Strings.escapehtml
 HTTP.Strings.tocameldash

--- a/docs/src/server.md
+++ b/docs/src/server.md
@@ -1,0 +1,17 @@
+# Server Functionality
+
+## `HTTP.serve`
+
+## `HTTP.Handler`
+
+## `HTTP.Middleware`
+
+## `HTTP.Router`
+
+## `HTTP.listen`
+
+## `logfmt"..."`
+
+```@docs
+HTTP.@logfmt_str
+```

--- a/docs/src/server.md
+++ b/docs/src/server.md
@@ -10,7 +10,7 @@
 
 ## `HTTP.listen`
 
-## `logfmt"..."`
+## Log formatting
 
 ```@docs
 HTTP.@logfmt_str

--- a/docs/src/server.md
+++ b/docs/src/server.md
@@ -1,14 +1,107 @@
-# Server Functionality
+# Server
+
+For server-side functionality, HTTP.jl provides a robust framework for core
+HTTP and websocket serving, flexible handler and middleware interfaces, and
+low-level access for unique workflows. The core server listening code is in
+the [`/src/Servers.jl`](https://github.com/JuliaWeb/HTTP.jl/blob/master/src/Servers.jl) file, while the handler, middleware, router, and 
+higher level `HTTP.serve` function are defined in the [`/src/Handlers.jl`](https://github.com/JuliaWeb/HTTP.jl/blob/master/src/Handlers.jl)
+file.
 
 ## `HTTP.serve`
 
+`HTTP.serve` is the primary entrypoint for HTTP server functionality, while `HTTP.listen` is considered the lower-level core server loop that only operates directly with `HTTP.Stream`s. `HTTP.serve` is also built directly integrated with the `Handler` and `Middleware` interfaces and provides easy flexiblity by doing so. The signature is:
+
+```julia
+HTTP.serve(f, host, port; kw...)
+```
+
+Where `f` is a `Handler` function, typically of the form `f(::Request) -> Response`, but can also operate directly on an `HTTP.Stream` of the form `f(::Stream) -> Nothing` while also passing `stream=true` to the keyword arguments. The `host` argument should be a `String`, or `IPAddr`, created like `ip"0.0.0.0"`. `port` should be a valid port number as an `Integer`.
+
+Supported keyword arguments include:
+ * `sslconfig=nothing`, Provide an `MbedTLS.SSLConfig` object to handle ssl
+    connections. Pass `sslconfig=MbedTLS.SSLConfig(false)` to disable ssl
+    verification (useful for testing), otherwise, the constructor is like
+    `MbedTLS.SSLConfig(certfile, keyfile)`
+ * `reuse_limit = nolimit`, number of times a connection is allowed to be
+   reused after the first request.
+ * `tcpisvalid = tcp->true`, function `f(::TCPSocket)::Bool` to, check accepted
+    connection before processing requests. e.g. to do source IP filtering.
+ * `readtimeout::Int=0`, close the connection if no data is received for this
+    many seconds. Use readtimeout = 0 to disable.
+ * `reuseaddr::Bool=false`, allow multiple servers to listen on the same port.
+ * `server::Base.IOServer=nothing`, provide an `IOServer` object to listen on;
+    allows closing the server when `HTTP.serve` is run via `@async`.
+ * `connection_count::Ref{Int}`, reference to track the number of currently
+    open connections.
+ * `verbose::Bool=false`, log connection information to `stdout`.
+ * `access_log::Function`, function for formatting access log messages. The
+    function should accept two arguments, `io::IO` to which the messages should
+    be written, and `http::HTTP.Stream` which can be used to query information
+    from. See also [`@logfmt_str`](@ref).
+ * `on_shutdown::Union{Function, Vector{<:Function}, Nothing}=nothing`, one or
+    more functions to be run if the server is closed (for example by an
+    `InterruptException`). Note, shutdown function(s) will not run if an
+    `IOServer` object is supplied to the `server` keyword argument and closed
+    by `close(server)`.
+
 ## `HTTP.Handler`
+
+Abstract type for the handler interface that exists for documentation purposes.
+A `Handler` is any function of the form `f(req::HTTP.Request) -> HTTP.Response`.
+There is no requirement to subtype `Handler` and users should not rely on or dispatch
+on `Handler`. A `Handler` function `f` can be passed to [`HTTP.serve`](@ref)
+wherein a server will pass each incoming request to `f` to be handled and a response
+to be returned. Handler functions are also the inputs to [`Middleware`](@ref) functions
+which are functions of the form `f(::Handler) -> Handler`, i.e. they take a `Handler`
+function as input, and return a "modified" or enhanced `Handler` function.
+
+For advanced cases, a `Handler` function can also be of the form `f(stream::HTTP.Stream) -> Nothing`.
+In this case, the server would be run like `HTTP.serve(f, ...; stream=true)`. For this use-case,
+the handler function reads the request and writes the response to the stream directly. Note that
+any middleware used with a stream handler also needs to be of the form `f(stream_handler) -> stream_handler`,
+i.e. it needs to accept a stream `Handler` function and return a stream `Handler` function.
 
 ## `HTTP.Middleware`
 
+Abstract type for the middleware interface that exists for documentation purposes.
+A `Middleware` is any function of the form `f(::Handler) -> Handler` (ref: [`Handler`](@ref)).
+There is no requirement to subtype `Middleware` and users should not rely on or dispatch
+on the `Middleware` type. While `HTTP.serve(f, ...)` requires a _handler_ function `f` to be
+passed, middleware can be "stacked" to create a chain of functions that are called in sequence,
+like `HTTP.serve(base_handler |> cookie_middleware |> auth_middlware, ...)`, where the
+`base_handler` `Handler` function is passed to `cookie_middleware`, which takes the handler
+and returns a "modified" handler (that parses and stores cookies). This "modified" handler is
+then an input to the `auth_middlware`, which further enhances/modifies the handler.
+
 ## `HTTP.Router`
 
+Object part of the `Handler` framework for routing requests based on path matching registered routes.
+
+```julia
+r = HTTP.Router(_404, _405)
+```
+
+Define a router object that maps incoming requests by path to registered routes and
+associated handlers. Paths can be registered using [`HTTP.register!`](@ref). The router
+object itself is a "request handler" that can be called like:
+```
+r = HTTP.Router()
+resp = r(reqest)
+```
+
+Which will inspect the `request`, find the matching, registered handler from the url,
+and pass the request on to be handled further.
+
+See [`HTTP.register!`](@ref) for additional information on registering handlers based on routes.
+
+If a request doesn't have a matching, registered handler, the `_404` handler is called which,
+by default, returns a `HTTP.Response(404)`. If a route matches the path, but not the method/verb
+(e.g. there's a registerd route for "GET /api", but the request is "POST /api"), then the `_405`
+handler is called, which by default returns `HTTP.Response(405)` (method not allowed).
+
 ## `HTTP.listen`
+
+Lower-level core server functionality that only operates on `HTTP.Stream`. Provides a level of separation from `HTTP.serve` and the `Handler` framework. Supports all the same arguments and keyword arguments as [`HTTP.serve`](@ref), but the handler function `f` _must_ take a single `HTTP.Stream` as argument.
 
 ## Log formatting
 

--- a/docs/src/server.md
+++ b/docs/src/server.md
@@ -12,6 +12,4 @@
 
 ## Log formatting
 
-```@docs
-HTTP.@logfmt_str
-```
+Nginx-style log formatting is supported via the [`HTTP.@logfmt_str`](@ref) macro and can be passed via the `access_log` keyword argument for [`HTTP.listen`](@ref) or [`HTTP.serve`](@ref).

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -1,0 +1,44 @@
+# WebSockets
+
+HTTP.jl provides a complete and well-tested websockets implementation via the `WebSockets` module. It is tested against the industry standard [autobahn testsuite](https://github.com/crossbario/autobahn-testsuite). The client and server usage are similar to their HTTP counterparts, but provide a `WebSocket` object that enables sending and receiving messages.
+
+## WebSocket object
+
+Both `WebSockets.open` (client) and `WebSockets.listen` (server) take a handler function that should accept a single `WebSocket` object argument. It has a small, simple API to provide full websocket functionality, including:
+  * `receive(ws)`: blocking call to receive a single, non-control message from the remote. If ping/pong messages are received, they are handled/responded to automatically and a non-control message is waited for. If a CLOSE message is received, an error will be thrown. Returns either a `String` or `Vector{UInt8}` depending on whether the message had a TEXT or BINARY frame type. Fragmented messages are received fully before returning and the bodies of each frame are concatenated for a full, final message body.
+  * `send(ws, msg)`: sends a message to the remote. If `msg` is `AbstractVector{UInt8}`, the message will have the BINARY type, if `AbstractString`, it will have TEXT type. `msg` can also be an iterable of either `AbstractVector{UInt8}` or `AbstractString` and a fragmented message will be sent, with one fragment for each iterated element.
+  * `close(ws)`: initiate the close sequence of the websocket
+  * `ping(ws[, data])`: send a PING message to the remote with optional `data`. PONG responses are received by calling `receive(ws)`.
+  * `pong(ws[, data])`: send a PONG message to the remote with optional `data`.
+  * `for msg in ws`: for convenience, the `WebSocket` object supports the iteration protocol, which results in a call to `receive(ws)` to produce each iterated element. Iteration terminates when a non-error CLOSE message is received. This is the most common way to handle the life of a `WebSocket`, and looks like:
+
+```julia
+# client
+WebSockets.open(url) do ws
+    for msg in ws
+        # do cool stuff with msg
+    end
+end
+
+# server
+WebSockets.listen(host, port) do ws
+    # iterate incoming websocket messages
+    for msg in ws
+        # send message back to client or do other logic here
+        send(ws, msg)
+    end
+    # iteration ends when the websocket connection is closed by client or error
+end
+```
+
+## WebSocket Client
+
+```@docs
+HTTP.WebSockets.open
+```
+
+## WebSocket Server
+
+```@docs
+HTTP.WebSockets.listen
+```

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -33,12 +33,36 @@ end
 
 ## WebSocket Client
 
-```@docs
-HTTP.WebSockets.open
+To initiate a websocket client connection, the [`WebSockets.open`](@ref) function is provided, which operates similar to [`HTTP.open`](@ref), but the handler function should operate on a single `WebSocket` argument instead of an `HTTP.Stream`.
+
+### Example
+
+```julia
+# simple websocket client
+WebSockets.open("ws://websocket.org") do ws
+    # we can iterate the websocket
+    # where each iteration yields a received message
+    # iteration finishes when the websocket is closed
+    for msg in ws
+        # do stuff with msg
+        # send back message as String, Vector{UInt8}, or iterable of either
+        send(ws, resp)
+    end
+end
 ```
 
 ## WebSocket Server
 
-```@docs
-HTTP.WebSockets.listen
+To start a websocket server to listen for client connections, the [`WebSockets.listen`](@ref) function is provided, which mirrors the [`HTTP.listen`](@ref) function, but the provided handler should operate on a single `WebSocket` argument instead of an `HTTP.Stream`.
+
+### Example
+
+```julia
+# websocket server is very similar to client usage
+WebSockets.listen("0.0.0.0", 8080) do ws
+    for msg in ws
+        # simple echo server
+        send(ws, msg)
+    end
+end
 ```

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -83,11 +83,14 @@ when sending a request (following the curl convention).
 
 `body` can be a variety of objects:
 
- - a `String`, a `Vector{UInt8}` or any `T` accepted by `write(::IO, ::T)`
- - a collection of `String` or `AbstractVector{UInt8}` or `IO` streams
-   or items of any type `T` accepted by `write(::IO, ::T...)`
+ - a `Dict` or `Vector{Pair{String, String}}` to be serialized as the "application/x-www-form-urlencoded" content type
+ - any `AbstractString` or `AbstractVector{UInt8}` which will be sent "as is" for the request body
  - a readable `IO` stream or any `IO`-like type `T` for which
-   `eof(T)` and `readavailable(T)` are defined.
+   `eof(T)` and `readavailable(T)` are defined. This stream will be read and sent until `eof` is `true`.
+   This object should support the `mark`/`reset` methods if request retires are desired (if not, no retries will be attempted).
+ - Any collection or iterable of the above (`Dict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`)
+   which will result in a "chunked" request body, where each iterated element will be sent as a separate chunk
+ - a [`HTTP.Form`](@ref), which will be serialized as the "multipart/form-data" content-type
 
 The `HTTP.Response` struct contains:
 

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -83,7 +83,7 @@ when sending a request (following the curl convention).
 
 `body` can be a variety of objects:
 
- - a `Dict` or `Vector{Pair{String, String}}` to be serialized as the "application/x-www-form-urlencoded" content type
+ - a `Dict` or `NamedTuple` to be serialized as the "application/x-www-form-urlencoded" content type
  - any `AbstractString` or `AbstractVector{UInt8}` which will be sent "as is" for the request body
  - a readable `IO` stream or any `IO`-like type `T` for which
    `eof(T)` and `readavailable(T)` are defined. This stream will be read and sent until `eof` is `true`.

--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -67,7 +67,8 @@ end
     HTTP.serve(f, host, port; stream::Bool=false, kw...)
 
 Start a server on the given host and port; for each incoming request, call the
-given handler function `f`, which should be of the form `f(req::HTTP.Request) -> HTTP.Response`.
+given handler function `f`, which should be of the form `f(req::HTTP.Request) -> HTTP.Response`
+(see the [`Handler`](@ref) and [`Middleware`](@ref) interfaces for more details).
 If `stream` is true, the handler function should be of the form `f(stream::HTTP.Stream) -> Nothing`.
 Accepts all the same keyword arguments (and passes them along) to [`HTTP.listen`](@ref), including:
   * `sslconfig`: custom `SSLConfig` to support ssl connections

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -242,7 +242,7 @@ Does this `Response` have a redirect status?
 """
 isredirect(r::Response) = isredirect(r.status)
 isredirect(r::Request) = !redirectlimitreached(r)
-isredirect(status) = status in (301, 302, 307, 308)
+isredirect(status) = status in (301, 302, 303, 307, 308)
 
 # whether the redirect limit has been reached for a given request
 # set in the RedirectRequest layer once the limit is reached
@@ -262,7 +262,7 @@ function retryable end
 retryable(r::Request) = (isbytes(r.body) || ismarked(r.body)) &&
     (isidempotent(r) || retry_non_idempotent(r)) && !retrylimitreached(r)
 retryable(r::Response) = retryable(r.status)
-retryable(status) = status in (408, 409, 429, 500, 502, 503, 504, 599)
+retryable(status) = status in (403, 408, 409, 429, 500, 502, 503, 504, 599)
 
 """
     ischunked(::Message)

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -304,6 +304,18 @@ function Base.read(http::Stream)
     return take!(buf)
 end
 
+function Base.readuntil(http::Stream, f::Function)::ByteView
+    UInt(ntoread(http)) == 0 && return UInt8[]
+    try
+        bytes = readuntil(http, f)
+        update_ntoread(http, length(bytes))
+        return bytes
+    catch e
+        # if we error, it means we didn't find what we were looking for
+        return UInt8[]
+    end
+end
+
 """
     isaborted(::Stream{<:Response})
 

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -305,9 +305,9 @@ function Base.read(http::Stream)
 end
 
 function Base.readuntil(http::Stream, f::Function)::ByteView
-    UInt(ntoread(http)) == 0 && return UInt8[]
+    UInt(ntoread(http)) == 0 && return ConnectionPool.nobytes
     try
-        bytes = readuntil(http, f)
+        bytes = readuntil(http.stream, f)
         update_ntoread(http, length(bytes))
         return bytes
     catch e

--- a/src/clientlayers/DefaultHeadersRequest.jl
+++ b/src/clientlayers/DefaultHeadersRequest.jl
@@ -10,7 +10,7 @@ using ..Messages, ..Forms, ..IOExtras
 Sets default expected headers.
 """
 function defaultheaderslayer(handler)
-    return function(req; iofunction=nothing, kw...)
+    return function(req; iofunction=nothing, decompress=true, kw...)
         headers = req.headers
         if isempty(req.url.port) ||
             (req.url.scheme == "http" && req.url.port == "80") ||
@@ -39,7 +39,10 @@ function defaultheaderslayer(handler)
             # "Content-Type" => "multipart/form-data; boundary=..."
             setheader(headers, content_type(req.body))
         end
-        return handler(req; iofunction=iofunction, kw...)
+        if decompress
+            defaultheader!(headers, "Accept-Encoding" => "gzip")
+        end
+        return handler(req; iofunction, decompress, kw...)
     end
 end
 

--- a/src/clientlayers/DefaultHeadersRequest.jl
+++ b/src/clientlayers/DefaultHeadersRequest.jl
@@ -35,9 +35,11 @@ function defaultheaderslayer(handler)
                 setheader(headers, "Content-Length" => "0")
             end
         end
-        if !hasheader(headers, "Content-Type") && req.body isa Form && req.method in ("POST", "PUT")
+        if !hasheader(headers, "Content-Type") && req.body isa Form && req.method in ("POST", "PUT", "PATCH")
             # "Content-Type" => "multipart/form-data; boundary=..."
             setheader(headers, content_type(req.body))
+        elseif !hasheader(headers, "Content-Type") && (req.body isa Dict || req.body isa NamedTuple) && req.method in ("POST", "PUT", "PATCH")
+            setheader(headers, "Content-Type" => "application/x-www-form-urlencoded")
         end
         if decompress
             defaultheader!(headers, "Accept-Encoding" => "gzip")

--- a/src/clientlayers/RedirectRequest.jl
+++ b/src/clientlayers/RedirectRequest.jl
@@ -99,7 +99,7 @@ function newmethod(request_method, response_status, redirect_method)
         return "GET"
     elseif redirect_method == :same
         return request_method
-    elseif redirect_method !== nothing && redirect_method in ("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
+    elseif redirect_method !== nothing && String(redirect_method) in ("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
         return redirect_method
     end
     return "GET"

--- a/src/clientlayers/StreamRequest.jl
+++ b/src/clientlayers/StreamRequest.jl
@@ -1,7 +1,7 @@
 module StreamRequest
 
 using ..IOExtras, ..Messages, ..Streams, ..ConnectionPool, ..Strings, ..RedirectRequest, ..Exceptions
-using LoggingExtras, CodecZlib
+using LoggingExtras, CodecZlib, URIs
 
 export streamlayer
 
@@ -93,7 +93,13 @@ function writebodystream(stream, body::IO)
     write(stream, body)
 end
 
+function writebodystream(stream, body::Union{Dict, NamedTuple})
+    # application/x-www-form-urlencoded
+    write(stream, URIs.escapeuri(body))
+end
+
 writechunk(stream, body::IO) = writebodystream(stream, body)
+writechunk(stream, body::Union{Dict, NamedTuple}) = writebodystream(stream, body)
 writechunk(stream, body) = write(stream, body)
 
 function readbody(stream::Stream, res::Response, decompress)

--- a/src/sniff.jl
+++ b/src/sniff.jl
@@ -24,7 +24,7 @@ const MAXSNIFFLENGTH = 512
 const WHITESPACE = Set{UInt8}([UInt8('\t'),UInt8('\n'),UInt8('\u0c'),UInt8('\r'),UInt8(' ')])
 
 """
-    `HTTP.sniff(content::Union{Vector{UInt8}, String, IO})` => `String` (mimetype)
+    HTTP.sniff(content::Union{Vector{UInt8}, String, IO}) => String (mimetype)
 
 `HTTP.sniff` will look at the first 512 bytes of `content` to try and determine a valid mimetype.
 If a mimetype can't be determined appropriately, `"application/octet-stream"` is returned.

--- a/test/client.jl
+++ b/test/client.jl
@@ -538,4 +538,19 @@ end
     end
 end
 
+findnewline(bytes) = something(findfirst(==(UInt8('\n')), bytes), 0)
+
+@testset "readuntil on Stream" begin
+
+    HTTP.open(:GET, "http://httpbin.org/stream/5") do io
+        while !eof(io)
+            bytes = readuntil(io, findnewline)
+            isempty(bytes) && break
+            x = JSON.parse(IOBuffer(bytes))
+            @show x
+        end
+    end
+
+end
+
 end # module

--- a/test/client.jl
+++ b/test/client.jl
@@ -102,7 +102,7 @@ end
         end
     end
 
-    @testset "Client Body Posting - Vector{UTF8}, String, IOStream, IOBuffer, BufferStream" begin
+    @testset "Client Body Posting - Vector{UTF8}, String, IOStream, IOBuffer, BufferStream, Dict, NamedTuple" begin
         @test status(HTTP.post("$sch://httpbin.org/post"; body="hey")) == 200
         @test status(HTTP.post("$sch://httpbin.org/post"; body=UInt8['h','e','y'])) == 200
         io = IOBuffer("hey"); seekstart(io)
@@ -116,6 +116,14 @@ end
         write(f, "hey")
         close(f)
         @test status(HTTP.post("$sch://httpbin.org/post"; body=f, enablechunked=false)) == 200
+        resp = HTTP.post("$sch://httpbin.org/post"; body=Dict("name" => "value"))
+        x = JSON.parse(IOBuffer(resp.body))
+        @test status(resp) == 200
+        @test x["form"] == Dict("name" => "value")
+        resp = HTTP.post("$sch://httpbin.org/post"; body=(name="value with spaces",))
+        x = JSON.parse(IOBuffer(resp.body))
+        @test status(resp) == 200
+        @test x["form"] == Dict("name" => "value with spaces")
     end
 
     @testset "Chunksize" begin


### PR DESCRIPTION
cc: @fredrikekre, I stubbed out a section in the server.md file about `logfmt"..."`; would you be interested in adding more docs/information + maybe an example of passing one to `HTTP.serve`?

cc: @oxinabox, I stubbed out a section in client.md about `HTTP.download`; would you be interested in adding any more information beyond the docstring + maybe an example or two?

Still working on the server.md docs, but will hopefully update in the next few hours.