### PR TITLE
Allow silencing server closing log message as well

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -390,7 +390,7 @@ function listenloop(f, listener, conns, tcpisvalid,
             end
         catch e
             if e isa Base.IOError && e.code == Base.UV_ECONNABORTED
-                @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
+                verbose >= 0 && @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
             else
                 @errorv 2 "Server on $(listener.hostname):$(listener.hostport) errored" exception=(e, catch_backtrace())
                 # quick little sleep in case there's a temporary


### PR DESCRIPTION
#955 allowed passing `verbose=-1` to silence the initial server listening log, it seems appropriate that this setting should also silence the server closing log