### PR TITLE
do not access `code` field if error is EOFError

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -384,7 +384,7 @@ function listenloop(f, listener, conns, tcpisvalid,
                 Base.release(sem)
             end
         catch e
-            if e isa IOError && e.code == Base.UV_ECONNABORTED
+            if e isa Base.IOError && e.code == Base.UV_ECONNABORTED
                 @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
             else
                 @errorv 2 "Server on $(listener.hostname):$(listener.hostport) errored" exception=(e, catch_backtrace())

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -384,7 +384,7 @@ function listenloop(f, listener, conns, tcpisvalid,
                 Base.release(sem)
             end
         catch e
-            if !isa(e, EOFError) && (e.code == Base.UV_ECONNABORTED)
+            if e isa IOError && e.code == Base.UV_ECONNABORTED
                 @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
             else
                 @errorv 2 "Server on $(listener.hostname):$(listener.hostport) errored" exception=(e, catch_backtrace())

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -384,7 +384,7 @@ function listenloop(f, listener, conns, tcpisvalid,
                 Base.release(sem)
             end
         catch e
-            if e.code == Base.UV_ECONNABORTED
+            if !isa(e, EOFError) && (e.code == Base.UV_ECONNABORTED)
                 @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
             else
                 @errorv 2 "Server on $(listener.hostname):$(listener.hostport) errored" exception=(e, catch_backtrace())

--- a/test/server.jl
+++ b/test/server.jl
@@ -183,7 +183,7 @@ const echostreamhandler = HTTP.streamhandler(echohandler)
     end
 
     # listen does not break with EOFError during ssl handshake
-    @test_warn "Server on 127.0.0.1:8081 errored" begin
+    let host = Sockets.localhost
         sslconfig = MbedTLS.SSLConfig(joinpath(dir, "resources/cert.pem"), joinpath(dir, "resources/key.pem"))
         server = HTTP.listen!(; listenany=true, sslconfig=sslconfig, verbose=true) do http::HTTP.Stream
             HTTP.setstatus(http, 200)
@@ -193,13 +193,12 @@ const echostreamhandler = HTTP.streamhandler(echohandler)
     
         port = HTTP.port(server)
     
-        sock = connect("127.0.0.1", port)
+        sock = connect(host, port)
         close(sock)
     
-        let host = Sockets.localhost
-            r = HTTP.get("https://$(host):$(port)/"; readtimeout=30, require_ssl_verification = false)
-            @test r.status == 200
-        end
+        r = HTTP.get("https://$(host):$(port)/"; readtimeout=30, require_ssl_verification = false)
+        @test r.status == 200
+
         close(server)
     end    
 end # @testset


### PR DESCRIPTION
Check for EOFError before attempting to access the `code` field of exceptions in the listen loop.
Fixes: #934