### PR TITLE
Updated: Rethrow errors so they may be handled outside of WebSocket.open()

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -384,7 +384,9 @@ function open(f::Function, url; suppress_close_error::Bool=false, verbose=false,
                     close(ws, CloseFrameBody(1008, "Unexpected client websocket error"))
                 end
             end
-            rethrow()
+            if !isok(e)
+                rethrow()
+            end
         finally
             if !isclosed(ws)
                 close(ws, CloseFrameBody(1000, ""))

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -384,6 +384,7 @@ function open(f::Function, url; suppress_close_error::Bool=false, verbose=false,
                     close(ws, CloseFrameBody(1008, "Unexpected client websocket error"))
                 end
             end
+            rethrow()
         finally
             if !isclosed(ws)
                 close(ws, CloseFrameBody(1000, ""))

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -451,6 +451,9 @@ function upgrade(f::Function, http::Streams.Stream; suppress_close_error::Bool=f
                 close(ws, CloseFrameBody(1011, "Unexpected server websocket error"))
             end
         end
+        if !isok(e)
+            rethrow()
+        end
     finally
         if !isclosed(ws)
             close(ws, CloseFrameBody(1000, ""))


### PR DESCRIPTION
Addresses comments in #1069 