### PR TITLE
tests and fixes for recoverability of DNS errors

### DIFF
--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -78,15 +78,10 @@ end
 
 isrecoverable(ex) = true
 isrecoverable(ex::CapturedException) = isrecoverable(ex.ex)
+isrecoverable(ex::ConnectError) = isrecoverable(ex.error)
 # Treat all DNS errors except `EAI_AGAIN`` as non-recoverable
 # Ref: https://github.com/JuliaLang/julia/blob/ec8df3da3597d0acd503ff85ac84a5f8f73f625b/stdlib/Sockets/src/addrinfo.jl#L108-L112
-function isrecoverable(ex::ConnectError)
-    if ex.error isa Sockets.DNSError
-        return (ex.error.code == Base.UV_EAI_AGAIN) ? true : false
-    else
-        return true
-    end
-end
+isrecoverable(ex::Sockets.DNSError) = (ex.code == Base.UV_EAI_AGAIN)
 isrecoverable(ex::StatusError) = retryable(ex.status)
 
 function _retry_check(s, ex, req, check)

--- a/test/client.jl
+++ b/test/client.jl
@@ -625,6 +625,37 @@ end
     end
 end
 
+@testset "Retry with ConnectError" begin
+    mktemp() do path, io
+        redirect_stdout(io) do
+            redirect_stderr(io) do
+                try
+                    HTTP.request("GET", "http://n0nexist3nthost/"; verbose=true)
+                catch
+                    # ignore
+                end
+            end
+        end
+        close(io)
+        logs = read(path, String)
+
+        if occursin("EAI_NODATA", logs)
+            @test occursin("No Retry: GET / HTTP/1.1", logs)
+        elseif occursin("EAI_EAGAIN", logs)
+            # interestingly some environments also result in EAGAIN in these cases
+            @test occursin("Retry HTTP.Exceptions.ConnectError", logs)
+        end
+    end
+
+    # isrecoverable tests
+    @test HTTP.RetryRequest.isrecoverable(nothing)
+    @test HTTP.RetryRequest.isrecoverable(ErrorException(""))
+    @test HTTP.RetryRequest.isrecoverable(Sockets.DNSError("localhost", Base.UV_EAI_AGAIN))
+    @test !HTTP.RetryRequest.isrecoverable(Sockets.DNSError("localhost", Base.UV_EAI_NONAME))
+    @test HTTP.RetryRequest.isrecoverable(HTTP.Exceptions.ConnectError("http://localhost", Sockets.DNSError("localhost", Base.UV_EAI_AGAIN)))
+    @test !HTTP.RetryRequest.isrecoverable(HTTP.Exceptions.ConnectError("http://localhost", Sockets.DNSError("localhost", Base.UV_EAI_NONAME)))
+end
+
 findnewline(bytes) = something(findfirst(==(UInt8('\n')), bytes), 0)
 
 @testset "readuntil on Stream" begin


### PR DESCRIPTION
Added some tests for `isrecoverable`, particularly for DNS errors. Added a test for one of the new behaviors, i.e. EAI_NONAME is not retried.

ref: #1088