### PR TITLE
Rethrow errors so they may be handled outside of WebSocket.open() 

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -384,6 +384,7 @@ function open(f::Function, url; suppress_close_error::Bool=false, verbose=false,
                     close(ws, CloseFrameBody(1008, "Unexpected client websocket error"))
                 end
             end
+            rethrow(e)
         finally
             if !isclosed(ws)
                 close(ws, CloseFrameBody(1000, ""))


### PR DESCRIPTION
This is a fix for a bug where any errors throw from within WebSocket.open() is hidden from an outer try/catch.

https://github.com/JuliaWeb/HTTP.jl/issues/1067