### PR TITLE
Allow user-configurable retry delay and check

### DIFF
--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -261,8 +261,9 @@ Whether a `Request` is eligible to be retried.
 """
 function retryable end
 
-retryable(r::Request) = (isbytes(r.body) || (r.body !== nothing && ismarked(r.body))) &&
-    allow_retries(r) && (isidempotent(r) || retry_non_idempotent(r)) && !retrylimitreached(r)
+retryable_requestbody(r::Request) = isbytes(r.body) || (r.body !== nothing && ismarked(r.body))
+retryable(r::Request) = retryable_requestbody(r) && allow_retries(r) &&
+    (isidempotent(r) || retry_non_idempotent(r)) && !retrylimitreached(r)
 retryable(r::Response) = retryable(r.status)
 retryable(status) = status in (403, 408, 409, 429, 500, 502, 503, 504, 599)
 

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -41,7 +41,7 @@ function retrylayer(handler)
             delays=retry_delays,
             check=(s, ex) -> begin
                 retryattempt[] += 1
-                retry = (isrecoverable(ex) && retryable(req)) || (Messages.retryable_requestbody(req) && retry_check(req, req.resp, ex))
+                retry = (isrecoverable(ex) && retryable(req)) || (Messages.retryable_requestbody(req) && retry_check(req, req.response, get_maybe_ephemeral_response_body(req), ex))
                 if retryattempt[] == retries
                     req.context[:retrylimitreached] = true
                 end
@@ -62,6 +62,8 @@ function retrylayer(handler)
         return retry_request(req; kw...)
     end
 end
+
+get_maybe_ephemeral_response_body(req::Request) = isbytes(req.response.body) ? req.response.body : get(() -> UInt8[], req.context, :ephemeral_response_body)
 
 supportsmark(x) = false
 supportsmark(x::T) where {T <: IO} = length(Base.methods(mark, Tuple{T}, parentmodule(T))) > 0 || hasfield(T, :mark)


### PR DESCRIPTION
It's been reported that users sometimes feel the need to disable HTTP's
retry abilities and wrap HTTP methods with their own retry logic due
to the lack of configurability around delays and overriding the retry
check. Since there is some tricky logic in getting retries just right,
especially in the presence of streaming request or response bodies,
this PR proposes more configurability for retry logic in the hopes
that users won't opt to roll their own incorrect retry logic.