### PR TITLE
Proxy support for HTTPS connection pool

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -42,6 +42,7 @@ include("Connections.jl")              ;using .Connections
 const ConnectionPool = Connections
 include("StatusCodes.jl")              ;using .StatusCodes
 include("Messages.jl")                 ;using .Messages
+include("Tunnel.jl")                   ;using .Tunnel
 include("cookies.jl")                  ;using .Cookies
 include("Streams.jl")                  ;using .Streams
 

--- a/src/Tunnel.jl
+++ b/src/Tunnel.jl
@@ -1,0 +1,106 @@
+module Tunnel
+
+export newtunnelconnection
+
+using Sockets, LoggingExtras, NetworkOptions, URIs
+using ConcurrentUtilities: acquire, try_with_timeout
+
+using ..Connections, ..Messages, ..Exceptions
+using ..Connections: connection_limit_warning, getpool, getconnection, sslconnection, connectionkey, connection_isvalid
+
+function newtunnelconnection(;
+        target_type::Type{<:IO},
+        target_host::AbstractString,
+        target_port::AbstractString,
+        proxy_type::Type{<:IO},
+        proxy_host::AbstractString,
+        proxy_port::AbstractString,
+        proxy_auth::AbstractString="",
+        pool::Union{Nothing, Pool}=nothing,
+        connection_limit=nothing,
+        forcenew::Bool=false,
+        idle_timeout=typemax(Int),
+        connect_timeout::Int=30,
+        readtimeout::Int=30,
+        keepalive::Bool=true,
+        kw...)
+    connection_limit_warning(connection_limit)
+
+    if isempty(target_port)
+        target_port = istcptype(target_type) ? "80" : "443"
+    end
+
+    require_ssl_verification = get(kw, :require_ssl_verification, NetworkOptions.verify_host(target_host, "SSL"))
+    host_key = proxy_host * "/" * target_host
+    port_key = proxy_port * "/" * target_port
+    key = (host_key, port_key, require_ssl_verification, keepalive, true)
+
+    return acquire(
+            getpool(pool, target_type),
+            key;
+            forcenew=forcenew,
+            isvalid=c->connection_isvalid(c, Int(idle_timeout))) do
+
+        conn = Connection(host_key, port_key, idle_timeout, require_ssl_verification, keepalive,
+            try_with_timeout0(connect_timeout) do _
+                getconnection(proxy_type, proxy_host, proxy_port; keepalive, kw...)
+            end
+        )
+        try
+            try_with_timeout0(readtimeout) do _
+                connect_tunnel(conn, target_host, target_port, proxy_auth)
+            end
+
+            if !istcptype(target_type)
+                tls = try_with_timeout0(readtimeout) do _
+                    sslconnection(target_type, conn.io, target_host; keepalive, kw...)
+                end
+
+                # success, now we turn it into a new Connection
+                conn = Connection(host_key, port_key, idle_timeout, require_ssl_verification, keepalive, tls)
+            end
+
+            @assert connectionkey(conn) === key
+
+            conn
+        catch ex
+            close(conn)
+            rethrow()
+        end
+    end
+end
+
+function connect_tunnel(io, target_host, target_port, proxy_auth)
+    target = "$(URIs.hoststring(target_host)):$(target_port)"
+    @debug "📡  CONNECT HTTPS tunnel to $target"
+    headers = Dict("Host" => target)
+    if (!isempty(proxy_auth))
+        headers["Proxy-Authorization"] = proxy_auth
+    end
+    request = Request("CONNECT", target, headers)
+    # @debug "connect_tunnel: writing headers"
+    writeheaders(io, request)
+    # @debug "connect_tunnel: reading headers"
+    readheaders(io, request.response)
+    # @debug "connect_tunnel: done reading headers"
+    if request.response.status != 200
+        throw(StatusError(request.response.status,
+              request.method, request.target, request.response))
+    end
+end
+
+"""
+Wrapper to try_with_timeout that optionally disables the timeout if given a non-positive duration.
+"""
+function try_with_timeout0(f, timeout, ::Type{T}=Any) where {T}
+    if timeout > 0
+        try_with_timeout(f, timeout, T)
+    else
+        f(Ref(false)) # `f` may check its argument to see if the timeout was reached.
+    end
+end
+
+istcptype(::Type{TCPSocket}) = true
+istcptype(::Type{<:IO}) = false
+
+end # module Tunnel

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -157,14 +157,14 @@ end
         @testset "Only one tunnel should be established with sequential requests" begin
             https_request_ip_through_proxy()
             https_request_ip_through_proxy()
-            @test_broken connectcount == 1
+            @test connectcount == 1
         end
         
         @testset "parallell tunnels should be established with parallell requests" begin
             n_asyncgetters = 3
             asyncgetters = [@async https_request_ip_through_proxy() for _ in 1:n_asyncgetters]
             wait.(asyncgetters)
