### PR TITLE
Don't use `===` to compare `nobytes`

### DIFF
--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -232,7 +232,7 @@ function Base.readuntil(c::Connection, f::F #=Vector{UInt8} -> Int=#,
     if bytesavailable(buf) == 0
         read_to_buffer(c, sizehint)
     end
-    while (bytes = readuntil(buf, f)) === nobytes
+    while (bytes = readuntil(buf, f)) == nobytes
         read_to_buffer(c, sizehint)
     end
     return bytes


### PR DESCRIPTION
This is a bit of a weird one, but in a nutshell

```
julia> HTTP.IOExtras.nobytes == view(UInt8[], 1:0)
true

julia> HTTP.IOExtras.nobytes === view(UInt8[], 1:0)
false
```

If you happen to overwrite the `Base.readuntil` method in `IOExtras`[^1], you will end up returning the "wrong" `nobytes`, and so this check yields the wrong result, and HTTP.jl will usually throw a random error (or also just hangs). Running this with HTTP 1.9.4, for example, should throw in the `HTTP.get()` call:

[^1]: Which is kind-of a valid thing to do, since it's doing type piracy. And we happen to do it because we sometimes need to load two different versions of HTTP.jl in the same Julia session.

```julia
import HTTP
module HTTPOverloads
const ByteView = typeof(view(UInt8[], 1:0))
const nobytes = view(UInt8[], 1:0)
"""
Read from an `IO` stream until `find_delimiter(bytes)` returns non-zero.
Return view of bytes up to the delimiter.
"""
function Base.readuntil(buf::IOBuffer,
                    find_delimiter::Function #= Vector{UInt8} -> Int =#
                   )::ByteView
    l = find_delimiter(view(buf.data, buf.ptr:buf.size))
    if l == 0
        return nobytes
    end
    bytes = view(buf.data, buf.ptr:buf.ptr + l - 1)
    buf.ptr += l
    return bytes
end
end
# At the time of writing at least, hitting GitHub with a GET call will consistently make
# HTTP throw HTTP.Parsers.ParseError(:INVALID_STATUS_LINE, ""). Although, hitting different
# servers leads to different errors, and sometimes also works fine.
HTTP.get("https://github.com/", verbose=true, retry=false)
```

Evaluating that `HTTPOverloads` module will lead to a method overwrite:

```
WARNING: Method definition readuntil(Base.GenericIOBuffer{Array{UInt8, 1}}, Function) in module IOExtras at /home/mortenpi/.julia/packages/HTTP/A83Es/src/IOExtras.jl:114 overwritten in module HTTPOverloads at /home/mortenpi/mwe/mwe.jl:9.
```

I would say that the correct fix here would be to get rid of the type piracy altogether (#1021), but this should fix the immediate problem (and therefore allow two different versions of HTTP to be safely loaded in the same Julia session).

I presume `nobytes` is largely just a convenience alias for an empty vector of bytes. So changing the comparison to `==` shouldn't introduce any incorrectness there. I suppose `===` might be there for performance reasons? If yes, them I am not sure if changing it to `==` affects it significantly or not.