### PR TITLE
Cleanup header initialization to avoid excessive copies

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -410,6 +410,9 @@ end
 function getconnection(::Type{TCPSocket},
                        host::AbstractString,
                        port::AbstractString;
+                       # set keepalive to true by default since it's cheap and helps keep long-running requests/responses
+                       # alive in the face of heavy workloads where Julia's task scheduler might take a while to
+                       # keep up with midflight requests
                        keepalive::Bool=true,
                        connect_timeout::Int=0,
                        readtimeout::Int=0,

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -410,7 +410,7 @@ end
 function getconnection(::Type{TCPSocket},
                        host::AbstractString,
                        port::AbstractString;
-                       keepalive::Bool=false,
+                       keepalive::Bool=true,
                        connect_timeout::Int=0,
                        readtimeout::Int=0,
                        kw...)::TCPSocket

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -57,7 +57,7 @@ export Message, Request, Response,
        readchunksize,
        writeheaders, writestartline,
        bodylength, unknown_length,
-       payload, decode, statustext, sprintcompact
+       payload, decode, sprintcompact
 
 using URIs, CodecZlib
 using ..Pairs, ..IOExtras, ..Parsers, ..Strings, ..Forms, ..Conditions
@@ -204,13 +204,14 @@ resource(uri::URI) = string( isempty(uri.path)     ? "/" :     uri.path,
                             !isempty(uri.fragment) ? "#" : "", uri.fragment)
 
 mkheaders(h::Headers) = h
-function mkheaders(h)::Headers
+function mkheaders(h, headers=Vector{Header}(undef, length(h)))::Headers
     # validation
-    foreach(h) do head
+    for (i, head) in enumerate(h)
         head isa String && throw(ArgumentError("header must be passed as key => value pair: `$head`"))
         length(head) != 2 && throw(ArgumentError("invalid header key-value pair: $head"))
+        headers[i] = SubString(string(head[1])) => SubString(string(head[2]))
     end
-    return Header[string(k) => string(v) for (k, v) in h]
+    return headers
 end
 
 method(r::Request) = getfield(r, :method)


### PR DESCRIPTION
Set keepalive to true by default for tcp layer.
Fix bug where both StatusCodes & Messages were exporting `statustext`.