-            @test_broken connectcount == n_asyncgetters
+            @test connectcount == n_asyncgetters
         end
     
     finally

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -1,0 +1,124 @@
+module TestPool
+
+using HTTP
+import ..httpbin
+using Sockets
+using Test
+
+function pooledconnections(socket_type)
+    pool = HTTP.Connections.getpool(nothing, socket_type)
+    conns_per_key = values(pool.keyedvalues)
+    [c for conns in conns_per_key for c in conns if isopen(c)]
+end
+
+@testset "$schema pool" for (schema, socket_type) in [
+        ("http", Sockets.TCPSocket),
+        ("https", HTTP.SOCKET_TYPE_TLS[])]
+    HTTP.Connections.closeall()
+    @test length(pooledconnections(socket_type)) == 0
+    try
+        function request_ip()
+            r = HTTP.get("$schema://$httpbin/ip"; retry=false, redirect = false, status_exception=true)
+            String(r.body)
+        end
+
+        @testset "Sequential request use the same socket" begin
+            request_ip()
+            conns = pooledconnections(socket_type)
+            @test length(conns) == 1
+            conn1io = conns[1].io
+            
+            request_ip()
+            conns = pooledconnections(socket_type)
+            @test length(conns) == 1
+            @test conn1io === conns[1].io
+        end
+
+        @testset "Parallell requests however use parallell connections" begin
+            n_asyncgetters = 3
+            asyncgetters = [@async request_ip() for _ in 1:n_asyncgetters]
+            wait.(asyncgetters)
+            
+            conns = pooledconnections(socket_type)
+            @test length(conns) == n_asyncgetters
+        end
+    finally
+        HTTP.Connections.closeall()
+    end
+end
+
+function readwrite(src, dst)
+    n = 0
+    while isopen(dst) && !eof(src)
+        buff = readavailable(src)
+        if isopen(dst)
+            write(dst, buff)
+        end
+        n += length(buff)
+    end
+    n
+end
+
+@testset "http pool with proxy" begin
+    downstreamconnections = Base.IdSet{HTTP.Connections.Connection}()
+    upstreamconnections = Base.IdSet{HTTP.Connections.Connection}()
+    downstreamcount = 0
+    upstreamcount = 0
+
+    # Simple implementation of an http proxy server
+    proxy = HTTP.listen!(IPv4(0), 8082; stream = true) do http::HTTP.Stream
+        push!(downstreamconnections, http.stream)
+        downstreamcount += 1
+        
+        HTTP.open(http.message.method, http.message.target, http.message.headers;
+                  decompress = false, version = http.message.version, retry=false,
+                  redirect = false) do targetstream
+            push!(upstreamconnections, targetstream.stream)
+            upstreamcount += 1
+            
+            up = @async readwrite(http, targetstream)
+            targetresponse = startread(targetstream)
+
+            HTTP.setstatus(http, targetresponse.status)
+            for h in targetresponse.headers
+                HTTP.setheader(http, h)
+            end
+
+            HTTP.startwrite(http)
+            readwrite(targetstream, http)
+
+            wait(up)
+        end
+    end
+
+    try
+        function http_request_ip_through_proxy()
+            r = HTTP.get("http://$httpbin/ip"; proxy="http://localhost:8082", retry=false, redirect = false, status_exception=true) 
+            String(r.body)
+        end
+
+        # Make the HTTP request
+        http_request_ip_through_proxy()
+        @test length(downstreamconnections) == 1
+        @test length(upstreamconnections) == 1
+        @test downstreamcount == 1
+        @test upstreamcount == 1
+
+        # Make another request
+        # This should reuse connections from the pool in both the client and the proxy
+        http_request_ip_through_proxy()
+        
+        # Check that additional requests were made, both downstream and upstream
+        @test downstreamcount == 2
+        @test upstreamcount == 2
+        # But the set of unique connections in either direction should remain of size 1
+        @test length(downstreamconnections) == 1
+        @test length(upstreamconnections) == 1
+    finally
+        HTTP.Connections.closeall()
+        close(proxy)
+        wait(proxy)
+    end
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ isok(r) = r.status == 200
         "chunking.jl",
         "utils.jl",
         "client.jl",
+        "pool.jl",
         # "download.jl",
         "multipart.jl",
         "parsemultipart.jl",


### PR DESCRIPTION
Connection pools are really effective. This PR makes them work through a proxy as well.

When establishing an HTTPS connection through a proxy a connection is first made with the proxy and then a second connection, a tunnel, is established with the target host. This second connection is kept in a pool whereas the connection with the proxy is not kept in the pool.

Later, when a subsequent connection is made with the same target host it could reuse the tunnel. Unfortunately the tunnel isn't found when looking in the pool for available connections. The reason is that the `sslupgrade` function creates a new `Connection` with a different `connectionkey`. This mismatch between keys causes  `newconnection` to not find the reusable tunnel connection, even though we readily keep the tunnel alive sitting there just waiting to be reused.

In this PR, `newtunnelconnection` uses a `connectionkey` that can be reused as expected.

Does this look like the right approach for this kind of functionality?