### PR TITLE
Allow retrying request regardless of idempotent if we failed to write…

### DIFF
--- a/src/Exceptions.jl
+++ b/src/Exceptions.jl
@@ -116,15 +116,4 @@ struct RequestError <: HTTPError
     error::Any
 end
 
-"""
-    HTTP.RequestWritingError
-
-Raised when an error occurs while physically sending a request to the remote server.
-To see the underlying error, see the `error` field.
-Used 
-"""
-struct RequestWritingError <: HTTPError
-    error::Any # underlying error
-end
-
 end # module Exceptions

--- a/src/Exceptions.jl
+++ b/src/Exceptions.jl
@@ -116,4 +116,15 @@ struct RequestError <: HTTPError
     error::Any
 end
 
+"""
+    HTTP.RequestWritingError
+
+Raised when an error occurs while physically sending a request to the remote server.
+To see the underlying error, see the `error` field.
+Used 
+"""
+struct RequestWritingError <: HTTPError
+    error::Any # underlying error
+end
+
 end # module Exceptions

--- a/src/access_log.jl
+++ b/src/access_log.jl
@@ -100,7 +100,7 @@ function symbol_mapping(s::Symbol)
     elseif s === :status
         :(http.message.response.status)
     elseif s === :body_bytes_sent
-        return :(http.nwritten)
+        return :(max(0, http.nwritten))
     else
         error("unknown variable in logfmt: $s")
     end

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -22,6 +22,7 @@ IOExtras.nbytes(x::Form) = length(x)
 
 function Base.mark(f::Form)
     foreach(mark, f.data)
+    f.mark = f.index
     return
 end
 
@@ -122,8 +123,9 @@ function Form(d; boundary=string(rand(UInt128), base=16))
             write(io, "\r\n\r\n")
             write(io, v)
         end
-        i == len && write(io, "\r\n--" * boundary * "--" * "\r\n")
     end
+    # write final boundary
+    write(io, "\r\n--" * boundary * "--" * "\r\n")
     seekstart(io)
     push!(data, io)
     return Form(data, 1, -1, boundary)

--- a/test/async.jl
+++ b/test/async.jl
@@ -1,30 +1,26 @@
 module test_async
 
+import ..httpbin
 using Test, HTTP, JSON
 
 @time @testset "ASync" begin
     configs = [
-        Pair{Symbol, Any}[:verbose => 0, :status_exception => false],
-        Pair{Symbol, Any}[:verbose => 0, :status_exception => false, :reuse_limit => 200],
-        Pair{Symbol, Any}[:verbose => 0, :status_exception => false, :reuse_limit => 50]
+        Pair{Symbol, Any}[:verbose => 0],
+        Pair{Symbol, Any}[:verbose => 0, :reuse_limit => 200],
+        Pair{Symbol, Any}[:verbose => 0, :reuse_limit => 50]
     ]
-    protocols = ["http", "https"]
 
     dump_async_exception(e, st) = @error "async exception: " exception=(e, st)
 
-    @testset "HTTP.request - Headers - $config - $protocol" for config in configs, protocol in protocols
+    @testset "HTTP.request - Headers - $config - https" for config in configs
         result = []
 
         @sync begin
             for i = 1:100
                 @async try
-                    response = HTTP.request("GET", "$protocol://httpbin.org/headers", ["i" => i]; config...)
-                    if response.status != 200
-                        @error "non-200 response" response=response
-                    else
-                        response = JSON.parse(String(response.body))
-                        push!(result, response["headers"]["I"] => string(i))
-                    end
+                    response = HTTP.request("GET", "https://$httpbin/headers", ["i" => i]; config...)
+                    response = JSON.parse(String(response.body))
+                    push!(result, response["headers"]["I"] => [string(i)])
                 catch e
                     dump_async_exception(e, stacktrace(catch_backtrace()))
                     rethrow(e)
@@ -39,20 +35,16 @@ using Test, HTTP, JSON
         HTTP.ConnectionPool.closeall()
     end
 
-    @testset "HTTP.request - Body - $config - $protocol" for config in configs, protocol in protocols
+    @testset "HTTP.request - Body - $config - https" for config in configs
         result = []
 
         @sync begin
             for i=1:100
                 @async try
-                    response = HTTP.request("GET", "$protocol://httpbin.org/stream/$i"; config...)
-                    if response.status != 200
-                        @error "non-200 response" response=response
-                    else
-                        response = String(response.body)
-                        response = split(strip(response), "\n")
-                        push!(result, length(response) => i)
-                    end
+                    response = HTTP.request("GET", "https://$httpbin/stream/$i"; config...)
+                    response = String(response.body)
+                    response = split(strip(response), "\n")
+                    push!(result, length(response) => i)
                 catch e
                     dump_async_exception(e, stacktrace(catch_backtrace()))
                     rethrow(e)
