### PR TITLE
permessage-deflate support

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -93,21 +93,23 @@ end
 
 function compress(data::T) where T <: AbstractVector{UInt8}
     compressed = transcode(DeflateCompressor, data)
-    return vcat(compressed, 0x00)
+    push!(compressed, 0x00)
+    return compressed
 end
 
 function compress(data::String)
     compressed = transcode(DeflateCompressor, data)
-    return String(vcat(compressed, 0x00))
+    push!(compressed, 0x00)
+    return String(compressed)
 end
 
 function decompress(data::T) where T <: AbstractVector{UInt8}
-    decompressed = transcode(DeflateDecompressor, vcat(data, [0x00, 0x00, 0xff, 0xff, 0x03, 0x00]))
+    decompressed = transcode(DeflateDecompressor, append!(data, [0x00, 0x00, 0xff, 0xff, 0x03, 0x00]))
     return decompressed
 end
 
 function decompress(data::String)
-    decompressed = transcode(DeflateDecompressor, vcat(Vector{UInt8}(data), [0x00, 0x00, 0xff, 0xff, 0x03, 0x00]))
+    decompressed = transcode(DeflateDecompressor, append!(Vector{UInt8}(data), [0x00, 0x00, 0xff, 0xff, 0x03, 0x00]))
     return String(decompressed)
 end
 


### PR DESCRIPTION
Hi.
Sharing my example of implementing permessage-deflate using CodecZlib in continuation #853.
In the process, I encountered fragmentation difficulties, since the `opcode` is calculated during the process of sending data and we do not know about the type of compressed data. Therefore, I decided to separately compress a string into a string, an array into an array before sending. Also moved utf-8 check after unpacking. Tested with Chrome and Julia client.

Please, review it

Server: 
```
WebSockets.listen(host, port; binary=false, isdeflate=true) do ws
    @async while true
        sleep(2)
        payload = WebSockets.compress("Hello")                       # if fragmentation true
        WebSockets.send(ws, [payload[1:2], payload[3:end]])
        # payload = "Hello"                                          # if fragmentation false
        # WebSockets.send(ws, payload)
    end
    for msg in ws
        @info "Received: ", msg
    end
end
```
Client:
```
WebSockets.open("ws://127.0.0.1:8080") do ws
    for msg in ws
        @info "Client received: ", msg
        # msg = WebSockets.compress(msg)                            # if fragmentation true
        WebSockets.send(ws, msg)
    end
end
```
