### PR TITLE
[BREAKING]: Modernize core server code and improve overall ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The server will start listening on 127.0.0.1:8081 by default.
 ```julia
 using HTTP
 
+# start a blocking server
 HTTP.listen() do http::HTTP.Stream
     @show http.message
     @show HTTP.header(http, "Content-Type")
@@ -83,7 +84,8 @@ end
 ```julia
 using HTTP
 
-HTTP.serve() do request::HTTP.Request
+# HTTP.listen! and HTTP.serve! are the non-blocking versions of HTTP.listen/HTTP.serve
+server = HTTP.serve!() do request::HTTP.Request
    @show request
    @show request.method
    @show HTTP.header(request, "Content-Type")
@@ -91,26 +93,31 @@ HTTP.serve() do request::HTTP.Request
    try
        return HTTP.Response("Hello")
    catch e
-       return HTTP.Response(404, "Error: $e")
+       return HTTP.Response(400, "Error: $e")
    end
 end
+# HTTP.serve! returns an `HTTP.Server` object that we can close manually
+close(server)
 ```
 
 ## WebSocket Examples
 
 ```julia
-julia> @async HTTP.WebSockets.listen("127.0.0.1", 8081) do ws
+julia> using HTTP.WebSockets
+julia> server = WebSockets.listen!("127.0.0.1", 8081) do ws
         for msg in ws
             send(ws, msg)
         end
     end
 
-julia> HTTP.WebSockets.open("ws://127.0.0.1:8081") do ws
+julia> WebSockets.open("ws://127.0.0.1:8081") do ws
            send(ws, "Hello")
            s = receive(ws)
-           println(x)
+           println(s)
        end;
 Hello
