### PR TITLE
Add content auto decoding for `download()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,6 @@ OpenSSL = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SimpleBufferStream = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ OpenSSL = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SimpleBufferStream = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/download.jl
+++ b/src/download.jl
@@ -1,6 +1,5 @@
 using .Pairs
 using CodecZlib
-using TranscodingStreams
 
 """
     safer_joinpath(basepart, parts...)
@@ -70,12 +69,6 @@ function determine_file(path, resp, hdrs)
                     )
 
         
-        # get the extension, if we are going to save it in encoded form.
-        # unlike a web-browser we don't automatically decompress
-        if header(resp, "Content-Encoding") == "gzip"
-            filename *= ".gz"
-        end
-        
         safer_joinpath(path, filename)
     else
         # We have been given a full filepath
@@ -124,7 +117,7 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
         prev_time = now()
 
         if header(resp, "Content-Encoding") == "gzip"
-            stream = TranscodingStream(GzipDecompressor(), stream) # auto decoding
+            stream = GzipDecompressorStream(stream) # auto decoding
             total_bytes = NaN # We don't know actual total bytes if the content is zipped.
         end
 

--- a/src/download.jl
+++ b/src/download.jl
@@ -1,4 +1,6 @@
 using .Pairs
+using CodecZlib
+using TranscodingStreams
 
 """
     safer_joinpath(basepart, parts...)
@@ -120,6 +122,11 @@ function download(url::AbstractString, local_path=nothing, headers=Header[]; upd
         downloaded_bytes = 0
         start_time = now()
         prev_time = now()
+
+        if header(resp, "Content-Encoding") == "gzip"
+            stream = TranscodingStream(GzipDecompressor(), stream) # auto decoding
+            total_bytes = NaN # We don't know actual total bytes if the content is zipped.
+        end
 
         function report_callback()
             prev_time = now()

--- a/test/download.jl
+++ b/test/download.jl
@@ -73,7 +73,6 @@ import ..httpbin
         # Add gz extension if we are determining the filename
         gzip_content_encoding_fn = HTTP.download("https://$httpbin/gzip")
         @test isfile(gzip_content_encoding_fn)
-        @test last(splitext(gzip_content_encoding_fn)) == ".gz"
 
         # Check content auto decoding
         open(gzip_content_encoding_fn, "r") do f
@@ -88,11 +87,6 @@ import ..httpbin
                 name,
             )
             @test name == downloaded_name
-
-            # Check content auto decoding
-            open(name, "r") do f
-                @test HTTP.sniff(read(f, String)) == "application/json; charset=utf-8"
-            end
         end
     end
 end

--- a/test/download.jl
+++ b/test/download.jl
@@ -75,6 +75,11 @@ import ..httpbin
         @test isfile(gzip_content_encoding_fn)
         @test last(splitext(gzip_content_encoding_fn)) == ".gz"
 
+        # Check content auto decoding
+        open(gzip_content_encoding_fn, "r") do f
+            @test HTTP.sniff(read(f, String)) == "application/json; charset=utf-8"
+        end
+
         # But not if the local name is fully given. HTTP#573
         mktempdir() do dir
             name = joinpath(dir, "foo")
@@ -83,6 +88,11 @@ import ..httpbin
                 name,
             )
             @test name == downloaded_name
+
+            # Check content auto decoding
+            open(name, "r") do f
+                @test HTTP.sniff(read(f, String)) == "application/json; charset=utf-8"
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ include(joinpath(dir, "resources/TestRequest.jl"))
             "chunking.jl",
             "utils.jl",
             "client.jl",
+            "download.jl",
             "multipart.jl",
             "parsemultipart.jl",
             "sniff.jl",


### PR DESCRIPTION
This PR adds content auto decoding function for `download()` using [TranscodingStreams\.jl](https://github.com/JuliaIO/TranscodingStreams.jl) to fix #889
