### PR TITLE
Remove `readuntil` type piracy

### DIFF
--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -233,13 +233,13 @@ end
 Read until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
-function Base.readuntil(c::Connection, f::F #=Vector{UInt8} -> Int=#,
+function IOExtras.readuntil(c::Connection, f::F #=Vector{UInt8} -> Int=#,
                                         sizehint=4096)::ByteView where {F <: Function}
     buf = c.buffer
     if bytesavailable(buf) == 0
         read_to_buffer(c, sizehint)
     end
-    while (bytes = readuntil(buf, f)) == nobytes
+    while (bytes = IOExtras.readuntil(buf, f)) == nobytes
         read_to_buffer(c, sizehint)
     end
     return bytes

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -12,7 +12,7 @@ using MbedTLS: SSLContext, MbedException
 using OpenSSL: SSLStream
 
 export bytes, isbytes, nbytes, ByteView, nobytes,
-       startwrite, closewrite, startread, closeread,
+       startwrite, closewrite, startread, closeread, readuntil,
        tcpsocket, localport, safe_getpeername
 
 """
@@ -107,11 +107,13 @@ end
 const ByteView = typeof(view(UInt8[], 1:0))
 const nobytes = view(UInt8[], 1:0)
 
+readuntil(args...) = Base.readuntil(args...)
+
 """
 Read from an `IO` stream until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
-function Base.readuntil(buf::IOBuffer,
+function readuntil(buf::IOBuffer,
                     find_delimiter::F #= Vector{UInt8} -> Int =#
                    )::ByteView where {F <: Function}
     l = find_delimiter(view(buf.data, buf.ptr:buf.size))

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -530,7 +530,7 @@ Read headers (and startline) from an `IO` stream into a `Message` struct.
 Throw `EOFError` if input is incomplete.
 """
 function readheaders(io::IO, message::Message)
-    bytes = String(readuntil(io, find_end_of_header))
+    bytes = String(IOExtras.readuntil(io, find_end_of_header))
     bytes = parse_start_line!(bytes, message)
     parse_header_fields!(bytes, message)
     return
@@ -555,9 +555,9 @@ Read chunk-size from an `IO` stream.
 After the final zero size chunk, read trailers into a `Message` struct.
 """
 function readchunksize(io::IO, message::Message)::Int
-    n = parse_chunk_size(readuntil(io, find_end_of_chunk_size))
+    n = parse_chunk_size(IOExtras.readuntil(io, find_end_of_chunk_size))
     if n == 0
-        bytes = readuntil(io, find_end_of_trailer)
+        bytes = IOExtras.readuntil(io, find_end_of_trailer)
         if bytes[2] != UInt8('\n')
             parse_header_fields!(SubString(String(bytes)), message)
         end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -320,10 +320,10 @@ function readall!(http::Stream, buf::Base.GenericIOBuffer=PipeBuffer())
     return n
 end
 
-function Base.readuntil(http::Stream, f::Function)::ByteView
+function IOExtras.readuntil(http::Stream, f::Function)::ByteView
     UInt(ntoread(http)) == 0 && return Connections.nobytes
     try
-        bytes = readuntil(http.stream, f)
+        bytes = IOExtras.readuntil(http.stream, f)
         update_ntoread(http, length(bytes))
         return bytes
     catch e

--- a/test/client.jl
+++ b/test/client.jl
@@ -1,6 +1,7 @@
 module TestClient
 
 using HTTP, HTTP.Exceptions, MbedTLS, OpenSSL
+using HTTP: IOExtras
 include(joinpath(dirname(pathof(HTTP)), "../test/resources/TestRequest.jl"))
 import ..isok, ..httpbin
 using .TestRequest

--- a/test/client.jl
+++ b/test/client.jl
@@ -627,10 +627,10 @@ end
 
 findnewline(bytes) = something(findfirst(==(UInt8('\n')), bytes), 0)
 
-@testset "readuntil on Stream" begin
+@testset "IOExtras.readuntil on Stream" begin
     HTTP.open(:GET, "https://$httpbin/stream/5") do io
         while !eof(io)
-            bytes = readuntil(io, findnewline)
+            bytes = IOExtras.readuntil(io, findnewline)
             isempty(bytes) && break
             x = JSON.parse(IOBuffer(bytes))
         end


### PR DESCRIPTION
This makes sure that the `readuntil` function used by HTTP is owned by the `IOExtras` module, and so that it would be safe to add the currently type-pirated method taking an `IOBuffer`. Towards #1021.

I am not entirely sure what the best approach here is in terms of code maintainability though. Currently, I opted to keep the name the same (`readuntil`) and export it from `IOExtras`, so any module doing `using IOExtras` and using an unqualified `readuntil` will error (as the same name is exported from `Base`).