+
+julia> close(server)
 ```
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg

--- a/docs/examples/cors_server.jl
+++ b/docs/examples/cors_server.jl
@@ -117,8 +117,7 @@ HTTP.register!(ANIMAL_ROUTER, "POST", "/api/zoo/v1/users/{userId}/animals", crea
 HTTP.register!(ANIMAL_ROUTER, "GET", "/api/zoo/v1/users/{userId}/animals/{id}", getAnimal)
 HTTP.register!(ANIMAL_ROUTER, "DELETE", "/api/zoo/v1/users/{userId}/animals/{id}", deleteAnimal)
 
-socket = Sockets.listen(Sockets.localhost, 8080)
-servertask = @async HTTP.serve(ANIMAL_ROUTER |> JSONMiddleware |> CorsMiddleware, Sockets.localhost, 8080; server=socket)
+server = HTTP.serve!(ANIMAL_ROUTER |> JSONMiddleware |> CorsMiddleware, Sockets.localhost, 8080)
 
 # using our server
 resp = HTTP.post("http://localhost:8080/api/zoo/v1/users")
@@ -134,6 +133,6 @@ x2 = JSON3.read(resp.body, Animal)
 resp = HTTP.get("http://localhost:8080/api/zoo/v1/users/$(userId)/animals/$(x2.id)")
 x3 = JSON3.read(resp.body, Animal)
 
-# close the server socket which will stop the HTTP server
-close(socket)
-@assert istaskdone(servertask)
+# close the server which will stop the HTTP server from listening
+close(server)
+@assert istaskdone(server.task)

--- a/docs/examples/readme_examples.jl
+++ b/docs/examples/readme_examples.jl
@@ -37,28 +37,36 @@ end
 
 using HTTP
 
-HTTP.serve() do request::HTTP.Request
-   @show request
-   @show request.method
-   @show HTTP.header(request, "Content-Type")
-   @show request.body
-   try
-       return HTTP.Response("Hello")
-   catch e
-       return HTTP.Response(404, "Error: $e")
-   end
-end
+# HTTP.listen! and HTTP.serve! are the non-blocking versions of HTTP.listen/HTTP.serve
+server = HTTP.serve!() do request::HTTP.Request
+    @show request
+    @show request.method
+    @show HTTP.header(request, "Content-Type")
+    @show request.body
+    try
+        return HTTP.Response("Hello")
+    catch e
+        return HTTP.Response(400, "Error: $e")
+    end
+ end
+ # HTTP.serve! returns an `HTTP.Server` object that we can close manually
+ close(server)
 
 #WebSocket Examples
-@async HTTP.WebSockets.listen("127.0.0.1", 8081) do ws
-    for msg in ws
-        send(ws, msg)
+using HTTP.WebSockets
+server = WebSockets.listen!("127.0.0.1", 8081) do ws
+        for msg in ws
+            send(ws, msg)
+        end
     end
-end
 
-HTTP.WebSockets.open("ws://127.0.0.1:8081") do ws
-    send(ws, "Hello")
-    x = receive(ws)
-    println(x)
-end;
+WebSockets.open("ws://127.0.0.1:8081") do ws
+           send(ws, "Hello")
+           s = receive(ws)
+           println(s)
+       end;
+Hello
 #Output: Hello
+
+close(server)
+

--- a/docs/examples/server_sent_events.jl
+++ b/docs/examples/server_sent_events.jl
@@ -86,8 +86,7 @@ end
 HTTP.register!(ROUTER, "GET", "/api/getItems", HTTP.streamhandler(getItems))
 HTTP.register!(ROUTER, "/api/events", events)
 
-socket = Sockets.listen(Sockets.localhost, 8080)
-servertask = @async HTTP.serve(ROUTER, "127.0.0.1", 8080; server=socket, stream=true)
+server = HTTP.serve!(ROUTER, "127.0.0.1", 8080; stream=true)
 
 # Julia usage
 resp = HTTP.get("http://localhost:8080/api/getItems")
@@ -102,6 +101,6 @@ end
 # run the following to stop the streaming client request
 close[] = true
 
-# close the server socket which will stop the HTTP server
-close(socket)
-@assert istaskdone(servertask)
+# close the server which will stop the HTTP server from listening
+close(server)
+@assert istaskdone(server.task)

--- a/docs/examples/simple_server.jl
+++ b/docs/examples/simple_server.jl
@@ -58,8 +58,7 @@ HTTP.register!(ANIMAL_ROUTER, "GET", "/api/zoo/v1/animals/{id}", getAnimal)
 HTTP.register!(ANIMAL_ROUTER, "PUT", "/api/zoo/v1/animals", updateAnimal)
 HTTP.register!(ANIMAL_ROUTER, "DELETE", "/api/zoo/v1/animals/{id}", deleteAnimal)
 
-socket = Sockets.listen(Sockets.localhost, 8080)
-servertask = @async HTTP.serve(ANIMAL_ROUTER, Sockets.localhost, 8080; server=socket)
+server = HTTP.serve!(ANIMAL_ROUTER, Sockets.localhost, 8080)
 
 # using our server
 x = Animal()
@@ -72,6 +71,6 @@ x2 = JSON3.read(resp.body, Animal)
 resp = HTTP.get("http://localhost:8080/api/zoo/v1/animals/$(x2.id)")
 x3 = JSON3.read(resp.body, Animal)
 
-# close the server socket which will stop the HTTP server
-close(socket)
-@assert istaskdone(servertask)
+# close the server which will stop the HTTP server from listening
+close(server)
+@assert istaskdone(server.task)

--- a/docs/examples/squaring_server_client.jl
+++ b/docs/examples/squaring_server_client.jl
@@ -61,14 +61,13 @@ end
 
 HTTP.register!(ROUTER, "POST", "/api/square", square)
 
-socket = Sockets.listen(Sockets.localhost, 8080)
-servertask = @async HTTP.serve(ROUTER, Sockets.localhost, 8080; server=socket)
+server = HTTP.serve!(ROUTER, Sockets.localhost, 8080)
 
 # usage
 resp = HTTP.post("http://localhost:8080/api/square"; body="3")
 sq = parse(Float64, String(resp.body))
 @assert sq == 9.0
 
-# close the server socket which will stop the HTTP server
-close(socket)
-@assert istaskdone(servertask)
+# close the server which will stop the HTTP server from listening
+close(server)
+@assert istaskdone(server.task)

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -341,9 +341,7 @@ function newconnection(::Type{T},
                        host::AbstractString,
                        port::AbstractString;
                        connection_limit=default_connection_limit,
-                       pipeline_limit=default_pipeline_limit,
                        idle_timeout=typemax(Int),
-                       reuse_limit=nolimit,
                        require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
                        kw...)::Connection where {T <: IO}
     return acquire(

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -54,7 +54,7 @@ Fields:
    part of the response body.
 - `timestamp`, time data was last received.
 - `readable`, whether the Connection object is readable
-- `writeable`, whether the Connection object is writable
+- `writable`, whether the Connection object is writable
 """
 mutable struct Connection <: IO
     host::String
@@ -70,6 +70,7 @@ mutable struct Connection <: IO
     timestamp::Float64
     readable::Bool
     writable::Bool
+    state::Any # populated & used by Servers code
 end
 
 """
@@ -89,7 +90,7 @@ Connection(host::AbstractString, port::AbstractString,
     Connection(host, port, idle_timeout,
                 require_ssl_verification,
                 safe_getpeername(io)..., localport(io),
-                io, client, PipeBuffer(), time(), false, false)
+                io, client, PipeBuffer(), time(), false, false, nothing)
 
 Connection(io; require_ssl_verification::Bool=true) =
     Connection("", "", 0, require_ssl_verification, io, false)

--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -126,6 +126,13 @@ close(server)
 """
 function serve end
 
+"""
+    HTTP.serve!(args...; kw...) -> HTTP.Server
+
+Non-blocking version of [`HTTP.serve`](@ref); see that function for details.
+"""
+function serve! end
+
 serve(f, args...; stream::Bool=false, kw...) = Servers.listen(stream ? f : streamhandler(f), args...; kw...)
 serve!(f, args...; stream::Bool=false, kw...) = Servers.listen!(stream ? f : streamhandler(f), args...; kw...)
 

--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -1,6 +1,6 @@
 module Handlers
 
-export Handler, Middleware, serve, Router, register!, getparams, getcookies, streamhandler
+export Handler, Middleware, serve, serve!, Router, register!, getparams, getcookies, streamhandler
 
 using URIs
 using ..Messages, ..Streams, ..IOExtras, ..Servers, ..Sockets, ..Cookies
@@ -65,6 +65,7 @@ end
 
 """
     HTTP.serve(f, host, port; stream::Bool=false, kw...)
+    HTTP.serve!(f, host, port; stream::Bool=false, kw...) -> HTTP.Server
 
 Start a server on the given host and port; for each incoming request, call the
 given handler function `f`, which should be of the form `f(req::HTTP.Request) -> HTTP.Response`
@@ -79,9 +80,10 @@ Accepts all the same keyword arguments (and passes them along) to [`HTTP.listen`
   * `connection_count`: a `Ref{Int}` to keep track of currently open connections
   * `readtimeout`: time in seconds (integer) that the server should wait for a request to be sent
 """
-function serve(f, host=Sockets.localhost, port=8081; stream::Bool=false, kw...)
-    return Servers.listen(stream ? f : streamhandler(f), host, port; kw...)
-end
+function serve end
+
+serve(f, args...; stream::Bool=false, kw...) = Servers.listen(stream ? f : streamhandler(f), args...; kw...)
+serve!(f, args...; stream::Bool=false, kw...) = Servers.listen!(stream ? f : streamhandler(f), args...; kw...)
 
 # tree-based router handler
 mutable struct Variable

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -259,7 +259,7 @@ Whether a `Request` is eligible to be retried.
 """
 function retryable end
 
-retryable(r::Request) = (isbytes(r.body) || ismarked(r.body)) &&
+retryable(r::Request) = (isbytes(r.body) || (r.body !== nothing && ismarked(r.body))) &&
     (isidempotent(r) || retry_non_idempotent(r)) && !retrylimitreached(r)
 retryable(r::Response) = retryable(r.status)
 retryable(status) = status in (403, 408, 409, 429, 500, 502, 503, 504, 599)

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -421,7 +421,6 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
             http = Stream(request, c)
             # attempt to read request line and headers
             try
-                dump(http)
                 startread(http)
                 @debugv 1 "startread called"
                 c.state = ACTIVE # once we've started reading, set ACTIVE state

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -51,16 +51,16 @@ function Listener(addr::Sockets.InetAddr, host::String, port::String;
             @warn "reuseaddr=true not supported on this platform: $(Sys.KERNEL)"
             @goto fallback
         end
-        server = TCPSocket(delay = false)
+        server = Sockets.TCPServer(delay = false)
         bindearly = Sys.islinux()
-        bindearly && Sockets.bind(server, addr.host, addr.port; reuseaddr=true)
+        bindearly && Sockets.bind(server, addr.host, addr.port)
         rc = ccall(:jl_tcp_reuseport, Int32, (Ptr{Cvoid},), server.handle)
         if rc < 0
             close(server)
             @warn "reuseaddr=true failed; falling back to regular listen: $(Sys.KERNEL)"
             @goto fallback
         end
-        bindearly || Sockets.bind(server, addr.host, addr.port; reuseaddr=true)
+        bindearly || Sockets.bind(server, addr.host, addr.port)
         Sockets.listen(server)
     else
 @label fallback

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -244,7 +244,6 @@ function Base.read(http::Stream, ::Type{UInt8})
         http.warn_not_to_read_one_byte_at_a_time = false
     end
 
-    @show ntoread(http)
     if ntoread(http) == 0
         throw(EOFError())
     end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -244,6 +244,7 @@ function Base.read(http::Stream, ::Type{UInt8})
         http.warn_not_to_read_one_byte_at_a_time = false
     end
 
+    @show ntoread(http)
     if ntoread(http) == 0
         throw(EOFError())
     end

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -391,6 +391,7 @@ end
 
 """
     WebSockets.listen(handler, host, port; verbose=false, kw...)
+    WebSockets.listen!(handler, host, port; verbose=false, kw...) -> HTTP.Server
 
 Listen for websocket connections on `host` and `port`, and call `handler(ws)`,
 which should be a function taking a single `WebSocket` argument.
@@ -407,11 +408,10 @@ WebSockets.listen(host, port) do ws
 end
 
 """
-function listen(f::Function, host="localhost", port::Integer=UInt16(8081); verbose=false, suppress_close_error::Bool=false, kw...)
-    Servers.listen(host, port; verbose=verbose, kw...) do http
-        upgrade(f, http; suppress_close_error, kw...)
-    end
-end
+function listen end
+
+listen(f, args...; kw...) = Servers.listen(http -> upgrade(f, http; kw...), args...; kw...)
+listen!(f, args...; kw...) = Servers.listen!(http -> upgrade(f, http; kw...), args...; kw...)
 
 function upgrade(f::Function, http::Streams.Stream; suppress_close_error::Bool=false, maxframesize::Integer=typemax(Int), maxfragmentation::Integer=DEFAULT_MAX_FRAG, kw...)
     @debugv 2 "Server websocket upgrade requested"

--- a/test/chunking.jl
+++ b/test/chunking.jl
@@ -17,8 +17,7 @@ using BufferedStreams
                    "data: 3$(repeat("x", sz))\n\n"
     split1 = 106
     split2 = 300
-    server = Sockets.listen(ip"127.0.0.1", port)
-    t = @async HTTP.listen("127.0.0.1", port; server=server) do http
+    server = HTTP.listen!(port) do http
         startwrite(http)
         tcp = http.stream.io
 
@@ -33,9 +32,6 @@ using BufferedStreams
         write(tcp, encoded_data[split2+1:end])
         flush(tcp)
     end
-
-    sleep(1)
-    @assert !istaskdone(t)
 
     r = HTTP.get("http://127.0.0.1:$port")
 

--- a/test/client.jl
+++ b/test/client.jl
@@ -513,10 +513,10 @@ end
 end
 
 @testset "Retry with request/response body streams" begin
-    server = listen(IPv4(0), 8080)
+    server = nothing
     try
         shouldfail = Ref(true)
-        tsk = @async HTTP.listen("0.0.0.0", 8080; server=server) do http
+        server = HTTP.listen!(8080) do http
             @assert !eof(http)
             msg = String(readavailable(http))
             if shouldfail[]
@@ -533,7 +533,9 @@ end
         @test resp.status == 200
         @test String(take!(res_body)) == "hey there sailor"
     finally
-        close(server)
+        if server !== nothing
+            close(server)
+        end
         HTTP.ConnectionPool.closeall()
     end
 end

--- a/test/cookies.jl
+++ b/test/cookies.jl
@@ -148,8 +148,7 @@ using Sockets, Test
     end
 
     @testset "Set-Cookie casing" begin
-        server = Sockets.listen(Sockets.localhost, 8080)
-        tsk = @async HTTP.listen(Sockets.localhost, 8080; server=server) do http
+        server = HTTP.listen!(8080) do http
             t = http.message.target
             HTTP.setstatus(http, 200)
             if t == "/set-cookie"
@@ -183,8 +182,6 @@ using Sockets, Test
         r = HTTP.get("http://localhost:8080/cookie"; cookies=true, cookiejar=cookiejar)
         @test HTTP.header(r, "X-Cookie") == "cookie=spongebob_cookie"
         close(server)
-        try; wait(tsk); catch e; end
-        @test istaskdone(tsk)
     end
 
     @testset "splithostport" begin

--- a/test/server.jl
+++ b/test/server.jl
@@ -13,40 +13,21 @@ function testget(url, m=1)
     return r
 end
 
+const echohandler = req -> HTTP.Response(200, req.body)
+const echostreamhandler = HTTP.streamhandler(echohandler)
+
 @testset "HTTP.listen" begin
     port = 8087 # rand(8000:8999)
 
-    # echo response
-    local handler = (http) -> begin
-        request::HTTP.Request = http.message
-        request.body = read(http)
-        closeread(http)
-        request.response::HTTP.Response = HTTP.Response(request.body)
-        request.response.request = request
-        startwrite(http)
-        write(http, request.response.body)
-    end
-
-    server = Sockets.listen(ip"127.0.0.1", port)
-    tsk = @async HTTP.listen(handler, "127.0.0.1", port; server=server)
-    sleep(3.0)
-    @test !istaskdone(tsk)
+    server = HTTP.listen!(echostreamhandler, port)
     r = testget("http://127.0.0.1:$port")
     @test r[1].status == 200
     close(server)
     sleep(0.5)
-    @test istaskdone(tsk)
+    @test istaskdone(server.task)
 
-    server = Sockets.listen(ip"127.0.0.1", port)
-    tsk = @async HTTP.listen(handler, "127.0.0.1", port; server=server)
-
-    handler2 = req -> HTTP.Response(200, req.body)
-
-    server2 = Sockets.listen(ip"127.0.0.1", port+100)
-    tsk2 = @async HTTP.serve(handler2, "127.0.0.1", port+100; server=server2)
-    sleep(0.5)
-    @test !istaskdone(tsk)
-    @test !istaskdone(tsk2)
+    server = HTTP.listen!(echostreamhandler, port)
+    server2 = HTTP.serve!(echohandler, port+100)
 
     r = testget("http://127.0.0.1:$port")
     @test r[1].status == 200
@@ -114,24 +95,13 @@ end
     @test occursin("Transfer-Encoding: chunked\r\n", client)
     @test occursin("Body of Request", client)
 
-    hello = (http) -> begin
-        request::HTTP.Request = http.message
-        request.body = read(http)
-        closeread(http)
-        request.response::HTTP.Response = HTTP.Response("Hello")
-        request.response.request = request
-        startwrite(http)
-        write(http, request.response.body)
-    end
     close(server)
     close(server2)
 
     # keep-alive vs. close: issue #81
+    hello = HTTP.streamhandler(req -> HTTP.Response("Hello"))
     port += 1
-    server = Sockets.listen(ip"127.0.0.1", port)
-    tsk = @async HTTP.listen(hello, "127.0.0.1", port; server=server, verbose=true)
-    sleep(0.5)
-    @test !istaskdone(tsk)
+    server =  HTTP.listen!(hello, port; verbose=true)
     tcp = Sockets.connect(ip"127.0.0.1", port)
     write(tcp, "GET / HTTP/1.0\r\n\r\n")
     sleep(0.5)
@@ -143,28 +113,24 @@ end
     end
 
     # SO_REUSEPORT
-    println("Testing server port reuse")
-    t1 = @async HTTP.listen(hello, "127.0.0.1", 8089; reuseaddr=true)
-    sleep(0.5)
-    @test !istaskdone(t1)
-
-    println("Starting second server listening on same port")
-    t2 = @async HTTP.listen(hello, "127.0.0.1", 8089; reuseaddr=true)
-    sleep(0.5)
-    @test Sys.iswindows() ? istaskdone(t2) : !istaskdone(t2)
-
-    println("Starting server on same port without port reuse (throws error)")
-    try
-        HTTP.listen(hello, "127.0.0.1", 8089)
-    catch e
-        @test e isa Base.IOError
-        @test startswith(e.msg, "listen")
-        @test e.code == Base.UV_EADDRINUSE
+    if HTTP.Servers.supportsreuseaddr()
+        println("Testing server port reuse")
+        t1 = HTTP.listen!(hello, 8089; reuseaddr=true)
+        println("Starting second server listening on same port")
+        t2 = HTTP.listen!(hello, 8089; reuseaddr=true)
+        println("Starting server on same port without port reuse (throws error)")
+        try
+            HTTP.listen(hello, 8089)
+        catch e
+            @test e isa Base.IOError
+            @test startswith(e.msg, "listen")
+            @test e.code == Base.UV_EADDRINUSE
+        end
     end
 
     # test automatic forwarding of non-sensitive headers
     # this is a server that will "echo" whatever headers were sent to it
-    t1 = @async HTTP.listen("127.0.0.1", 8090) do http
+    t1 = HTTP.listen!(8090) do http
         request::HTTP.Request = http.message
         request.body = read(http)
         closeread(http)
@@ -174,115 +140,48 @@ end
         write(http, request.response.body)
     end
 
-    sleep(0.5)
-    @test !istaskdone(t1)
-
     # test that an Authorization header is **not** forwarded to a domain different than initial request
     @test !HTTP.hasheader(HTTP.get("http://httpbin.org/redirect-to?url=http://127.0.0.1:8090", ["Authorization"=>"auth"]), "Authorization")
 
     # test that an Authorization header **is** forwarded to redirect in same domain
     @test HTTP.hasheader(HTTP.get("http://httpbin.org/redirect-to?url=https://httpbin.org/response-headers?Authorization=auth"), "Authorization")
+    close(t1)
 
     # 318
     dir = joinpath(dirname(pathof(HTTP)), "../test")
     sslconfig = MbedTLS.SSLConfig(joinpath(dir, "resources/cert.pem"), joinpath(dir, "resources/key.pem"))
-    tsk = @async try
-        HTTP.listen("127.0.0.1", 8092; sslconfig = sslconfig, verbose=true) do http::HTTP.Stream
-            while !eof(http)
-                println("body data: ", String(readavailable(http)))
-            end
-            HTTP.setstatus(http, 200)
-            HTTP.startwrite(http)
-            write(http, "response body\n")
-            write(http, "more response body")
+    server = HTTP.listen!(8092; sslconfig = sslconfig, verbose=true) do http::HTTP.Stream
+        while !eof(http)
+            println("body data: ", String(readavailable(http)))
         end
-    catch err
-        @error err exception = (err, catch_backtrace())
+        HTTP.setstatus(http, 200)
+        HTTP.startwrite(http)
+        write(http, "response body\n")
+        write(http, "more response body")
     end
-    clientoptions = (;
-        require_ssl_verification = false,
-    )
-    r = HTTP.request("GET", "https://127.0.0.1:8092"; clientoptions...)
-    @test_throws HTTP.RequestError HTTP.request("GET", "http://127.0.0.1:8092"; clientoptions...)
-
-end # @testset
-
-@testset "HTTP.listen: rate_limit" begin
-    io = IOBuffer()
-    logger = Base.CoreLogging.SimpleLogger(io)
-    server = listen(IPv4(0), 8080)
-    @async Base.CoreLogging.with_logger(logger) do
-        HTTP.listen("0.0.0.0", 8080; server=server, rate_limit=2//1) do http
-            HTTP.setstatus(http, 200)
-            HTTP.setheader(http, "Content-Length" => "0")
-            HTTP.startwrite(http)
-            HTTP.close(http.stream) # close to force a new connection everytime
-        end
-    end
-    # Test requests from the same IP within the limit
-    for _ in 1:5
-        sleep(0.6) # rate limit allows 2 per second
-        @test HTTP.get("http://127.0.0.1:8080").status == 200
-    end
-    # Test requests from the same IP over the limit
-    try
-        for _ in 1:5
-            sleep(0.2) # rate limit allows 2 per second
-            r = HTTP.get("http://127.0.0.1:8080"; retry=false)
-            @test r.status == 200
-        end
-    catch e
-        @test e isa HTTP.RequestError
-    end
-
+    r = HTTP.request("GET", "https://127.0.0.1:8092"; require_ssl_verification = false)
+    @test_throws HTTP.RequestError HTTP.request("GET", "http://127.0.0.1:8092"; require_ssl_verification = false)
     close(server)
-    @test occursin("discarding connection from 127.0.0.1 due to rate limiting", String(take!(io)))
-
-    # # Tests to make sure the correct client IP is used (https://github.com/JuliaWeb/HTTP.jl/pull/701)
-    # # This test requires a second machine and thus commented out
-    #
-    # Machine 1
-    # @async HTTP.listen("0.0.0.0", 8080; rate_limit=2//1) do http
-    #     HTTP.setstatus(http, 200)
-    #     HTTP.setheader(http, "Content-Length" => "0")
-    #     HTTP.startwrite(http)
-    #     HTTP.close(http.stream) # close to force a new connection everytime
-    # end
-    # while true
-    #     sleep(0.6)
-    #     print("#") # to show some progress
-    #     HTTP.get("http://$(MACHINE_1_IPV4):8080"; retry=false)
-    # end
-    #
-    # # Machine 2
-    # while true
-    #     sleep(0.6)
-    #     print("#") # to show some progress
-    #     HTTP.get("http://$(MACHINE_1_IPV4):8080"; retry=false)
-    # end
-
-end
+end # @testset
 
 @testset "on_shutdown" begin
     @test HTTP.Servers.shutdown(nothing) === nothing
 
-    IOserver = Sockets.listen(ip"127.0.0.1", 8052)
-
     # Shutdown adds 1
     TEST_COUNT = Ref(0)
     shutdown_add() = TEST_COUNT[] += 1
-    server = HTTP.Servers.Server(nothing, IOserver, "host", "port", shutdown_add)
+    server = HTTP.listen!(x -> nothing, 8052; on_shutdown=shutdown_add)
     close(server)
 
     # Shutdown adds 1, performed twice
     @test TEST_COUNT[] == 1
-    server = HTTP.Servers.Server(nothing, IOserver, "host", "port", [shutdown_add, shutdown_add])
+    server = HTTP.listen!(x -> nothing, 8052; on_shutdown=[shutdown_add, shutdown_add])
     close(server)
     @test TEST_COUNT[] == 3
 
     # First shutdown function errors, second adds 1
     shutdown_throw() = throw(ErrorException("Broken"))
-    server = HTTP.Servers.Server(nothing, IOserver, "host", "port", [shutdown_throw, shutdown_add])
+    server = HTTP.listen!(x -> nothing, 8052; on_shutdown=[shutdown_throw, shutdown_add])
     @test_logs (:error, r"shutdown function .* failed") close(server)
     @test TEST_COUNT[] == 4
 end # @testset
@@ -307,21 +206,14 @@ end # @testset
         end
     end
     function with_testserver(f, fmt)
-        l = Sockets.listen(ip"0.0.0.0", 32612)
         logger = Test.TestLogger()
-        ready_to_accept = Ref(false)
-        tsk = @async begin
-            Base.CoreLogging.with_logger(logger) do
-                HTTP.listen(handler, Sockets.localhost, 32612; server=l, ready_to_accept, access_log=fmt)
-            end
-        end
-        while !ready_to_accept[]
-            sleep(0.1)
+        server = Base.CoreLogging.with_logger(logger) do
+            HTTP.listen!(handler, Sockets.localhost, 32612; access_log=fmt)
         end
         try
             f()
         finally
-            close(l)
+            close(server)
         end
         return filter!(x -> x.group == :access, logger.logs)
     end

--- a/test/server.jl
+++ b/test/server.jl
@@ -51,7 +51,7 @@ const echostreamhandler = HTTP.streamhandler(echohandler)
     sleep(0.1)
     try
         resp = String(readavailable(tcp))
-        @test occursin(r"HTTP/1.1 413 Request Entity Too Large", resp)
+        @test occursin(r"HTTP/1.1 431 Request Header Fields Too Large", resp)
     catch
         println("Failed reading bad request response")
     end

--- a/test/websockets/autobahn.jl
+++ b/test/websockets/autobahn.jl
@@ -52,15 +52,10 @@ if Int === Int64 && !Sys.iswindows()
 end # @testset "Autobahn testsuite"
 
 @testset "Server" begin
-    server = Sockets.listen(Sockets.localhost, 9002)
-    ready_to_accept = Ref(false)
-    @async WebSockets.listen(Sockets.localhost, 9002; server, ready_to_accept, suppress_close_error=true) do ws
+    server = WebSockets.listen!(9002; suppress_close_error=true) do ws
         for msg in ws
             send(ws, msg)
         end
-    end
-    while !ready_to_accept[]
-        sleep(0.5)
     end
     rm(joinpath(DIR, "reports/server/index.json"); force=true)
     @test success(run(Cmd(`wstest -u 0 -m fuzzingclient -s config/fuzzingclient.json`; dir=DIR)))

--- a/test/websockets/deno_client/server.jl
+++ b/test/websockets/deno_client/server.jl
@@ -3,25 +3,18 @@ using Test, Sockets, Deno_jll, HTTP
 # Not all architectures have a Deno_jll
 hasproperty(Deno_jll, :deno) && @testset "WebSocket server" begin
     port = 36984
-    server = listen(Sockets.localhost, port)
     # Will contain a list of received messages
     server_received_messages = []
     # Start the server async
-    @async try
-        WebSockets.listen(Sockets.localhost, port; server=server) do ws
-            for msg in ws
-                push!(server_received_messages, msg)
-                if msg == "close"
-                    close(ws)
-                else
-                    response = "Hello, " * msg
-                    send(ws, response)
-                end
+    server = WebSockets.listen!(port) do ws
+        for msg in ws
+            push!(server_received_messages, msg)
+            if msg == "close"
+                close(ws)
+            else
+                send(ws, "Hello, " * msg)
             end
         end
-    catch e
-        @error "WebSocket server error" exception=(e,catch_backtrace())
-        rethrow(e)
     end
 
     try


### PR DESCRIPTION
There have been a few issues (#587, #563) around the overall ergonomics
of using `HTTP.listen` and the code hasn't had a good comb-through in a while.

I used the core golang [server code](https://github.com/golang/go/blob/master/src/net/http/server.go)
as a reference to see what kinds of things they allowed in terms of configuration,
functionality, and overall ergonomics.

The changes proposed here include:
  * New `HTTP.listen!` non-blocking version of `HTTP.listen` that returns a `Server` object
  * `Server` object supports `wait`, `close`, and `forceclose`; `close` initiates a "graceful"
    shutdown where active connections are waited for until they are finished being processed;
    `forceclose` just force closes all open connections.
  * The combination of `HTTP.listen!` + `Server` mean we have a much more convenient and simple
    way to interact with a running server.
  * In addition, when calling the provided handler function `f`, we use `Base.invokelatest(f, stream)`
    which gives the nice property of allowing Revise to "update" a live server by reflecting edits
    made to the handler/middleware stack.
  * Removed `reuse_limit` and `rate_limit` features since they were either problematic in their
    implementation or not really that useful
  * Tried to clean up the verbose logging story, though there's more to do here
  * Tried to clean up some core listenloop logic, though there's more to do here

Otherwise, the core `HTTP.listen` function remains mostly unchanged, except for the changes to supported
keyword arguments. Still need to update some tests, docs, and comb-through the `handle_transaction`
function, but wanted to put this up now in case others are interested in taking a look.