### PR TITLE
connectionlayer: sslupgrade(socket_type_tls) fixup (#941)

### DIFF
--- a/src/clientlayers/ConnectionRequest.jl
+++ b/src/clientlayers/ConnectionRequest.jl
@@ -102,7 +102,7 @@ function connectionlayer(handler)
                     return r
                 end
                 if target_url.scheme in ("https", "wss")
-                    io = ConnectionPool.sslupgrade(IOType, io, target_url.host; readtimeout=readtimeout, kw...)
+                    io = ConnectionPool.sslupgrade(socket_type_tls, io, target_url.host; readtimeout=readtimeout, kw...)
                 end
                 req.headers = filter(x->x.first != "Proxy-Authorization", req.headers)
             end


### PR DESCRIPTION
The sockettype for ConnectionPool.sslupgrade should depend on target_url  rather than url. These are not necessarily on the same scheme. I.e if  "https_proxy=http://..."