### PR TITLE
docs: fix markdown formatting

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -336,6 +336,7 @@ will enable debug logging for the life of the websocket connection.
 `handler` should be a function of the form `f(ws) -> nothing`, where `ws` is a [`WebSocket`](@ref).
 Supported keyword arguments are the same as supported by [`HTTP.request`](@ref).
 Typical websocket usage is:
+
 ```julia
 WebSockets.open(url) do ws
     # iterate incoming websocket messages


### PR DESCRIPTION
Fenced code sections need some more space around them, at least for documenter.

Actually, there are loads of these. Going to close this. Might reopen after building docs locally and checking if this fixes the issue I saw.