### PR TITLE
Fix setting of response body for StatusError exception

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -351,6 +351,7 @@ function newconnection(::Type{T},
                        host::AbstractString,
                        port::AbstractString;
                        connection_limit=default_connection_limit[],
+                       forcenew::Bool=false,
                        idle_timeout=typemax(Int),
                        require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
                        kw...)::Connection where {T <: IO}
@@ -358,6 +359,7 @@ function newconnection(::Type{T},
             POOL,
             (T, host, port, require_ssl_verification, true);
             max_concurrent_connections=Int(connection_limit),
+            forcenew=forcenew,
             idle_timeout=Int(idle_timeout)) do
         Connection(host, port,
             idle_timeout, require_ssl_verification,

--- a/src/clientlayers/MessageRequest.jl
+++ b/src/clientlayers/MessageRequest.jl
@@ -1,7 +1,7 @@
 module MessageRequest
 
 using URIs
-using ..IOExtras, ..Messages, ..Parsers
+using ..IOExtras, ..Messages, ..Parsers, ..Exceptions
 
 export messagelayer
 
@@ -17,6 +17,12 @@ function messagelayer(handler)
         local resp
         try
             resp = handler(req; response_stream=response_stream, kw...)
+        catch e
+            if e isa StatusError
+                resp = e.response
+            else
+                rethrow(e)
+            end
         finally
             if @isdefined(resp) && iserror(resp) && haskey(resp.request.context, :response_body)
                 if isbytes(resp.body)

--- a/src/clientlayers/MessageRequest.jl
+++ b/src/clientlayers/MessageRequest.jl
@@ -20,9 +20,8 @@ function messagelayer(handler)
         catch e
             if e isa StatusError
                 resp = e.response
-            else
-                rethrow(e)
             end
+            rethrow(e)
         finally
             if @isdefined(resp) && iserror(resp) && haskey(resp.request.context, :response_body)
                 if isbytes(resp.body)


### PR DESCRIPTION
As reported in https://github.com/JuliaCloud/AWS.jl/issues/593, the recently refactored retry logic was failing to properly write the response body when a `response_stream` was used and a `StatusError` was thrown.