### PR TITLE
Ensure a Request accounts correctly for isredirect/retryable

### DIFF
--- a/src/clientlayers/RedirectRequest.jl
+++ b/src/clientlayers/RedirectRequest.jl
@@ -14,9 +14,9 @@ function redirectlayer(handler)
     return function(req; redirect::Bool=true, redirect_limit::Int=3, redirect_method=nothing, forwardheaders::Bool=true, response_stream=nothing, kw...)
         if !redirect || redirect_limit == 0
             # no redirecting
-            return handler(req; redirect_limit=redirect_limit, kw...)
+            return handler(req; kw...)
         end
-
+        req.context[:allow_redirects] = true
         count = 0
         while true
             # Verify the url before making the request. Verification is done in

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -24,6 +24,7 @@ function retrylayer(handler)
             # no retry
             return handler(req; kw...)
         end
+        req.context[:allow_retries] = true
         if retry_non_idempotent
             req.context[:retry_non_idempotent] = true
         end

--- a/test/client.jl
+++ b/test/client.jl
@@ -532,6 +532,11 @@ end
         resp = HTTP.get("http://localhost:8080/retry"; body=req_body, response_stream=res_body, verbose=2)
         @test resp.status == 200
         @test String(take!(res_body)) == "hey there sailor"
+        # ensure if retry=false, that we write the response body immediately
+        shouldfail[] = true
+        seekstart(req_body)
+        resp = HTTP.get("http://localhost:8080/retry"; body=req_body, response_stream=res_body, retry=false, status_exception=false)
+        @test String(take!(res_body)) == "500 unexpected error"
     finally
         if server !== nothing
             close(server)


### PR DESCRIPTION
In the new functionality where a response_stream will only be written to
on the "final" request in the case of redirects/retries, we failed to account
for the case when the user specifically requests no redirects/retries,
so the behavior involved NOT redirecting/retrying, yet we weren't writing
the response body to the response_stream because the Request was otherwise
deemed redirectable/retryable. This PR fixes it by incorporating the values
of the redirect/redirect_limit/retry/retry_limit keyword args into the
computation of isredirect/retryable.