### PR TITLE
Write cookie separator with space

### DIFF
--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -158,7 +158,16 @@ end
 
 function stringify(cookiestring::AbstractString, cookies::Vector{Cookie}, isrequest::Bool=true)
     io = IOBuffer()
-    !isempty(cookiestring) && write(io, cookiestring, endswith(cookiestring, "; ") ? "" : "; ")
+    if !isempty(cookiestring)
+        write(io, cookiestring)
+        if !isempty(cookies)
+            if endswith(rstrip(cookiestring, [' ']), ";")
+                cookiestring[end] == ';' && write(io, ' ')
+            else
+                write(io, "; ")
+            end
+        end
+    end
     len = length(cookies)
     for (i, cookie) in enumerate(cookies)
         write(io, stringify(cookie, isrequest), ifelse(i == len, "", "; "))

--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -158,7 +158,7 @@ end
 
 function stringify(cookiestring::AbstractString, cookies::Vector{Cookie}, isrequest::Bool=true)
     io = IOBuffer()
-    !isempty(cookiestring) && write(io, cookiestring, cookiestring[end] == ';' ? "" : ";")
+    !isempty(cookiestring) && write(io, cookiestring, endswith(cookiestring, "; ") ? "" : "; ")
     len = length(cookies)
     for (i, cookie) in enumerate(cookies)
         write(io, stringify(cookie, isrequest), ifelse(i == len, "", "; "))

--- a/test/cookies.jl
+++ b/test/cookies.jl
@@ -58,8 +58,11 @@ using Sockets, Test
             @test HTTP.stringify("cookie-0", cookies) == "cookie-0; $expected"
             @test HTTP.stringify("cookie-0=", cookies) == "cookie-0=; $expected"
             @test HTTP.stringify("cookie-0=0", cookies) == "cookie-0=0; $expected"
-            @test HTTP.stringify("cookie-0=0;", cookies) == "cookie-0=0;; $expected"
+            @test HTTP.stringify("cookie-0=0 ", cookies) == "cookie-0=0 ; $expected"
+            @test HTTP.stringify("cookie-0=0  ", cookies) == "cookie-0=0  ; $expected"
+            @test HTTP.stringify("cookie-0=0;", cookies) == "cookie-0=0; $expected"
             @test HTTP.stringify("cookie-0=0; ", cookies) == "cookie-0=0; $expected"
+            @test HTTP.stringify("cookie-0=0;  ", cookies) == "cookie-0=0;  $expected"
         end
     end
 

--- a/test/cookies.jl
+++ b/test/cookies.jl
@@ -51,7 +51,16 @@ using Sockets, Test
                    HTTP.Cookie("cookie-2", "v\$2"),
                    HTTP.Cookie("cookie-3", "v\$3"),
                   ]
-        @test HTTP.stringify("", cookies) == "cookie-1=v\$1; cookie-2=v\$2; cookie-3=v\$3"
+        expected = "cookie-1=v\$1; cookie-2=v\$2; cookie-3=v\$3"
+        @test HTTP.stringify("", cookies) == expected
+
+        @testset "combine cookies with existing header" begin
+            @test HTTP.stringify("cookie-0", cookies) == "cookie-0; $expected"
+            @test HTTP.stringify("cookie-0=", cookies) == "cookie-0=; $expected"
+            @test HTTP.stringify("cookie-0=0", cookies) == "cookie-0=0; $expected"
+            @test HTTP.stringify("cookie-0=0;", cookies) == "cookie-0=0;; $expected"
+            @test HTTP.stringify("cookie-0=0; ", cookies) == "cookie-0=0; $expected"
+        end
     end
 
     @testset "readsetcookies" begin


### PR DESCRIPTION
When a request includes cookies as a header (as opposed to a keyword argument) HTTP.jl strings them together, but misses a space character, causing the receiving party to parse the cookies incorrectly if it adheres to `; ` as separator.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie)
> Pairs in the list are separated by a semicolon and a space ('; ').