### PR TITLE
New retry_check should take response body as arg

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -136,8 +136,9 @@ Retry arguments:
  - `retries = 4`, number of times to retry.
  - `retry_non_idempotent = false`, retry non-idempotent requests too. e.g. POST.
  - `retry_delay = ExponentialBackOff(n = retries)`, provide a custom `ExponentialBackOff` object to control the delay between retries.
- - `retry_check = (s, ex, req, resp) -> Bool`, provide a custom function to control whether a retry should be attempted.
-    The function should accept 4 arguments: the delay state, exception, request, and response, and return `true` if a retry should be attempted.
+ - `retry_check = (s, ex, req, resp, resp_body) -> Bool`, provide a custom function to control whether a retry should be attempted.
+    The function should accept 5 arguments: the delay state, exception, request, response (as `HTTP.Response` object), and `resp_body`
+    response body (which may be `nothing` if there is no response yet, otherwise a `Vector{UInt8}`), and return `true` if a retry should be attempted.
 
 Redirect arguments:
  - `redirect = true`, follow 3xx redirect responses; i.e. additional requests will be made to the redirected location

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -137,8 +137,9 @@ Retry arguments:
  - `retry_non_idempotent = false`, retry non-idempotent requests too. e.g. POST.
  - `retry_delay = ExponentialBackOff(n = retries)`, provide a custom `ExponentialBackOff` object to control the delay between retries.
  - `retry_check = (s, ex, req, resp, resp_body) -> Bool`, provide a custom function to control whether a retry should be attempted.
-    The function should accept 5 arguments: the delay state, exception, request, response (as `HTTP.Response` object), and `resp_body`
-    response body (which may be `nothing` if there is no response yet, otherwise a `Vector{UInt8}`), and return `true` if a retry should be attempted.
+    The function should accept 5 arguments: the delay state, exception, request, response (an `HTTP.Response` object *if* a request was
+    successfully made, otherwise `nothing`), and `resp_body` response body (which may be `nothing` if there is no response yet, otherwise
+    a `Vector{UInt8}`), and return `true` if a retry should be attempted.
 
 Redirect arguments:
  - `redirect = true`, follow 3xx redirect responses; i.e. additional requests will be made to the redirected location

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -69,7 +69,8 @@ end
 
 function _retry_check(s, ex, req, check)
     resp = req.response
-    return check(s, ex, req, resp, get(req.context, :response_body, nothing))
+    resp_body = get(req.context, :response_body, nothing)
+    return check(s, ex, req, resp_body !== nothing ? resp : nothing, resp_body)
 end
 
 function no_retry_reason(ex, req)

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -69,10 +69,7 @@ end
 
 function _retry_check(s, ex, req, check)
     resp = req.response
-    if haskey(req.context, :response_body)
-        resp.body = req.context[:response_body]
-    end
-    return check(s, ex, req, resp)
+    return check(s, ex, req, resp, get(req.context, :response_body, nothing))
 end
 
 function no_retry_reason(ex, req)

--- a/test/client.jl
+++ b/test/client.jl
@@ -539,8 +539,8 @@ end
         shouldfail[] = false
         status[] = 404
         seekstart(req_body)
-        check = (s, ex, req, resp) -> begin
-            str = String(resp.body)
+        check = (s, ex, req, resp, resp_body) -> begin
+            str = String(resp_body)
             if str != "404 unexpected error" || resp.status != 404
                 @error "unexpected response body" str
                 return false


### PR DESCRIPTION
I realized we can't mess with the Response body field directly when using the new `retry_check` functionality because we might clobber a user-provided `response_stream`, which we set as the Response body field. Instead, it should just be an additional arg to the `retry_check` function.