### PR TITLE
Do not turn HEAD requests to GET by default through redirects

### DIFF
--- a/src/clientlayers/RedirectRequest.jl
+++ b/src/clientlayers/RedirectRequest.jl
@@ -101,6 +101,16 @@ function newmethod(request_method, response_status, redirect_method)
         return request_method
     elseif redirect_method !== nothing && String(redirect_method) in ("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
         return redirect_method
+    elseif request_method == "HEAD"
+        # Unless otherwise specified (e.g. with `redirect_method`), be conservative and keep the
+        # same method, see:
+        #
+        # * <https://httpwg.org/specs/rfc9110.html#status.301>
+        # * <https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#permanent_redirections>
+        #
+        # Turning a HEAD request through a redirect may be undesired:
+        # <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD>.
+        return request_method
     end
     return "GET"
 end

--- a/test/client.jl
+++ b/test/client.jl
@@ -208,6 +208,15 @@ end
 
         # canonicalizeheaders
         @test isok(HTTP.get("https://$httpbin/ip"; canonicalizeheaders=false, socket_type_tls=tls))
+
+        # Ensure HEAD requests stay the same through redirects by default
+        r = HTTP.head("https://$httpbin/redirect/1")
+        @test r.request.method == "HEAD"
+        @test iszero(length(r.body))
+        # But if explicitly requested, GET can be used instead
+        r = HTTP.head("https://$httpbin/redirect/1"; redirect_method="GET")
+        @test r.request.method == "GET"
+        @test length(r.body) > 0
     end
 end
 


### PR DESCRIPTION
I don't think this is a breaking change, in fact I didn't have to change any existing tests: this is only a change in the default behaviour if `redirect_method` is not set, but the user can always override it by setting that keyword argument.

This is also consistent with what `Downloads.jl` does:
```julia
julia> using Downloads

julia> io = IOBuffer();

julia> Downloads.request("https://google.com/"; output=io, method="HEAD"); # The HEAD request produces an empty body also through redirect

julia> length(String(take!(io)))
0
```