### PR TITLE
debuglayer(): fix DEBUG_LEVEL handling

### DIFF
--- a/src/clientlayers/DebugRequest.jl
+++ b/src/clientlayers/DebugRequest.jl
@@ -8,9 +8,9 @@ export debuglayer
 """
     debuglayer(handler) -> handler
 
-If `verbose` keyword arg passed to the handler is > 0,
-or the HTTP.jl global `DEBUG_LEVEL[]` is > 0, then enable
+If the positive `verbose` keyword arg passed to the `handler`, then enable
 debug logging with verbosity `verbose` for the lifetime of the request.
+If no `verbose` is specified, it defaults to the *HTTP.jl* global `DEBUG_LEVEL[]`.
 """
 function debuglayer(handler)
     return function(request; verbose=DEBUG_LEVEL[], kw...)

--- a/src/clientlayers/DebugRequest.jl
+++ b/src/clientlayers/DebugRequest.jl
@@ -8,15 +8,16 @@ export debuglayer
 """
     debuglayer(handler) -> handler
 
-If `verbose` keyword arg is > 0, or the HTTP.jl global `DEBUG_LEVEL[]` is > 0,
-then enabled debug logging with verbosity `verbose` for the lifetime of the request.
+If `verbose` keyword arg passed to the handler is > 0,
+or the HTTP.jl global `DEBUG_LEVEL[]` is > 0, then enable
+debug logging with verbosity `verbose` for the lifetime of the request.
 """
 function debuglayer(handler)
-    return function(request; verbose=0, kw...)
+    return function(request; verbose=DEBUG_LEVEL[], kw...)
         # if debugging, enable by wrapping request in custom logger logic
-        if verbose > 0 || DEBUG_LEVEL[] > 0
+        if verbose > 0
             LoggingExtras.withlevel(Logging.Debug; verbosity=verbose) do
-                handler(request; verbose=verbose, kw...)
+                handler(request; verbose, kw...)
             end
         else
             return handler(request; verbose, kw...)


### PR DESCRIPTION
If *verbose* kwarg was not specified, `DEBUG_LEVEL[]` should have been used instead, but it was not.