### PR TITLE
Ensure underlying Connection gets closed in websocket close sequence …

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -575,6 +575,7 @@ function Base.close(ws::WebSocket, body::CloseFrameBody=CloseFrameBody(1000, "")
     if !ws.readclosed
         Timer(5) do t
             ws.readclosed = true
+            !ws.client && isopen(ws.io) && close(ws.io)
         end
     end
     while !ws.readclosed
@@ -590,9 +591,7 @@ function Base.close(ws::WebSocket, body::CloseFrameBody=CloseFrameBody(1000, "")
     # or there was an error/timeout reading it; in any case, readclosed should be closed now
     @assert ws.readclosed
     # if we're the server, it's our job to close the underlying socket
-    if !ws.client
-        close(ws.io)
-    end
+    !ws.client && isopen(ws.io) && close(ws.io)
     return
 end
 


### PR DESCRIPTION
…if timer runs out

Noticed this while doing a local back and forth w/ a manual server socket.
The problem is when we try to initiate the websocket close sequence, but we
have a remote who just won't respond (like in my manual socket case). I
*thought* the Timer would kick in and close things up, but it turns out
the `receive(ws)` call will just block indefinitely, so we never manage
to break out of our while loop. The fix proposed here adds the logic to
the Timer, so if we wait 5 seconds and nothing has been received, we
actually go ahead and close the underlying Connection which in turn
will break us out of the `receive` while loop and not cause `close(ws)`
to hang.