### PR TITLE
Setup Request.url on the server side (issue #1041)

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -54,6 +54,7 @@ function streamhandler(handler)
     return function(stream::Stream)
         request::Request = stream.message
         request.body = read(stream)
+        request.url = URI(request.target)
         closeread(stream)
         request.response::Response = handler(request)
         request.response.request = request


### PR DESCRIPTION
#1041 describes what I need. The fact request.url exists would make the user of the package want to use it but having it always empty and that you have to call URI(request.target).path is not obvious. 
It's a one line change because I don't want to change the other gethandler functions.