### PR TITLE
Tweak IOBuffer handling

### DIFF
--- a/src/clientlayers/StreamRequest.jl
+++ b/src/clientlayers/StreamRequest.jl
@@ -155,7 +155,7 @@ function readbody!(stream::Stream, res::Response, buf_or_stream)
             else
                 res.body = read(buf_or_stream)
             end
-        elseif (res.body isa IOBuffers || res.body isa Base.GenericIOBuffer) && buf_or_stream isa Stream
+        elseif res.body isa Base.GenericIOBuffer && buf_or_stream isa Stream
             # optimization for IOBuffer response_stream to avoid temporary allocations
             readall!(buf_or_stream, res.body)
         else


### PR DESCRIPTION
This PR takes into account the `append` flag of `GenericIOBuffer` and adjusts the `readbytes!` behavior to treat the `size` field as the end pointer for `append=true` and `ptr` as the end pointer for `append=false`