### PR TITLE
Ensure that unused TCP connections are closed

### DIFF
--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -517,7 +517,11 @@ function getconnection(::Type{TCPSocket},
                 isready(ch) && return
                 keepalive && keepalive!(tcp)
                 Base.@lock ch begin
-                    isready(ch) && return
+                    if isready(ch)
+                        # a valid connection was already made and returned, so close ours
+                        close(tcp)
+                        return
+                    end
                     put!(ch, tcp)
                 end
             catch e


### PR DESCRIPTION
Otherwise, the new preemptive connection strategy can possibly leave a lot of extra connections open until garbage collection kicks in.