### PR TITLE
Reduce slightly allocations when reading/writing HTTP messages

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -72,6 +72,7 @@ mutable struct Connection <: IO
     timestamp::Float64
     readable::Bool
     writable::Bool
+    writebuffer::IOBuffer
     state::Any # populated & used by Servers code
 end
 
@@ -92,7 +93,7 @@ Connection(host::AbstractString, port::AbstractString,
     Connection(host, port, idle_timeout,
                 require_ssl_verification,
                 safe_getpeername(io)..., localport(io),
-                io, client, PipeBuffer(), time(), false, false, nothing)
+                io, client, PipeBuffer(), time(), false, false, IOBuffer(), nothing)
 
 Connection(io; require_ssl_verification::Bool=true) =
     Connection("", "", 0, require_ssl_verification, io, false)

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -185,7 +185,7 @@ Request() = Request("", "")
 
 function Request(
     method::String, target, headers=[], body=nobody;
-    version=HTTPVersion(1,1), url::URI=URI(), responsebody=nothing, parent=nothing, context=Context()
+    version=HTTPVersion(1, 1), url::URI=URI(), responsebody=nothing, parent=nothing, context=Context()
 )
     b = isbytes(body) ? bytes(body) : body
     r = Request(method, target == "" ? "/" : target, version,

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -101,7 +101,7 @@ mutable struct Response <: Message
     request::Union{Message, Nothing} # Union{Request, Nothing}
 end
 
-function Response(status::Integer, headers, body; version=HTTPVersion(1,1), request=nothing)
+function Response(status::Integer, headers, body; version=HTTPVersion(1, 1), request=nothing)
     b = isbytes(body) ? bytes(body) : something(body, nobody)
     @assert (request isa Request || request === nothing)
     return Response(version, status, mkheaders(headers), b, request)

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -191,7 +191,7 @@ function parse_request_line!(bytes::AbstractString, request)::SubString{String}
     end
     request.method = group(1, re, bytes)
     request.target = group(2, re, bytes)
-    request.version = VersionNumber(group(3, re, bytes))
+    request.version = HTTPVersion(group(3, re, bytes))
     return nextbytes(re, bytes)
 end
 
@@ -205,7 +205,7 @@ function parse_status_line!(bytes::AbstractString, response)::SubString{String}
     if !exec(re, bytes)
         throw(ParseError(:INVALID_STATUS_LINE, bytes))
     end
-    response.version = VersionNumber(group(1, re, bytes))
+    response.version = HTTPVersion(group(1, re, bytes))
     response.status = parse(Int, group(2, re, bytes))
     return nextbytes(re, bytes)
 end

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -494,7 +494,7 @@ function check_readtimeout(c, readtimeout, wait_for_timeout)
         if inactiveseconds(c) > readtimeout
             @warnv 2 "Connection Timeout: $c"
             try
-                writeheaders(c.io, Response(408, ["Connection" => "close"]))
+                writeheaders(c, Response(408, ["Connection" => "close"]))
             finally
                 closeconnection(c)
             end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -76,9 +76,7 @@ function IOExtras.startwrite(http::Stream)
     else
         http.writechunked = ischunked(m)
     end
-    buf = IOBuffer()
-    writeheaders(buf, m)
-    n = write(http.stream, take!(buf))
+    n = writeheaders(http.stream, m)
     # nwritten starts at -1 so that we can tell if we've written anything yet
     http.nwritten = 0 # should not include headers
     return n

--- a/src/Strings.jl
+++ b/src/Strings.jl
@@ -83,16 +83,6 @@ function Base.tryparse(::Type{HTTPVersion}, v::AbstractString)
     return HTTPVersion(major, minor)
 end
 
-# const RE_HTTP_VERSION = r"(\d+)(?:\.(\d+))?"
-# function Base.tryparse(::Type{HTTPVersion}, v::AbstractString)
-#     m = match(RE_HTTP_VERSION, String(v)::String)
-#     m === nothing && return nothing
-#     major, minor = m.captures
-#     major = parse(UInt8, major)
-#     minor = minor !== nothing ? parse(UInt8, minor) : 0x00
-#     return HTTPVersion(major, minor)
-# end
-
 """
     escapehtml(i::String)
 

--- a/src/Strings.jl
+++ b/src/Strings.jl
@@ -1,8 +1,97 @@
 module Strings
 
-export escapehtml, tocameldash, iso8859_1_to_utf8, ascii_lc_isequal
+export HTTPVersion, escapehtml, tocameldash, iso8859_1_to_utf8, ascii_lc_isequal
 
 using ..IOExtras
+
+# A `Base.VersionNumber` is a SemVer spec, whereas a HTTP versions is just 2 digits,
+# This allows us to use a smaller type and more importantly write a simple parse method
+# that avoid allocations.
+"""
+    HTTPVersion(major, minor)
+
+The HTTP version number consists of two digits separated by a
+"." (period or decimal point). The first digit (`major` version)
+indicates the HTTP messaging syntax, whereas the second digit (`minor`
+version) indicates the highest minor version within that major
+version to which the sender is conformant and able to understand for
+future communication.
+
+See [RFC7230 2.6](https://tools.ietf.org/html/rfc7230#section-2.6)
+"""
+struct HTTPVersion
+    major::UInt8
+    minor::UInt8
+end
+
+HTTPVersion(major::Integer) = HTTPVersion(major, 0x00)
+HTTPVersion(v::AbstractString) = parse(HTTPVersion, v)
+HTTPVersion(v::VersionNumber) = convert(HTTPVersion, v)
+# Lossy conversion. We ignore patch/prerelease/build parts even if non-zero/non-empty,
+# because we don't want to add overhead for a case that should never be relevant.
+Base.convert(::Type{HTTPVersion}, v::VersionNumber) = HTTPVersion(v.major, v.minor)
+Base.VersionNumber(v::HTTPVersion) = VersionNumber(v.major, v.minor)
+
+Base.show(io::IO, v::HTTPVersion) = print(io, "HTTPVersion(\"", string(v.major), ".", string(v.minor), "\")")
+
+Base.:(==)(va::VersionNumber, vb::HTTPVersion) = va == VersionNumber(vb)
+Base.:(==)(va::HTTPVersion, vb::VersionNumber) = VersionNumber(va) == vb
+
+Base.isless(va::VersionNumber, vb::HTTPVersion) = isless(va, VersionNumber(vb))
+Base.isless(va::HTTPVersion, vb::VersionNumber) = isless(VersionNumber(va), vb)
+function Base.isless(va::HTTPVersion, vb::HTTPVersion)
+    va.major < vb.major && return true
+    va.major > vb.major && return false
+    va.minor < vb.minor && return true
+    return false
+end
+
+function Base.parse(::Type{HTTPVersion}, v::AbstractString)
+    ver = tryparse(HTTPVersion, v)
+    ver === nothing && throw(ArgumentError("invalid HTTP version string: $(repr(v))"))
+    return ver
+end
+
+# We only support single-digits for major and minor versions
+# - we can parse 0.9 but not 0.10
+# - we can parse 9.0 but not 10.0
+function Base.tryparse(::Type{HTTPVersion}, v::AbstractString)
+    isempty(v) && return nothing
+    len = ncodeunits(v)
+
+    i = firstindex(v)
+    d1 = v[i]
+    if isdigit(d1)
+        major = parse(UInt8, d1)
+    else
+        return nothing
+    end
+
+    i = nextind(v, i)
+    i > len && return HTTPVersion(major)
+    dot = v[i]
+    dot == '.' || return nothing
+
+    i = nextind(v, i)
+    i > len && return HTTPVersion(major)
+    d2 = v[i]
+    if isdigit(d2)
+        minor = parse(UInt8, d2)
+    else
+        return nothing
+    end
+    return HTTPVersion(major, minor)
+end
+
+# const RE_HTTP_VERSION = r"(\d+)(?:\.(\d+))?"
+# function Base.tryparse(::Type{HTTPVersion}, v::AbstractString)
+#     m = match(RE_HTTP_VERSION, String(v)::String)
+#     m === nothing && return nothing
+#     major, minor = m.captures
+#     major = parse(UInt8, major)
+#     minor = minor !== nothing ? parse(UInt8, minor) : 0x00
+#     return HTTPVersion(major, minor)
+# end
 
 """
     escapehtml(i::String)

--- a/src/clientlayers/MessageRequest.jl
+++ b/src/clientlayers/MessageRequest.jl
@@ -14,7 +14,7 @@ Construct a [`Request`](@ref) object from method, url, headers, and body.
 Hard-coded as the first layer in the request pipeline.
 """
 function messagelayer(handler)
-    return function(method::String, url::URI, headers::Headers, body; response_stream=nothing, http_version=HTTPVersion(1,1), kw...)
+    return function(method::String, url::URI, headers::Headers, body; response_stream=nothing, http_version=HTTPVersion(1, 1), kw...)
         req = Request(method, resource(url), headers, body; url=url, version=http_version, responsebody=response_stream)
         local resp
         try

--- a/src/clientlayers/MessageRequest.jl
+++ b/src/clientlayers/MessageRequest.jl
@@ -2,6 +2,8 @@ module MessageRequest
 
 using URIs
 using ..IOExtras, ..Messages, ..Parsers, ..Exceptions
+using ..Messages, ..Parsers
+using ..Strings: HTTPVersion
 
 export messagelayer
 
@@ -12,7 +14,7 @@ Construct a [`Request`](@ref) object from method, url, headers, and body.
 Hard-coded as the first layer in the request pipeline.
 """
 function messagelayer(handler)
-    return function(method::String, url::URI, headers::Headers, body; response_stream=nothing, http_version=v"1.1", kw...)
+    return function(method::String, url::URI, headers::Headers, body; response_stream=nothing, http_version=HTTPVersion(1,1), kw...)
         req = Request(method, resource(url), headers, body; url=url, version=http_version, responsebody=response_stream)
         local resp
         try

--- a/test/httpversion.jl
+++ b/test/httpversion.jl
@@ -11,6 +11,11 @@
 @test VersionNumber(HTTPVersion(1)) == v"1"
 @test VersionNumber(HTTPVersion(1, 1)) == v"1.1"
 
+# Important that we can parse a string into a `HTTPVersion` without allocations,
+# as we do this for every request/response. Similarly if we then want a `VersionNumber`.
+@test @allocated(HTTPVersion("1.1")) == 0
+@test @allocated(VersionNumber(HTTPVersion("1.1"))) == 0
+
 req = HTTP.Request("GET", "http://httpbin.org/anything")
 res = HTTP.Response(200)
 for r in (req, res)

--- a/test/httpversion.jl
+++ b/test/httpversion.jl
@@ -1,3 +1,6 @@
+@testset "HTTPVersion" begin
+
+# Constructors
 @test HTTPVersion(1) == HTTPVersion(1, 0)
 @test HTTPVersion(1) == HTTPVersion("1")
 @test HTTPVersion(1) == HTTPVersion("1.0")
@@ -16,6 +19,7 @@
 @test @allocated(HTTPVersion("1.1")) == 0
 @test @allocated(VersionNumber(HTTPVersion("1.1"))) == 0
 
+# Test comparisons with `VersionNumber`s
 req = HTTP.Request("GET", "http://httpbin.org/anything")
 res = HTTP.Response(200)
 for r in (req, res)
@@ -23,3 +27,5 @@ for r in (req, res)
     @test r.version <= v"1.1"
     @test r.version < v"1.2"
 end
+
+end # testset

--- a/test/httpversion.jl
+++ b/test/httpversion.jl
@@ -1,0 +1,20 @@
+@test HTTPVersion(1) == HTTPVersion(1, 0)
+@test HTTPVersion(1) == HTTPVersion("1")
+@test HTTPVersion(1) == HTTPVersion("1.0")
+@test HTTPVersion(1) == HTTPVersion(v"1")
+@test HTTPVersion(1) == HTTPVersion(v"1.0")
+
+@test HTTPVersion(1, 1) == HTTPVersion("1.1")
+@test HTTPVersion(1, 1) == HTTPVersion(v"1.1")
+@test HTTPVersion(1, 1) == HTTPVersion(v"1.1.0")
+
+@test VersionNumber(HTTPVersion(1)) == v"1"
+@test VersionNumber(HTTPVersion(1, 1)) == v"1.1"
+
+req = HTTP.Request("GET", "http://httpbin.org/anything")
+res = HTTP.Response(200)
+for r in (req, res)
+    @test r.version == v"1.1"
+    @test r.version <= v"1.1"
+    @test r.version < v"1.2"
+end

--- a/test/loopback.jl
+++ b/test/loopback.jl
@@ -262,8 +262,9 @@ end
         @test_throws HTTP.StatusError begin
             r = lbopen("abort", []) do http
                 @sync begin
+                    event = Base.Event()
                     @async try
-                        sleep(0.1)
+                        wait(event)
                         write(http, "Hello World!")
                         closewrite(http)
                         body_sent = true
@@ -278,6 +279,7 @@ end
                     startread(http)
                     body = read(http)
                     closeread(http)
+                    notify(event)
                 end
             end
         end

--- a/test/loopback.jl
+++ b/test/loopback.jl
@@ -43,7 +43,7 @@ Base.readavailable(fio::FunctionIO) = (call(fio); readavailable(fio.buf))
 Base.readavailable(lb::Loopback) = readavailable(lb.io)
 Base.unsafe_read(lb::Loopback, p::Ptr, n::Integer) = unsafe_read(lb.io, p, n)
 
-HTTP.IOExtras.tcpsocket(::Loopback) = Sockets.connect("$httpbin", 80)
+HTTP.IOExtras.tcpsocket(::Loopback) = TCPSocket()
 
 lbreq(req, headers, body; method="GET", kw...) =
       HTTP.request(method, "http://test/$req", headers, body; config..., kw...)

--- a/test/messages.jl
+++ b/test/messages.jl
@@ -99,10 +99,7 @@ using JSON
         @test header(req, "Null", nothing) === nothing
     end
 
-    @testset "HTTP Version" begin
-        @test Messages.httpversion(req) == "HTTP/1.1"
-        @test Messages.httpversion(res) == "HTTP/1.1"
-
+    @testset "HTTP message parsing" begin
         raw = String(req)
         req = parse(Request,raw)
         @test String(req) == raw

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ include(joinpath(dir, "resources/TestRequest.jl"))
             "async.jl",
             "mwe.jl",
             "try_with_timeout.jl",
+            "httpversion.jl",
             ]
         file = joinpath(dir, f)
         println("Running $file tests...")


### PR DESCRIPTION
1. write direct to io rather than first creating strings
    - we need to be careful to `string` any numbers before doing this, but doing this selectively still reduces allocations
2. don't create a `VersionNumber` every time we parse a message (in `parse_status_line!`/`parse_request_line!`), as the `VersionNumber` constructor relies on regex matching which allocates, instead we can define our own much simpler type with allocation-free parsing

Together this takes a simple GET request from 170 -> 155 allocations