### PR TITLE
Add $bytes_received to log number of (body) bytes read from client, fixes #892.

### DIFF
--- a/src/access_log.jl
+++ b/src/access_log.jl
@@ -20,6 +20,7 @@ The following variables are currently supported:
  - `$time_local`: local time in Common Log Format
  - `$status`: response status code
  - `$body_bytes_sent`: number of bytes in response body
+ - `$body_bytes_received`: number of bytes read from client
 
 ## Examples
 ```julia
@@ -34,7 +35,6 @@ end
 
 function logfmt_parser(s)
     s = String(s)
-    vars = Symbol[]
     ex = Expr(:call, :print, :io)
     i = 1
     while i <= lastindex(s)
@@ -101,6 +101,8 @@ function symbol_mapping(s::Symbol)
         :(http.message.response.status)
     elseif s === :body_bytes_sent
         return :(http.nwritten)
+    elseif s === :body_bytes_received
+        return :(http.nread)
     else
         error("unknown variable in logfmt: $s")
     end


### PR DESCRIPTION
NGINX `$bytes_received` includes header bytes as well, I think (http://nginx.org/en/docs/stream/ngx_stream_core_module.html#var_bytes_received) so perhaps this should be called `$body_bytes_receieved`? Or perhaps this should be updated to also count header bytes. (NGINX doesn't have `$body_bytes_receieved`.)