### PR TITLE
Fix access_threaded in the forthcoming interactive threadpool world

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -351,11 +351,12 @@ const unhex = Int8[
 function __init__()
     # FIXME Consider turing off `PCRE.UTF` in `Regex.compile_options`
     # https://github.com/JuliaLang/julia/pull/26731#issuecomment-380676770
-    resize!(empty!(status_line_regex),           Threads.nthreads())
-    resize!(empty!(request_line_regex),          Threads.nthreads())
-    resize!(empty!(header_field_regex),          Threads.nthreads())
-    resize!(empty!(obs_fold_header_field_regex), Threads.nthreads())
-    resize!(empty!(empty_header_field_regex),    Threads.nthreads())
+    nt = isdefined(Base.Threads, :maxthreadid) ? Threads.maxthreadid() : Threads.nthreads()
+    resize!(empty!(status_line_regex),           nt)
+    resize!(empty!(request_line_regex),          nt)
+    resize!(empty!(header_field_regex),          nt)
+    resize!(empty!(obs_fold_header_field_regex), nt)
+    resize!(empty!(empty_header_field_regex),    nt)
     return
 end
 

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -363,7 +363,7 @@ Accepts new tcp connections and spawns async tasks to handle them."
 function listenloop(f, listener, conns, tcpisvalid,
                        max_connections, readtimeout, access_log, ready_to_accept, verbose)
     sem = Base.Semaphore(max_connections)
-    verbose >= 0 && @infov 1 "Listening on: $(listener.hostname):$(listener.hostport)"
+    verbose >= 0 && @infov 1 "Listening on: $(listener.hostname):$(listener.hostport), thread id: $(Threads.threadid())"
     notify(ready_to_accept)
     while isopen(listener)
         try

--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -246,10 +246,11 @@ function parse_multipart_form(msg::Message)::Union{Vector{Multipart}, Nothing}
 end
 
 function __init__()
-    resize!(empty!(content_disposition_regex), Threads.nthreads())
-    resize!(empty!(content_disposition_flag_regex), Threads.nthreads())
-    resize!(empty!(content_disposition_pair_regex), Threads.nthreads())
-    resize!(empty!(content_type_regex), Threads.nthreads())
+    nt = isdefined(Base.Threads, :maxthreadid) ? Threads.maxthreadid() : Threads.nthreads()
+    resize!(empty!(content_disposition_regex), nt)
+    resize!(empty!(content_disposition_flag_regex), nt)
+    resize!(empty!(content_disposition_pair_regex), nt)
+    resize!(empty!(content_type_regex), nt)
     return
 end
 


### PR DESCRIPTION
Fixes #970.

The issue here is that our `access_threaded` function, and thread-specific arrays, all relied on `Threads.nthreads()`, which by default only returns the number of threads in the `:default` threadpool. In the new world where the `:interactive` threadpool exists, there can also be threads there.

There is a new function `Threads.maxthreadid()` which helpfully tells us the max id of any thread, regardless of threadpool. So the proposed fix here is that if that function is defined, use that, otherwise fallback to `Threads.nthreads()`.