### PR TITLE
fix for issue #988 --> seemles highly customizable retry setup

### DIFF
--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -3,9 +3,7 @@ module RetryRequest
 using Sockets, LoggingExtras, MbedTLS, OpenSSL
 using ..IOExtras, ..Messages, ..Strings, ..ExceptionRequest, ..Exceptions
 
-export retrylayer
-
-FALSE(x...) = false
+export retrylayer, retry_check, isrecoverable
 
 """
     retrylayer(handler) -> handler
@@ -21,13 +19,12 @@ e.g. `Sockets.DNSError`, `Base.EOFError` and `HTTP.StatusError`
 (if status is `5xx`).
 """
 function retrylayer(handler)
-    return function(req::Request; retry::Bool=true, retries::Int=4,
-        retry_delays::ExponentialBackOff=ExponentialBackOff(n = retries, factor=3.0), retry_check=FALSE,
-        retry_non_idempotent::Bool=false, kw...)
-        if !retry || retries == 0
-            # no retry
-            return handler(req; kw...)
-        end
+    return function(req::Request; retries::Int=4, retry::Bool=retries>0, 
+        retry_delays=ExponentialBackOff(n=retries, factor=3.0), retry_check=retry_check,
+        retry_non_idempotent::Bool=false, kw...
+    )
+        retry || return handler(req; kw...) # no retry
+        retries = length(retry_delays)
         req.context[:allow_retries] = true
         req.context[:retryattempt] = 0
         if retry_non_idempotent
@@ -39,16 +36,10 @@ function retrylayer(handler)
             req_body_is_marked = true
             mark(req.body)
         end
-        retryattempt = Ref(0)
-        retry_request = Base.retry(handler,
-            delays=retry_delays,
-            check=(s, ex) -> begin
-                retryattempt[] += 1
-                req.context[:retryattempt] = retryattempt[]
-                retry = retryable(req) || retryablebody(req) && _retry_check(s, ex, req, retry_check)
-                if retryattempt[] == retries
-                    req.context[:retrylimitreached] = true
-                end
+        retry_request = Base.retry(handler, delays=retry_delays,
+            check = (s, ex) -> begin
+                req.context[:retrylimitreached] = (req.context[:retryattempt] += 1) > retries
+                retry = retryable(req) && _retry_check(s, ex, req, retry_check)
                 if retry
                     @debugv 1 "🔄  Retry $ex: $(sprintcompact(req))"
                     reset!(req.response)
@@ -72,6 +63,14 @@ function _retry_check(s, ex, req, check)
     resp_body = get(req.context, :response_body, nothing)
     return check(s, ex, req, resp_body !== nothing ? resp : nothing, resp_body)
 end
+retry_check(s, ex, x...) = isrecoverable(ex)
+isrecoverable(e) = false
+isrecoverable(e::Union{Base.EOFError, Base.IOError, MbedTLS.MbedException, OpenSSL.OpenSSLError}) = true
+isrecoverable(e::ArgumentError) = e.msg == "stream is closed or unusable"
+isrecoverable(e::Sockets.DNSError) = true
+isrecoverable(e::ConnectError) = true
+isrecoverable(e::RequestError) = isrecoverable(e.error)
+isrecoverable(e::StatusError) = retryable(e.status)
 
 function no_retry_reason(ex, req)
     buf = IOBuffer()


### PR DESCRIPTION
Solves issue https://github.com/JuliaWeb/HTTP.jl/issues/988 to my understanding.

features: 

- `retry_check` is always executed/checked if retryable(req) returns true.
- `retry_check` keyword arguments defaults to function `HTTP.retry_check` respectively `HTTP.isrecoverable` which restores the old behaviour that minimizes unnecessary (little promising) retries.
- `retry_delays` is not restricted to `ExponentialBackOff`, it can be any iterator with length over Reals
- `retry` defaults to `retries>0`
- `retries` is default `n` for `ExponentialBackOff`, but is overwritten by `length(retry_delays)` to avoid inconsistencies caused by `req.context[:retrylimitreached]`
- even though I don't see the use of `req.context[:retrylimitreached]` and `req.context[:retryattempt]` it's consistently integrated into the `Base.retry`-check-function.