### PR TITLE
Allow passing pre-allocated buffer for response body

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -257,8 +257,8 @@ function http_unsafe_read(http::Stream, p::Ptr{UInt8}, n::UInt)::Int
     # If there is spare space in `p`
     # read two extra bytes
     # (`\r\n` at end ofchunk).
-    n = min(n, ntr + (http.readchunked ? 2 : 0))
-    unsafe_read(http.stream, p, n)
+    unsafe_read(http.stream, p, min(n, ntr + (http.readchunked ? 2 : 0)))
+    n = min(n, ntr)
     update_ntoread(http, n)
     return n
 end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -288,8 +288,7 @@ function Base.readbytes!(http::Stream, buf::IOBuffer, n=bytesavailable(http))
     buf.size += n
 end
 
-function Base.read(http::Stream)
-    buf = PipeBuffer()
+function Base.read(http::Stream, buf::IOBuffer=PipeBuffer())
     if ntoread(http) == unknown_length
         while !eof(http)
             readbytes!(http, buf)

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -291,7 +291,7 @@ function Base.readbytes!(http::Stream, buf::Base.GenericIOBuffer, n=bytesavailab
     buf.size += n
 end
 
-Base.read(http::Stream, buf::Base.GenericIOBuffer=PipeBuffer()) = take!(readall(http, buf))
+Base.read(http::Stream, buf::Base.GenericIOBuffer=PipeBuffer()) = take!(readall!(http, buf))
 
 function readall!(http::Stream, buf::Base.GenericIOBuffer=PipeBuffer())
     if ntoread(http) == unknown_length

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -22,7 +22,7 @@ e.g. `Sockets.DNSError`, `Base.EOFError` and `HTTP.StatusError`
 """
 function retrylayer(handler)
     return function(req::Request; retry::Bool=true, retries::Int=4,
-        retry_delays::ExponentialBackOff=ExponentialBackOff(n = retries), retry_check=FALSE,
+        retry_delays::ExponentialBackOff=ExponentialBackOff(n = retries, factor=3.0), retry_check=FALSE,
         retry_non_idempotent::Bool=false, kw...)
         if !retry || retries == 0
             # no retry
@@ -61,8 +61,8 @@ function retrylayer(handler)
                     @debugv 1 "🚷  No Retry: $(no_retry_reason(ex, req))"
                 end
                 return s, retry
-            end)
-
+            end
+        )
         return retry_request(req; kw...)
     end
 end

--- a/test/client.jl
+++ b/test/client.jl
@@ -112,6 +112,17 @@ end
         seekstart(io)
         @test isok(r)
 
+        b = [JSON.parse(l) for l in eachline(io)]
+        @test all(zip(a, b)) do (x, y)
+            x["args"] == y["args"] &&
+            x["id"] == y["id"] &&
+            x["url"] == y["url"] &&
+            x["origin"] == y["origin"] &&
+            x["headers"]["Content-Length"] == y["headers"]["Content-Length"] &&
+            x["headers"]["Host"] == y["headers"]["Host"] &&
+            x["headers"]["User-Agent"] == y["headers"]["User-Agent"]
+        end
+
         # pass pre-allocated buffer
         body = zeros(UInt8, 100)
         r = HTTP.get("https://$httpbin/bytes/100"; response_stream=body, socket_type_tls=tls)
@@ -139,17 +150,6 @@ end
         # same Array, though it was resized larger
         @test body === r.body.data
         @test length(body) == 100
-
-        b = [JSON.parse(l) for l in eachline(io)]
-        @test all(zip(a, b)) do (x, y)
-            x["args"] == y["args"] &&
-            x["id"] == y["id"] &&
-            x["url"] == y["url"] &&
-            x["origin"] == y["origin"] &&
-            x["headers"]["Content-Length"] == y["headers"]["Content-Length"] &&
-            x["headers"]["Host"] == y["headers"]["Host"] &&
-            x["headers"]["User-Agent"] == y["headers"]["User-Agent"]
-        end
     end
 
     @testset "Client Body Posting - Vector{UTF8}, String, IOStream, IOBuffer, BufferStream, Dict, NamedTuple" begin

--- a/test/client.jl
+++ b/test/client.jl
@@ -124,7 +124,7 @@ end
 
         # if provided buffer is too small, we won't grow it for user
         body = zeros(UInt8, 10)
-        @test_throws HTTP.RequestError HTTP.get("https://$httpbin/bytes/100"; response_stream=body, socket_type_tls=tls)
+        @test_throws HTTP.RequestError HTTP.get("https://$httpbin/bytes/100"; response_stream=body, socket_type_tls=tls, retry=false)
 
         # also won't shrink it if buffer provided is larger than response body
         body = zeros(UInt8, 10)


### PR DESCRIPTION
This is one piece in some efforts we're going to make to drastically reduce the # of allocations required for making HTTP requests.

This PR allows the user to pass a pre-allocated `Vector{UInt8}` via the `response_stream` keyword arg (previously not allowed), which will then be used directly for writing the response body.

cc: @nickrobinson251, @Drvi

Haven't added tests/docs yet, but wanted to at least get this up in case it overlaps w/ @Drvi's allocation hunting.