### PR TITLE
Revert "When monitoring idle connections, only call eof on tcp socket"

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -261,8 +261,8 @@ TODO: or if response data arrives when no request was sent (isreadable == false)
 """
 function monitor_idle_connection(c::Connection)
     try
-        if eof(tcpsocket(c.io))                                  ;@debugv 3 "💀  Closed:     $c"
-            isopen(c.io) && close(c.io)
+        if eof(c.io)                                  ;@debugv 3 "💀  Closed:     $c"
+            close(c.io)
         end
     catch ex
         @try Base.IOError close(c.io)


### PR DESCRIPTION
Reverts JuliaWeb/HTTP.jl#912

The problem here is that when we go to reuse connections later, the ssl layer hasn't had time (or been told by `monitor_idle_connections`) to process encrypted data and potential close notify records. This can be bad if you, for example, do a bunch of simultaneous requests which build up a bunch of MbedTLS.SSLContext connections in the connection pool, then go to try and do a request later and all the connections are actually closed, even though they haven't been properly closed at the ssl layer.