### PR TITLE
Add AbstractDict for request bodies

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -89,12 +89,12 @@ as an additional keyword argument to the request.
 
 `body` can be a variety of objects:
 
- - a `Dict` or `NamedTuple` to be serialized as the "application/x-www-form-urlencoded" content type
+ - an `AbstractDict` or `NamedTuple` to be serialized as the "application/x-www-form-urlencoded" content type
  - any `AbstractString` or `AbstractVector{UInt8}` which will be sent "as is" for the request body
  - a readable `IO` stream or any `IO`-like type `T` for which
    `eof(T)` and `readavailable(T)` are defined. This stream will be read and sent until `eof` is `true`.
    This object should support the `mark`/`reset` methods if request retires are desired (if not, no retries will be attempted).
- - Any collection or iterable of the above (`Dict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`)
+ - Any collection or iterable of the above (`AbstractDict`, `AbstractString`, `AbstractVector{UInt8}`, or `IO`)
    which will result in a "chunked" request body, where each iterated element will be sent as a separate chunk
  - a [`HTTP.Form`](@ref), which will be serialized as the "multipart/form-data" content-type
 

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -277,9 +277,9 @@ function retryable end
 supportsmark(x) = false
 supportsmark(x::T) where {T <: IO} = length(Base.methods(mark, Tuple{T}, parentmodule(T))) > 0 || hasfield(T, :mark)
 
-# request body is retryable if it was provided as "bytes", a Dict or NamedTuple,
+# request body is retryable if it was provided as "bytes", an AbstractDict or NamedTuple,
 # or a chunked array of "bytes"; OR if it supports mark() and is marked
-retryablebody(r::Request) = (isbytes(r.body) || r.body isa Union{Dict, NamedTuple} ||
+retryablebody(r::Request) = (isbytes(r.body) || r.body isa Union{AbstractDict, NamedTuple} ||
     (r.body isa Vector && all(isbytes, r.body)) || (supportsmark(r.body) && ismarked(r.body)))
 
 # request is retryable if the body is retryable, the user is allowing retries at all,
@@ -581,7 +581,7 @@ const BODY_SHOW_MAX = Ref(1000)
 The first chunk of the Message Body (for display purposes).
 """
 bodysummary(body) = isbytes(body) ? view(bytes(body), 1:min(nbytes(body), BODY_SHOW_MAX[])) : "[Message Body was streamed]"
-bodysummary(body::Union{Dict, NamedTuple}) = URIs.escapeuri(body)
+bodysummary(body::Union{AbstractDict, NamedTuple}) = URIs.escapeuri(body)
 function bodysummary(body::Form)
     if length(body.data) == 1 && isa(body.data[1], IOBuffer)
         return body.data[1].data[1:body.data[1].ptr-1]

--- a/src/clientlayers/DefaultHeadersRequest.jl
+++ b/src/clientlayers/DefaultHeadersRequest.jl
@@ -38,7 +38,7 @@ function defaultheaderslayer(handler)
         if !hasheader(headers, "Content-Type") && req.body isa Form && req.method in ("POST", "PUT", "PATCH")
             # "Content-Type" => "multipart/form-data; boundary=..."
             setheader(headers, content_type(req.body))
-        elseif !hasheader(headers, "Content-Type") && (req.body isa Dict || req.body isa NamedTuple) && req.method in ("POST", "PUT", "PATCH")
+        elseif !hasheader(headers, "Content-Type") && (req.body isa Union{AbstractDict, NamedTuple}) && req.method in ("POST", "PUT", "PATCH")
             setheader(headers, "Content-Type" => "application/x-www-form-urlencoded")
         end
         if decompress === nothing || decompress

--- a/src/clientlayers/StreamRequest.jl
+++ b/src/clientlayers/StreamRequest.jl
@@ -94,13 +94,13 @@ function writebodystream(stream, body::IO)
     write(stream, body)
 end
 
-function writebodystream(stream, body::Union{Dict, NamedTuple})
+function writebodystream(stream, body::Union{AbstractDict, NamedTuple})
     # application/x-www-form-urlencoded
     write(stream, URIs.escapeuri(body))
 end
 
 writechunk(stream, body::IO) = writebodystream(stream, body)
-writechunk(stream, body::Union{Dict, NamedTuple}) = writebodystream(stream, body)
+writechunk(stream, body::Union{AbstractDict, NamedTuple}) = writebodystream(stream, body)
 writechunk(stream, body) = write(stream, body)
 
 function readbody(stream::Stream, res::Response, decompress::Union{Nothing, Bool})

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -78,7 +78,7 @@ end
 
 Construct a request body for multipart/form-data encoding from `data`.
 
-`data` must iterate key-value pairs (e.g. `Dict` or `Vector{Pair}`) where the key/value of the
+`data` must iterate key-value pairs (e.g. `AbstractDict` or `Vector{Pair}`) where the key/value of the
 iterator is the key/value of each mutipart boundary chunk.
 Files and other large data arguments can be provided as values as IO arguments: either an `IOStream`
 such as returned via `open(file)`, or an `IOBuffer` for in-memory data.


### PR DESCRIPTION
I've broadened the accepted request body types from `Dict` to `AbstractDict` to allow for custom dictionary types.

I have a number of custom dictionary types representing JSON objects of various schema (a fairly common practice) and it is convenient to not have to explicitly convert them.

All tests pass and I don't think this will break any uses? Happy for any feedback.