### PR TITLE
A grab-bag of improvements

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -125,8 +125,9 @@ Supported optional keyword arguments:
    environment variables are also detected/used; if set, they will be used automatically when making requests.
  - `detect_content_type = false`: if `true` and the request body is not a form or `IO`, it will be
     inspected and the "Content-Type" header will be set to the detected content type.
- - `decompress = true`, if `true`, decompress the response body if the response has a
-    "Content-Encoding" header set to "gzip".
+ - `decompress = nothing`, by default, decompress the response body if the response has a
+    "Content-Encoding" header set to "gzip". If `decompress=true`, decompress the response body
+    regardless of `Content-Encoding` header. If `decompress=false`, do not decompress the response body.
 
 Retry arguments:
  - `retry = true`, retry idempotent requests in case of error.
@@ -453,6 +454,7 @@ macro client(requestlayers, streamlayers=[])
         patch(a...; kw...) = request("PATCH", a...; kw...)
         head(u; kw...) = request("HEAD", u; kw...)
         delete(a...; kw...) = request("DELETE", a...; kw...)
+        open(f, a...; kw...) = request(a...; iofunction=f, kw...)
         request(method, url, h=HTTP.Header[], b=HTTP.nobody; headers=h, body=b, query=nothing, kw...)::HTTP.Response =
             HTTP.request(HTTP.stack($requestlayers, $streamlayers), method, url, headers, body, query; kw...)
     end)

--- a/src/clientlayers/DefaultHeadersRequest.jl
+++ b/src/clientlayers/DefaultHeadersRequest.jl
@@ -10,7 +10,7 @@ using ..Messages, ..Forms, ..IOExtras
 Sets default expected headers.
 """
 function defaultheaderslayer(handler)
-    return function(req; iofunction=nothing, decompress=true, kw...)
+    return function(req; iofunction=nothing, decompress=nothing, kw...)
         headers = req.headers
         if isempty(req.url.port) ||
             (req.url.scheme == "http" && req.url.port == "80") ||
@@ -41,7 +41,7 @@ function defaultheaderslayer(handler)
         elseif !hasheader(headers, "Content-Type") && (req.body isa Dict || req.body isa NamedTuple) && req.method in ("POST", "PUT", "PATCH")
             setheader(headers, "Content-Type" => "application/x-www-form-urlencoded")
         end
-        if decompress
+        if decompress === nothing || decompress
             defaultheader!(headers, "Accept-Encoding" => "gzip")
         end
         return handler(req; iofunction, decompress, kw...)

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -29,7 +29,7 @@ function retrylayer(handler)
             req.context[:retry_non_idempotent] = true
         end
         req_body_is_marked = false
-        if req.body isa IO && supportsmark(req.body)
+        if req.body isa IO && Messages.supportsmark(req.body)
             @debugv 2 "Marking request body stream"
             req_body_is_marked = true
             mark(req.body)
@@ -60,9 +60,6 @@ function retrylayer(handler)
         return retry_request(req; kw...)
     end
 end
-
-supportsmark(x) = false
-supportsmark(x::T) where {T <: IO} = length(Base.methods(mark, Tuple{T}, parentmodule(T))) > 0 || hasfield(T, :mark)
 
 isrecoverable(e) = false
 isrecoverable(e::Union{Base.EOFError, Base.IOError, MbedTLS.MbedException}) = true

--- a/src/clientlayers/StreamRequest.jl
+++ b/src/clientlayers/StreamRequest.jl
@@ -17,7 +17,7 @@ immediately so that the transmission can be aborted if the `Response` status
 indicates that the server does not wish to receive the message body.
 [RFC7230 6.5](https://tools.ietf.org/html/rfc7230#section-6.5).
 """
-function streamlayer(stream::Stream; iofunction=nothing, decompress::Bool=true, kw...)::Response
+function streamlayer(stream::Stream; iofunction=nothing, decompress::Union{Nothing, Bool}=nothing, kw...)::Response
     response = stream.message
     req = response.request
     io = stream.stream
@@ -103,8 +103,8 @@ writechunk(stream, body::IO) = writebodystream(stream, body)
 writechunk(stream, body::Union{Dict, NamedTuple}) = writebodystream(stream, body)
 writechunk(stream, body) = write(stream, body)
 
-function readbody(stream::Stream, res::Response, decompress::Bool)
-    if decompress && header(res, "Content-Encoding") == "gzip"
+function readbody(stream::Stream, res::Response, decompress::Union{Nothing, Bool})
+    if decompress === true || (decompress === nothing && header(res, "Content-Encoding") == "gzip")
         # Plug in a buffer stream in between so that we can (i) read the http stream in
         # chunks instead of byte-by-byte and (ii) make sure to stop reading the http stream
         # at eof.


### PR DESCRIPTION
I've accumulated some of these while updating packages around the
ecosystem. They include:
  * Fix for https://github.com/JuliaWeb/HTTP.jl/issues/895
  * Allow forcing decompression by passing `decompress=true`,
    this can be handy when you want to decompress, but you don't
    get the `Content-Encoding` header back
  * In our `@client` macro, allowing `open` form request as well