### PR TITLE
Add some deprecations to help upgrading to HTTP.jl v1.

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -63,6 +63,9 @@ function streamhandler(handler)
     end
 end
 
+# Interface change in HTTP@1
+@deprecate RequestHandlerFunction streamhandler
+
 """
     HTTP.serve(handler, host=Sockets.localhost, port=8081; kw...)
     HTTP.serve(handler, port::Integer=8081; kw...)

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -317,6 +317,9 @@ function isupgrade(r::Message)
     hasheader(r, "Upgrade", "websocket")
 end
 
+# Renamed in HTTP@1
+@deprecate is_upgrade isupgrade
+
 @noinline handshakeerror() = throw(WebSocketError(CloseFrameBody(1002, "Websocket handshake failed")))
 
 function hashedkey(key)


### PR DESCRIPTION
Doesn't really cost anything to add deprecations for simple things like this. Thoughts?