### PR TITLE
Fix set_default_connection_limit not being respected

### DIFF
--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -45,7 +45,14 @@ function __init__()
     return
 end
 
-set_default_connection_limit!(n) = default_connection_limit[] = n
+function set_default_connection_limit!(n)
+    default_connection_limit[] = n
+    # reinitialize the global connection pools
+    TCP_POOL[] = CPool{Sockets.TCPSocket}(n)
+    MBEDTLS_POOL[] = CPool{MbedTLS.SSLContext}(n)
+    OPENSSL_POOL[] = CPool{OpenSSL.SSLStream}(n)
+    return
+end
 
 """
     Connection

--- a/test/client.jl
+++ b/test/client.jl
@@ -13,6 +13,7 @@ using InteractiveUtils: @which
 
 # test we can adjust default_connection_limit
 HTTP.set_default_connection_limit!(12)
+@test HTTP.Connections.TCP_POOL[].max == 12
 
 @testset "@client macro" begin
     @eval module MyClient

--- a/test/client.jl
+++ b/test/client.jl
@@ -12,8 +12,12 @@ using URIs
 using InteractiveUtils: @which
 
 # test we can adjust default_connection_limit
-HTTP.set_default_connection_limit!(12)
-@test HTTP.Connections.TCP_POOL[].max == 12
+for x in (10, 12)
+    HTTP.set_default_connection_limit!(x)
+    @test HTTP.Connections.TCP_POOL[].max == x
+    @test HTTP.Connections.MBEDTLS_POOL[].max == x
+    @test HTTP.Connections.OPENSSL_POOL[].max == x
+end
 
 @testset "@client macro" begin
     @eval module MyClient


### PR DESCRIPTION
With all the default global connection pool shuffling that has happened, we missed making sure `set_default_connection_limit!` was still being respected. It was updating the global connection limit ref, but the global pools were still stuck with whatever their values were when first initialized.

This PR reinitializes the global connection pools when the default connection pool limit is changed.