### PR TITLE
Cleanup connection reuse logic

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -356,8 +356,8 @@ function newconnection(::Type{T},
     end
 end
 
-releaseconnection(c::Connection) =
-    release(POOL, connectionkey(c), c)
+releaseconnection(c::Connection, reuse) =
+    release(POOL, connectionkey(c), c; return_for_reuse=reuse)
 
 function keepalive!(tcp)
     @debugv 2 "setting keepalive on tcp socket"


### PR DESCRIPTION
Fixes #875. The problem in the original issue here was that if you tried
to do a websocket request, then very quickly tried another request,
the connection pool would try to reuse the same underlying Connection
object for the 2nd request, even while the 1st was still in the shutdown
and close sequence. This resulted in the 2nd connection having sporadic
behavior, usually in the form of an EOFError.

The fix here is cleaning up our ConnectionRequest logic around which
connections should be reused or closed prior to being released back
to the connection pool.