@@ -60,32 +52,28 @@ using Test, HTTP, JSON
             end
         end
 
-        for (a,b) in result
+        for (a, b) in result
             @test a == b
         end
 
         HTTP.ConnectionPool.closeall()
     end
 
-    @testset "HTTP.open - $config - $protocol" for config in configs, protocol in protocols
+    @testset "HTTP.open - $config - https" for config in configs
         result = []
 
         @sync begin
             for i=1:100
                 @async try
                     open_response = nothing
-                    url = "$protocol://httpbin.org/stream/$i"
+                    url = "https://$httpbin/stream/$i"
 
                     response = HTTP.open("GET", url; config...) do http
                         open_response = String(read(http))
                     end
 
-                    if response.status != 200
-                        @error "non-200 response" response=response
-                    else
-                        open_response = split(strip(open_response), "\n")
-                        push!(result, length(open_response) => i)
-                    end
+                    open_response = split(strip(open_response), "\n")
+                    push!(result, length(open_response) => i)
                 catch e
                     dump_async_exception(e, stacktrace(catch_backtrace()))
                     rethrow(e)
@@ -93,14 +81,14 @@ using Test, HTTP, JSON
             end
         end
 
-        for (a,b) in result
+        for (a, b) in result
             @test a == b
         end
 
         HTTP.ConnectionPool.closeall()
     end
 
-    @testset "HTTP.request - Response Stream - $config - $protocol" for config in configs, protocol in protocols
+    @testset "HTTP.request - Response Stream - $config - https" for config in configs
         result = []
 
         @sync begin
@@ -109,23 +97,19 @@ using Test, HTTP, JSON
                     stream_response = nothing
 
                     # Note: url for $i will give back $i responses split on "\n"
-                    url = "$protocol://httpbin.org/stream/$i"
+                    url = "https://$httpbin/stream/$i"
 
                     try
                         stream = Base.BufferStream()
                         response = HTTP.request("GET", url; response_stream=stream, config...)
                         close(stream)
 
-                        if response.status != 200
-                            @error "non-200 response" response=response
-                        else
-                            stream_response = String(read(stream))
-                            stream_response = split(strip(stream_response), "\n")
-                            if length(stream_response) != i
-                                @show join(stream_response, "\n")
-                            end
-                            push!(result, length(stream_response) => i)
+                        stream_response = String(read(stream))
+                        stream_response = split(strip(stream_response), "\n")
+                        if length(stream_response) != i
+                            @show join(stream_response, "\n")
                         end
+                        push!(result, length(stream_response) => i)
                     catch e
                         if !HTTP.RetryRequest.isrecoverable(e)
                             rethrow(e)
@@ -138,7 +122,7 @@ using Test, HTTP, JSON
             end
         end
 
-        for (a,b) in result
+        for (a, b) in result
             @test a == b
         end
 

--- a/test/download.jl
+++ b/test/download.jl
@@ -1,5 +1,7 @@
 using HTTP
 
