### PR TITLE
Fix HTTP.listen with provided TCP server

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -32,7 +32,7 @@ end
 function Listener(server::Base.IOServer; sslconfig::Union{MbedTLS.SSLConfig, Nothing}=nothing, kw...)
     host, port = getsockname(server)
     addr = getinet(host, port)
-    return Listener(addr, host, port, sslconfig, server)
+    return Listener(addr, string(host), string(port), sslconfig, server)
 end
 
 supportsreuseaddr() = ccall(:jl_has_so_reuseport, Int32, ()) == 1

--- a/test/server.jl
+++ b/test/server.jl
@@ -162,6 +162,18 @@ const echostreamhandler = HTTP.streamhandler(echohandler)
     r = HTTP.request("GET", "https://127.0.0.1:8092"; require_ssl_verification = false)
     @test_throws HTTP.RequestError HTTP.request("GET", "http://127.0.0.1:8092"; require_ssl_verification = false)
     close(server)
+
+    # HTTP.listen with server kwarg
+    let host = Sockets.localhost; port = 8093
+        server = Sockets.listen(host, port)
+        HTTP.listen!(Sockets.localhost, 8093; server=server) do http
+            HTTP.setstatus(http, 200)
+            HTTP.startwrite(http)
+        end
+        r = HTTP.get("http://$(host):$(port)/"; readtimeout=30)
+        @test r.status == 200
+        close(server)
+    end
 end # @testset
 
 @testset "on_shutdown" begin


### PR DESCRIPTION
Sockets.getsockname returns host as an IPAddr and port as Int, but
HTTP.Listener expects host and port as Strings.