### PR TITLE
Cleanup all timeout code and places where we might timeout

### DIFF
--- a/src/clientlayers/ConnectionRequest.jl
+++ b/src/clientlayers/ConnectionRequest.jl
@@ -53,7 +53,7 @@ Close the connection if the request throws an exception.
 Otherwise leave it open so that it can be reused.
 """
 function connectionlayer(handler)
-    return function(req; proxy=getproxy(req.url.scheme, req.url.host), socket_type::Type=TCPSocket, kw...)
+    return function(req; proxy=getproxy(req.url.scheme, req.url.host), socket_type::Type=TCPSocket, readtimeout::Int=0, kw...)
         if proxy !== nothing
             target_url = req.url
             url = URI(proxy)
@@ -73,7 +73,7 @@ function connectionlayer(handler)
         IOType = sockettype(url, socket_type)
         local io
         try
-            io = newconnection(IOType, url.host, url.port; kw...)
+            io = newconnection(IOType, url.host, url.port; readtimeout=readtimeout, kw...)
         catch e
             throw(ConnectError(string(url), e))
         end
@@ -88,19 +88,25 @@ function connectionlayer(handler)
                 elseif target_url.scheme in ("ws", ) && target_url.port == ""
                     target_url = URI(target_url, port=80) # if there is no port info, connect_tunnel will fail
                 end
-                r = connect_tunnel(io, target_url, req)
+                r = if readtimeout > 0
+                    try_with_timeout(() -> shouldtimeout(io, readtimeout), readtimeout) do
+                        connect_tunnel(io, target_url, req)
+                    end
+                else
+                    connect_tunnel(io, target_url, req)
+                end
                 if r.status != 200
                     close(io)
                     return r
                 end
                 if target_url.scheme in ("https", "wss")
-                    io = ConnectionPool.sslupgrade(io, target_url.host; kw...)
+                    io = ConnectionPool.sslupgrade(io, target_url.host; readtimeout=readtimeout, kw...)
                 end
                 req.headers = filter(x->x.first != "Proxy-Authorization", req.headers)
             end
 
             stream = Stream(req.response, io)
-            return handler(stream; kw...)
+            return handler(stream; readtimeout=readtimeout, kw...)
         catch e
             @debugv 1 "❗️  ConnectionLayer $e. Closing: $io"
             shouldreuse = false
@@ -108,10 +114,10 @@ function connectionlayer(handler)
             e isa HTTPError || throw(RequestError(req, e))
             rethrow(e)
         finally
+            releaseconnection(io, shouldreuse)
             if !shouldreuse
                 @try Base.IOError close(io)
             end
-            releaseconnection(io, shouldreuse)
         end
     end
 end
@@ -126,8 +132,11 @@ function connect_tunnel(io, target_url, req)
         headers["Proxy-Authorization"] = auth
     end
     request = Request("CONNECT", target, headers)
+    # @debugv 2 "connect_tunnel: writing headers"
     writeheaders(io, request)
+    # @debugv 2 "connect_tunnel: reading headers"
     readheaders(io, request.response)
+    # @debugv 2 "connect_tunnel: done reading headers"
     return request.response
 end
 

--- a/src/clientlayers/ConnectionRequest.jl
+++ b/src/clientlayers/ConnectionRequest.jl
@@ -89,7 +89,7 @@ function connectionlayer(handler)
                     target_url = URI(target_url, port=80) # if there is no port info, connect_tunnel will fail
                 end
                 r = if readtimeout > 0
-                    try_with_timeout(() -> shouldtimeout(io, readtimeout), readtimeout) do
+                    try_with_timeout(() -> shouldtimeout(io, readtimeout, () -> close(io)), readtimeout) do
                         connect_tunnel(io, target_url, req)
                     end
                 else

--- a/src/clientlayers/TimeoutRequest.jl
+++ b/src/clientlayers/TimeoutRequest.jl
@@ -17,28 +17,8 @@ function timeoutlayer(handler)
             return handler(stream; kw...)
         end
         io = stream.stream
-        wait_for_timeout = Ref{Bool}(true)
-        timedout = Ref{Bool}(false)
-
-        @async while wait_for_timeout[]
-            if isreadable(io) && inactiveseconds(io) > readtimeout
-                timedout[] = true
-                close(io)
-                @debugv 1 "💥  Read inactive > $(readtimeout)s: $io"
-                break
-            end
-            sleep(readtimeout / 10)
-        end
-
-        try
-            return handler(stream; kw...)
-        catch e
-            if timedout[]
-                throw(TimeoutError(readtimeout))
-            end
-            rethrow(e)
-        finally
-            wait_for_timeout[] = false
+        return try_with_timeout(() -> shouldtimeout(io, readtimeout), readtimeout) do
+            handler(stream; kw...)
         end
     end
 end

--- a/src/clientlayers/TimeoutRequest.jl
+++ b/src/clientlayers/TimeoutRequest.jl
@@ -17,7 +17,7 @@ function timeoutlayer(handler)
             return handler(stream; kw...)
         end
         io = stream.stream
-        return try_with_timeout(() -> shouldtimeout(io, readtimeout), readtimeout) do
+        return try_with_timeout(() -> shouldtimeout(io, readtimeout), readtimeout, () -> close(io)) do
             handler(stream; kw...)
         end
     end

--- a/src/connectionpools.jl
+++ b/src/connectionpools.jl
@@ -103,6 +103,7 @@ function acquire(f, pod::Pod)
             # println("$(taskid()): checking idle_timeout connections for reuse")
             conn = popfirst!(pod.conns)
             if isvalid(pod, conn)
+                # println("$(taskid()): found a valid connection to reuse")
                 return trackconnection!(pod, conn)
             else
                 # nothing, let the non-valid connection fall into GC oblivion


### PR DESCRIPTION
Fixes #909. Great issue that stretches our current system and exposes
a bunch of places where we weren't accounting for timeouts. The core
issues here are when we have a proxy involved, we had a couple more
places where we were connecting/writing/reading, but weren't applying
a user-provided `connect_timeout` or `readtimeout`. Also for our
ssl upgrade path. In the OP's example, we're hitting thousands of mostly
non-functional proxies, so it's basically a huge stress test on all the
error paths of our request code. This PR proposes:
  * a new `try_with_timeout` function to provide a consistent way to run
    code while waiting for a timeout
  * use the new function in a number of places where we might be stuck waiting

I'm able to get the original script OP provided to finish in ~150 seconds, and
I tried out a multithreaded version that finished in about ~17 seconds w/ 8 threads.