+import ..httpbin
+
 @testset "HTTP.download" begin
     @testset "Update Period" begin
         @test_logs (:info, "Downloading") HTTP.download(
@@ -69,7 +71,7 @@ using HTTP
 
     @testset "Content-Encoding" begin
         # Add gz extension if we are determining the filename
-        gzip_content_encoding_fn = HTTP.download("https://httpbin.org/gzip")
+        gzip_content_encoding_fn = HTTP.download("https://$httpbin/gzip")
         @test isfile(gzip_content_encoding_fn)
         @test last(splitext(gzip_content_encoding_fn)) == ".gz"
 

--- a/test/loopback.jl
+++ b/test/loopback.jl
@@ -6,6 +6,7 @@ using HTTP.IOExtras
 using HTTP.Parsers
 using HTTP.Messages
 using HTTP.Sockets
+import ..httpbin
 
 mutable struct FunctionIO <: IO
     f::Function
@@ -42,7 +43,7 @@ Base.readavailable(fio::FunctionIO) = (call(fio); readavailable(fio.buf))
 Base.readavailable(lb::Loopback) = readavailable(lb.io)
 Base.unsafe_read(lb::Loopback, p::Ptr, n::Integer) = unsafe_read(lb.io, p, n)
 
-HTTP.IOExtras.tcpsocket(::Loopback) = Sockets.connect("httpbin.org", 80)
+HTTP.IOExtras.tcpsocket(::Loopback) = Sockets.connect("$httpbin", 80)
 
 lbreq(req, headers, body; method="GET", kw...) =
       HTTP.request(method, "http://test/$req", headers, body; config..., kw...)

--- a/test/multipart.jl
+++ b/test/multipart.jl
@@ -1,15 +1,19 @@
+function test_multipart(r, body)
+    @test isok(r)
+    json = JSON.parse(IOBuffer(HTTP.payload(r)))
+    @test startswith(json["headers"]["Content-Type"][1], "multipart/form-data; boundary=")
+    reset(body); mark(body)
+end
+
 @testset "HTTP.Form for multipart/form-data" begin
     headers = Dict("User-Agent" => "HTTP.jl")
     body = HTTP.Form(Dict())
-    uri = "https://httpbin.org/post"
-    uri_put = "https://httpbin.org/put"
+    mark(body)
     @testset "Setting of Content-Type" begin
-        for r in (HTTP.request("POST", uri, headers, body), HTTP.post(uri, headers, body),
-                  HTTP.request("PUT", uri_put, headers, body), HTTP.put(uri_put, headers, body))
-            @test r.status == 200
-            json = JSON.parse(IOBuffer(HTTP.payload(r)))
-            @test startswith(json["headers"]["Content-Type"], "multipart/form-data; boundary=")
-        end
+        test_multipart(HTTP.request("POST", "https://$httpbin/post", headers, body), body)
+        test_multipart(HTTP.post("https://$httpbin/post", headers, body), body)
+        test_multipart(HTTP.request("PUT", "https://$httpbin/put", headers, body), body)
+        test_multipart(HTTP.put("https://$httpbin/put", headers, body), body)
     end
     @testset "HTTP.Multipart ensure show() works correctly" begin
         # testing that there is no error in printing when nothing is set for filename

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,10 @@ using Test, HTTP, JSON
 
 const dir = joinpath(dirname(pathof(HTTP)), "..", "test")
 
+const httpbin = get(ENV, "JULIA_TEST_HTTPBINGO_SERVER", "httpbingo.julialang.org")
+
+isok(r) = r.status == 200
+
 include(joinpath(dir, "resources/TestRequest.jl"))
 @testset "HTTP" begin
     for f in [

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,5 +1,6 @@
 module test_server
 
+import ..httpbin
 using HTTP, HTTP.IOExtras, Sockets, Test, MbedTLS
 
 function testget(url, m=1)
@@ -147,10 +148,10 @@ const echostreamhandler = HTTP.streamhandler(echohandler)
     port = HTTP.port(t1)
 
     # test that an Authorization header is **not** forwarded to a domain different than initial request
-    @test !HTTP.hasheader(HTTP.get("http://httpbin.org/redirect-to?url=http://127.0.0.1:$port", ["Authorization"=>"auth"]), "Authorization")
+    @test !HTTP.hasheader(HTTP.get("https://$httpbin/redirect-to?url=http://127.0.0.1:$port", ["Authorization"=>"auth"]), "Authorization")
 
     # test that an Authorization header **is** forwarded to redirect in same domain
-    @test HTTP.hasheader(HTTP.get("http://httpbin.org/redirect-to?url=https://httpbin.org/response-headers?Authorization=auth"), "Authorization")
+    @test HTTP.hasheader(HTTP.get("https://$httpbin/redirect-to?url=https://$httpbin/response-headers?Authorization=auth"), "Authorization")
     close(t1)
 
     # 318


### PR DESCRIPTION
… anything

There isn't one specific issue this addresses, but I've received reports from a few private sources around production issues people have run into with a `IOError: NET - Connection was reset by peer` error with a stacktrace coming from https://github.com/JuliaWeb/HTTP.jl/blob/37fec3578428f4033c5a031d9d418fb96edbffb9/src/Streams.jl#L81, which is the 1st place we try to write the request start line + headers on the wire.

After investigating the MbedTLS.jl side of things (this happens with https connections), from what I can tell, the core issue is a race condition between the remote server closing a connection we just used in a previous request and when we try to reuse that request in a subsequent, _non-idempotent_ request (i.e. POST). So the problem manifests with the following sequence of events:
  * We make a request, it completes successfully
  * We try to make a subsequent, non-idempotent request and reuse the previous request connection
  * When we initially retrieve the connection from the connection pool, it looks open/valid
  * In between the time we retrieve the conn from the pool and the time we _actually_ start writing our non-idempotent request, the remote closes the connection
  * Subsequently, our first write fails because the connection is closed
  * Our retry logic _doesn't_ attempt to retry because the request is idempotent

This theory is partly confirmed by reports that this issue can be "solved" by calling `HTTP.ConnectionPool.closeall()` before the non-idempotent request, which forces a brand-new connection to be made for the request.

This PR proposes the following solution:
  * When we create a `Stream`, we set the `nwritten` field to -1 to signal that we haven't written the start line or headers
  * `nwritten` is set to 0 once we've finished writing request headers
  * In `ConnectionRequest`, when we catch a downstream error, we set a `nothingwritten` values in the `Request` `context` dict to signal that nothing was written for this request yet
  * In the `retryable(::Request)` check, we now check if the request is idempotent, the user passed `retry_non_idempotent` _OR_ (new) if we failed to write anything in the first place