### PR TITLE
Preserve response body when retrying/redirecting

### DIFF
--- a/test/client.jl
+++ b/test/client.jl
@@ -537,6 +537,13 @@ end
         seekstart(req_body)
         resp = HTTP.get("http://localhost:8080/retry"; body=req_body, response_stream=res_body, retry=false, status_exception=false)
         @test String(take!(res_body)) == "500 unexpected error"
+        # when retrying, we can still get access to the most recent failed response body in the response's request context
+        shouldfail[] = true
+        seekstart(req_body)
+        resp = HTTP.get("http://localhost:8080/retry"; body=req_body, response_stream=res_body)
+        @test resp.status == 200
+        @test String(take!(res_body)) == "hey there sailor"
+        @test String(resp.request.context[:response_body]) == "500 unexpected error"
     finally
         if server !== nothing
             close(server)


### PR DESCRIPTION
This is another iteration in our redirect/retry response body handling.
Previously, when the response body is streamed, we ensured only the
"final" response body is the one written to the user-provided stream.
The only issue is that sometimes it can be helpful to have access to
the intermediate response bodies that ended up being retried/redirected.
This PR refactors the `readbody` machinery a bit to ensure we always read
the response body, and in the case of a user-provided response stream,
we read the response body as a string and store it in the request context.

One motivation I'm working towards with this is providing more nuanced control
over the retry logic, even allowing users to pass in their own `check` function
to determine if a request should be retried or not based on the failed response.
In that scenario, you'll want access to the failed response body, so this will
enabled that.