### PR TITLE
Request retries respect response

### DIFF
--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -78,6 +78,7 @@ end
 
 const EAI_AGAIN = 2
 isrecoverable(ex) = true
+isrecoverable(ex::CapturedException) = isrecoverable(ex.ex)
 isrecoverable(ex::ConnectError) = ex.error isa Sockets.DNSError && ex.error.code == EAI_AGAIN ? false : true
 isrecoverable(ex::StatusError) = retryable(ex.status)
 


### PR DESCRIPTION
I think we recently increased our usage of `CapturedExceptions` which broke `isrecoverable`, which dispatches on exception type and tries to recover exceptions by default.

Without this PR, the following would hang for 15 minutes.
```julia
import HTTP
HTTP.retryable(status::Int16) = false

using CloudStore
url = "azure://account/container/file.csv"
ok, host, account, container, blob = CloudStore.parseAzureAccountContainerBlob(url)
store =  CloudStore.Azure.Container(container, account; host)
retry_delays = ExponentialBackOff(n=12, max_delay=180, factor=3.0) # ~ 15 minutes of total delay time
credentials = nothing
CloudStore.get(store, blob; credentials, retry_delays, retries=length(retry_delays), verbose=2) # retries 403
```

This would also explain https://github.com/RelationalAI/raicode/pull/13231#discussion_r1180219818