### PR TITLE
Add getparam and empty Listener definitions for convenience

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -117,6 +117,7 @@ HTTP.Middleware
 HTTP.streamhandler
 HTTP.Router
 HTTP.register!
+HTTP.getparam
 HTTP.getparams
 HTTP.Handlers.cookie_middleware
 HTTP.getcookies

--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -441,6 +441,19 @@ and can be retrieved like `id = HTTP.getparams(req)["id"]`.
 getparams(req) = get(req.context, :params, nothing)
 
 """
+    HTTP.getparam(req, name, default=nothing) -> String
+
+Retrieve a matched path parameter with name `name` from request context.
+If a path was registered with a router via `HTTP.register!` like
+"/api/widget/{id}", then the path parameter can be retrieved like `id = HTTP.getparam(req, "id").
+"""
+function getparam(req, name, default=nothing)
+    params = getparams(req)
+    params === nothing && return default
+    return get(params, name, default)
+end
+
+"""
     HTTP.Handlers.cookie_middleware(handler) -> handler
 
 Middleware that parses and stores any cookies in the incoming

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -69,6 +69,7 @@ end
 
 Listener(host::Union{IPAddr, String}, port::Integer; kw...) = Listener(getinet(host, port), string(host), string(port); kw...)
 Listener(port::Integer; kw...) = Listener(Sockets.localhost, port; kw...)
+Listener(; kw...) = Listener(Sockets.localhost, 8081; kw...)
 
 Base.isopen(l::Listener) = isopen(l.server)
 Base.close(l::Listener) = close(l.server)


### PR DESCRIPTION
We have `HTTP.getparams`, but it can be convenient to have `HTTP.getparam`
when you only need one param. The params are also considered immutable
so we don't need much else in terms of an AbstractDict interface.

Also adds a missing Listener definition so we support the case
like `HTTP.serve(; server=Sockets.listen(...))`.