### PR TITLE
Specialize functions to avoid dynamic dispatch

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -212,7 +212,7 @@ Read until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
 function Base.readuntil(c::Connection, f::F #=Vector{UInt8} -> Int=#,
-                                        sizehint=4096)::ByteView where {F}
+                                        sizehint=4096)::ByteView where {F <: Function}
     buf = c.buffer
     if bytesavailable(buf) == 0
         read_to_buffer(c, sizehint)

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -211,8 +211,8 @@ end
 Read until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
-function Base.readuntil(c::Connection, f::Function #=Vector{UInt8} -> Int=#,
-                                        sizehint=4096)::ByteView
+function Base.readuntil(c::Connection, f::F #=Vector{UInt8} -> Int=#,
+                                        sizehint=4096)::ByteView where {F}
     buf = c.buffer
     if bytesavailable(buf) == 0
         read_to_buffer(c, sizehint)

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -112,9 +112,8 @@ Read from an `IO` stream until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
 function Base.readuntil(buf::IOBuffer,
-                    find_delimiter::Function #= Vector{UInt8} -> Int =#
-                   )::ByteView
-
+                    find_delimiter::F #= Vector{UInt8} -> Int =#
+                   )::ByteView where {F}
     l = find_delimiter(view(buf.data, buf.ptr:buf.size))
     if l == 0
         return nobytes

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -113,7 +113,7 @@ Return view of bytes up to the delimiter.
 """
 function Base.readuntil(buf::IOBuffer,
                     find_delimiter::F #= Vector{UInt8} -> Int =#
-                   )::ByteView where {F}
+                   )::ByteView where {F <: Function}
     l = find_delimiter(view(buf.data, buf.ptr:buf.size))
     if l == 0
         return nobytes


### PR DESCRIPTION
This helps reduce allocations and make client requests a little more stable with regards to allocations and performance.