### PR TITLE
Set line info for `@client` macro as call site

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,9 +33,10 @@ julia = "1.6"
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 Deno_jll = "04572ae6-984a-583e-9378-9577a1c2574d"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["BufferedStreams", "Deno_jll", "Distributed", "JSON", "Test", "Unitful"]
+test = ["BufferedStreams", "Deno_jll", "Distributed", "InteractiveUtils", "JSON", "Test", "Unitful"]

--- a/test/client.jl
+++ b/test/client.jl
@@ -9,9 +9,21 @@ using Sockets
 using JSON
 using Test
 using URIs
+using InteractiveUtils: @which
 
 # test we can adjust default_connection_limit
 HTTP.set_default_connection_limit!(12)
+
+@testset "@client macro" begin
+    @eval module MyClient
+        using HTTP
+        HTTP.@client () ()
+    end
+    # Test the `@client` sets the location info to the definition site, i.e. this file.
+    meth = @which MyClient.get()
+    file = String(meth.file)
+    @test file == @__FILE__
+end
 
 @testset "Custom HTTP Stack" begin
    @testset "Low-level Request" begin


### PR DESCRIPTION
Make it easier to find where the `@client` was defined

e.g. 
Before 
```julia
julia> using CloudBase

julia> @which CloudBase.Azure.get()  # Points to where the `HTTP.@client` macro is defined
get(a...; kw...) in CloudBase.Azure at /Users/nickr/.julia/packages/HTTP/RyUY8/src/HTTP.jl:460
```
Now
```julia
julia> using CloudBase

julia> @which CloudBase.Azure.get()  # Points to where `HTTP.@client` was called
get(a...; kw...) in CloudBase.Azure at /Users/nickr/repos/CloudBase.jl/src/CloudBase.jl:187
```

I don't know if there is a more standard way to do this 😊 