### PR TITLE
Revert readtimeout back to 0 by default; connect_timeout to 10

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -414,8 +414,8 @@ function getconnection(::Type{TCPSocket},
                        # alive in the face of heavy workloads where Julia's task scheduler might take a while to
                        # keep up with midflight requests
                        keepalive::Bool=true,
-                       connect_timeout::Int=60,
-                       readtimeout::Int=60,
+                       connect_timeout::Int=10,
+                       readtimeout::Int=0,
                        kw...)::TCPSocket
 
     p::UInt = isempty(port) ? UInt(80) : parse(UInt, port)
@@ -539,7 +539,7 @@ end
 function sslupgrade(::Type{IOType}, c::Connection,
                     host::AbstractString;
                     require_ssl_verification::Bool=NetworkOptions.verify_host(host, "SSL"),
-                    readtimeout::Int=60,
+                    readtimeout::Int=0,
                     kw...)::Connection{IOType} where {IOType}
     # initiate the upgrade to SSL
     # if the upgrade fails, an error will be thrown and the original c will be closed

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -117,10 +117,10 @@ Supported optional keyword arguments:
     will be written to this stream instead of returned as a `Vector{UInt8}`.
  - `verbose = 0`, set to `1` or `2` for increasingly verbose logging of the
     request and response process
- - `connect_timeout = 60`, close the connection after this many seconds if it
+ - `connect_timeout = 10`, close the connection after this many seconds if it
    is still attempting to connect. Use `connect_timeout = 0` to disable.
  - `connection_limit = 8`, number of concurrent connections allowed to each host:port.
- - `readtimeout = 60`, close the connection if no data is received for this many
+ - `readtimeout = 0`, close the connection if no data is received for this many
    seconds. Use `readtimeout = 0` to disable.
  - `status_exception = true`, throw `HTTP.StatusError` for response status >= 300.
  - Basic authentication is detected automatically from the provided url's `userinfo` (in the form `scheme://user:password@host`)

--- a/src/clientlayers/ConnectionRequest.jl
+++ b/src/clientlayers/ConnectionRequest.jl
@@ -55,7 +55,7 @@ Close the connection if the request throws an exception.
 Otherwise leave it open so that it can be reused.
 """
 function connectionlayer(handler)
-    return function(req; proxy=getproxy(req.url.scheme, req.url.host), socket_type::Type=TCPSocket, socket_type_tls::Type=SOCKET_TYPE_TLS[], readtimeout::Int=60, kw...)
+    return function(req; proxy=getproxy(req.url.scheme, req.url.host), socket_type::Type=TCPSocket, socket_type_tls::Type=SOCKET_TYPE_TLS[], readtimeout::Int=0, kw...)
         local io, stream
         if proxy !== nothing
             target_url = req.url

--- a/src/clientlayers/TimeoutRequest.jl
+++ b/src/clientlayers/TimeoutRequest.jl
@@ -11,7 +11,7 @@ export timeoutlayer
 Close the `HTTP.Stream` if no data has been received for `readtimeout` seconds.
 """
 function timeoutlayer(handler)
-    return function(stream::Stream; readtimeout::Int=60, kw...)
+    return function(stream::Stream; readtimeout::Int=0, kw...)
         if readtimeout <= 0
             # skip
             return handler(stream; kw...)


### PR DESCRIPTION
After trying this on some real applications, it seems setting the readtimeout by default may be too disruptive, so this PR reverts the setting of 60 seconds back to 0, which disables it. Change connect_timeout, however to 10 seconds, since that is expected to happen very quickly