### PR TITLE
disallow bugs in `@try` usage

### DIFF
--- a/src/Exceptions.jl
+++ b/src/Exceptions.jl
@@ -5,15 +5,20 @@ import ..HTTP # for doc references
 
 @eval begin
 """
-    @try expr
+    @try Permitted Error Types expr
 
 Convenience macro for wrapping an expression in a try/catch block
 where thrown exceptions are ignored.
 """
-macro $(:try)(ex)
+macro $(:try)(exes...)
+    errs = Any[exes...]
+    ex = pop!(errs)
+    isempty(errs) && error("no permitted errors")
     quote
         try $(esc(ex))
-        catch
+        catch e
+            e isa InterruptException && rethrow(e)
+            |($([:(e isa $(esc(err))) for err in errs]...)) || rethrow(e)
         end
     end
 end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -109,7 +109,7 @@ Write the final `0` chunk if needed.
 function closebody(http::Stream)
     if http.writechunked
         http.writechunked = false
-        @try write(http.stream, "0\r\n\r\n")
+        @try Base.IOError write(http.stream, "0\r\n\r\n")
     end
 end
 

--- a/src/clientlayers/ConnectionRequest.jl
+++ b/src/clientlayers/ConnectionRequest.jl
@@ -104,11 +104,12 @@ function connectionlayer(handler)
         catch e
             @debugv 1 "❗️  ConnectionLayer $e. Closing: $io"
             shouldreuse = false
+            @try Base.IOError close(io)
             e isa HTTPError || throw(RequestError(req, e))
             rethrow(e)
         finally
             if !shouldreuse
-                @try close(io)
+                @try Base.IOError close(io)
             end
             releaseconnection(io, shouldreuse)
         end

--- a/src/clientlayers/StreamRequest.jl
+++ b/src/clientlayers/StreamRequest.jl
@@ -41,7 +41,7 @@ function streamlayer(stream::Stream; iofunction=nothing, decompress::Bool=true, 
                 catch e
                     # @error "error" exception=(e, catch_backtrace())
                     write_error = e
-                    isopen(io) && @try close(io)
+                    isopen(io) && @try Base.IOError close(io)
                 end
                 @debugv 2 "client startread"
                 startread(stream)
@@ -52,7 +52,7 @@ function streamlayer(stream::Stream; iofunction=nothing, decompress::Bool=true, 
             if isaborted(stream)
                 # The server may have closed the connection.
                 # Don't propagate such errors.
-                @try close(io)
+                @try Base.IOError close(io)
             end
         end
     catch e

--- a/test/client.jl
+++ b/test/client.jl
@@ -173,7 +173,7 @@ end
             @test err.error isa EOFError
         finally
             # Shutdown
-            @try close(server)
+            @try Base.IOError close(server)
             HTTP.ConnectionPool.closeall()
         end
     end
@@ -299,7 +299,7 @@ end
                 @test req.status == 200
                 @test String(req.body) == "hello, world"
             finally
-                @try close(server)
+                @try Base.IOError close(server)
                 HTTP.ConnectionPool.closeall()
             end
         end
@@ -337,7 +337,7 @@ end
             @test peer[2] == 8080
         end
     finally
-        @try close(server)
+        @try Base.IOError close(server)
         HTTP.ConnectionPool.closeall()
     end
 
@@ -394,7 +394,7 @@ end
 
         HTTP.setuseragent!(old_user_agent)
     finally
-        @try close(server)
+        @try Base.IOError close(server)
         HTTP.ConnectionPool.closeall()
     end
 end
@@ -435,7 +435,7 @@ import NetworkOptions, MbedTLS
             @test HTTP.get(url; require_ssl_verification=false).status == 200
         end
     finally
-        @try close(server)
+        @try Base.IOError close(server)
         HTTP.ConnectionPool.closeall()
     end
 end


### PR DESCRIPTION
Catching all exceptions is considered bad practice, which is why the
default `try` block forbids it.