### PR TITLE
feat(server): spawn task sooner in listenloop + fast accept

### DIFF
--- a/docs/examples/cors_server.jl
+++ b/docs/examples/cors_server.jl
@@ -39,7 +39,7 @@ const CORS_RES_HEADERS = ["Access-Control-Allow-Origin" => "*"]
 #= 
 JSONMiddleware minimizes code by automatically converting the request body
 to JSON to pass to the other service functions automatically. JSONMiddleware
-recieves the body of the response from the other service funtions and sends
+receives the body of the response from the other service funtions and sends
 back a success response code
 =#
 function JSONMiddleware(handler)
@@ -65,9 +65,9 @@ function JSONMiddleware(handler)
 end
 
 #= CorsMiddleware: handles preflight request with the OPTIONS flag
-If a request was recieved with the correct headers, then a response will be 
+If a request was received with the correct headers, then a response will be 
 sent back with a 200 code, if the correct headers were not specified in the request,
-then a CORS error will be recieved on the client side
+then a CORS error will be received on the client side
 
 Since each request passes throught the CORS Handler, then if the request is 
 not a preflight request, it will simply go to the JSONMiddleware to be passed to the

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -77,6 +77,7 @@ include("clientlayers/ConnectionRequest.jl");        using .ConnectionRequest
 include("clientlayers/StreamRequest.jl");            using .StreamRequest
 
 include("download.jl")
+include("accept.jl")
 include("Servers.jl")                  ;using .Servers; using .Servers: listen
 include("Handlers.jl")                 ;using .Handlers; using .Handlers: serve
 include("parsemultipart.jl")           ;using .MultiPartParsing: parse_multipart_form

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -453,7 +453,7 @@ function listenloop(f, listener, conns, tcpisvalid,
                         end
                         max_connections < typemax(Int) && Base.release(sem)
                     end
-                end  # Task.@spawn
+                end  # @async
             end
         catch e
             if e isa Base.IOError && e.code == Base.UV_ECONNABORTED

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -16,6 +16,7 @@ using MbedTLS: SSLContext, SSLConfig
 using ConcurrentUtilities: ConcurrentUtilities, Lockable, lock
 using ..IOExtras, ..Streams, ..Messages, ..Parsers, ..Connections, ..Exceptions
 import ..access_threaded, ..SOCKET_TYPE_TLS, ..@logfmt_str
+using ..Accept: acceptmany
 
 TRUE(x) = true
 getinet(host::String, port::Integer) = Sockets.InetAddr(parse(IPAddr, host), port)
@@ -366,47 +367,6 @@ function listen!(f, listener::Listener;
     return Server(listener, on_shutdown, conns, tsk)
 end
 
-using Base: iolock_begin, iolock_end, uv_error, preserve_handle, unpreserve_handle,
-    StatusClosing, StatusClosed, StatusActive, UV_EAGAIN, UV_ECONNABORTED
-using Sockets: accept_nonblock
-
-function acceptmany(server; MAXSIZE=Sockets.BACKLOG_DEFAULT)
-    result = Vector{TCPSocket}()
-    sizehint!(result, MAXSIZE)
-    iolock_begin()
-    if server.status != StatusActive && server.status != StatusClosing && server.status != StatusClosed
-        throw(ArgumentError("server not connected, make sure \"listen\" has been called"))
-    end
-    while isopen(server)
-        client = TCPSocket()
-        err = Sockets.accept_nonblock(server, client)
-        while err == 0 && length(result) < MAXSIZE  # Don't try to fill more than half the buffer
-            push!(result, client)
-            client = TCPSocket()
-            err = Sockets.accept_nonblock(server, client)
-        end
-        if length(result) > 0
-            iolock_end()
-            return result
-        end
-        if err != UV_EAGAIN
-            uv_error("accept", err)
-        end
-        preserve_handle(server)
-        lock(server.cond)
-        iolock_end()
-        try
-            wait(server.cond)
-        finally
-            unlock(server.cond)
-            unpreserve_handle(server)
-        end
-        iolock_begin()
-    end
-    uv_error("accept", UV_ECONNABORTED)
-    nothing
-end
-
 """"
 Main server loop.
 Accepts new tcp connections and spawns async tasks to handle them."
@@ -421,8 +381,10 @@ function listenloop(f, listener, conns, tcpisvalid,
     while isopen(listener)
         try
             for io in acceptmany(listener.server)
+                # I would prefer this inside the async, so we can loop and accept again, 
+                # but https://github.com/JuliaWeb/HTTP.jl/pull/647/files says it's bad for performance
+                max_connections < typemax(Int) && Base.acquire(sem)
                 @async begin
-                    max_connections < typemax(Int) && Base.acquire(sem)
                     local conn = nothing
                     isssl = !isnothing(listener.ssl)
                     try

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -13,6 +13,7 @@ export listen, listen!, Server, forceclose, port
 
 using Sockets, Logging, LoggingExtras, MbedTLS, Dates
 using MbedTLS: SSLContext, SSLConfig
+using ConcurrentUtilities: Lockable, lock
 using ..IOExtras, ..Streams, ..Messages, ..Parsers, ..Connections, ..Exceptions
 import ..access_threaded, ..SOCKET_TYPE_TLS, ..@logfmt_str
 
@@ -83,10 +84,19 @@ accept(s::Listener{SSLConfig}) = getsslcontext(Sockets.accept(s.server), s.ssl)
 
 function getsslcontext(tcp, sslconfig)
     try
+        handshake_done = Ref{Bool}(false)
         ssl = MbedTLS.SSLContext()
         MbedTLS.setup!(ssl, sslconfig)
         MbedTLS.associate!(ssl, tcp)
-        MbedTLS.handshake!(ssl)
+        handshake_task = @async begin
+            MbedTLS.handshake!(ssl)
+            handshake_done[] = true
+        end
+        timedwait(5.0) do
+            handshake_done[] || istaskdone(handshake_task)
+        end
+        !istaskdone(handshake_task) && wait(handshake_task)
+        handshake_done[] || throw(Base.IOError("SSL handshake timed out", Base.ETIMEDOUT))
         return ssl
     catch e
         @try Base.IOError close(tcp)
@@ -363,31 +373,46 @@ Accepts new tcp connections and spawns async tasks to handle them."
 function listenloop(f, listener, conns, tcpisvalid,
                        max_connections, readtimeout, access_log, ready_to_accept, verbose)
     sem = Base.Semaphore(max_connections)
+    ssl = Lockable(listener.ssl)
+    connections = Lockable(conns)
     verbose >= 0 && @infov 1 "Listening on: $(listener.hostname):$(listener.hostport), thread id: $(Threads.threadid())"
     notify(ready_to_accept)
     while isopen(listener)
         try
             Base.acquire(sem)
-            io = accept(listener)
-            if io === nothing
-                @warnv 1 "unable to accept new connection"
-                continue
-            elseif !tcpisvalid(io)
-                @warnv 1 "!tcpisvalid: $io"
-                close(io)
-                continue
-            end
-            conn = Connection(io)
-            conn.state = IDLE
-            push!(conns, conn)
-            conn.host, conn.port = listener.hostname, listener.hostport
-            @async try
-                handle_connection(f, conn, listener, readtimeout, access_log)
-            finally
-                # handle_connection is in charge of closing the underlying io
-                delete!(conns, conn)
-                Base.release(sem)
-            end
+            io = Sockets.accept(listener.server)
+            Threads.@spawn begin
+                local conn = nothing
+                isssl = !isnothing(listener.ssl)
+                try
+                    if io === nothing
+                        @warnv 1 "unable to accept new connection"
+                        return
+                    end
+                    if isssl
+                        io = lock(ssl) do ssl
+                            return getsslcontext(io, ssl)
+                        end
+                    end
+                    if !tcpisvalid(io)
+                        close(io)
+                        return
+                    end
+                    conn = Connection(io)
+                    conn.state = IDLE
+                    lock(connections) do conns
+                        push!(conns, conn)
+                    end
+                    conn.host, conn.port = listener.hostname, listener.hostport
+                    handle_connection(f, conn, listener, readtimeout, access_log)
+                finally
+                    # handle_connection is in charge of closing the underlying io, but it may not get there
+                    !isnothing(conn) && lock(connections) do conns
+                        delete!(conns, conn)
+                    end
+                    Base.release(sem)
+                end
+            end  # Task.@spawn
         catch e
             if e isa Base.IOError && e.code == Base.UV_ECONNABORTED
                 verbose >= 0 && @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
@@ -442,7 +467,7 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
             request.response.status = 200
 
             try
-                # invokelatest becuase the perf is negligible, but this makes live-editing handlers more Revise friendly
+                # invokelatest because the perf is negligible, but this makes live-editing handlers more Revise friendly
                 @debugv 1 "invoking handler"
                 Base.invokelatest(f, http)
                 # If `startwrite()` was never called, throw an error so we send a 500 and log this

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -587,7 +587,7 @@ function Base.close(ws::WebSocket, body::CloseFrameBody=CloseFrameBody(1000, "")
             ws.readclosed = true
         end
     end
-    # we either recieved the responding CLOSE frame and readclosed was set
+    # we either received the responding CLOSE frame and readclosed was set
     # or there was an error/timeout reading it; in any case, readclosed should be closed now
     @assert ws.readclosed
     # if we're the server, it's our job to close the underlying socket

--- a/src/accept.jl
+++ b/src/accept.jl
@@ -1,0 +1,47 @@
+
+module Accept
+
+export acceptmany
+
+using Base: iolock_begin, iolock_end, uv_error, preserve_handle, unpreserve_handle,
+    StatusClosing, StatusClosed, StatusActive, UV_EAGAIN, UV_ECONNABORTED
+using Sockets
+
+function acceptmany(server; MAXSIZE=Sockets.BACKLOG_DEFAULT)
+    result = Vector{TCPSocket}()
+    sizehint!(result, MAXSIZE)
+    iolock_begin()
+    if server.status != StatusActive && server.status != StatusClosing && server.status != StatusClosed
+        throw(ArgumentError("server not connected, make sure \"listen\" has been called"))
+    end
+    while isopen(server)
+        client = TCPSocket()
+        err = Sockets.accept_nonblock(server, client)
+        while err == 0 && length(result) < MAXSIZE  # Don't try to fill more than half the buffer
+            push!(result, client)
+            client = TCPSocket()
+            err = Sockets.accept_nonblock(server, client)
+        end
+        if length(result) > 0
+            iolock_end()
+            return result
+        end
+        if err != UV_EAGAIN
+            uv_error("accept", err)
+        end
+        preserve_handle(server)
+        lock(server.cond)
+        iolock_end()
+        try
+            wait(server.cond)
+        finally
+            unlock(server.cond)
+            unpreserve_handle(server)
+        end
+        iolock_begin()
+    end
+    uv_error("accept", UV_ECONNABORTED)
+    nothing
+end
+
+end


### PR DESCRIPTION
So, this is a bit speculative, but I'm very very concerned about the backlog getting big; I think it's always a good idea to get through as many accepts as possible, _before_ spawning the tasks to handle the connections. This builds on https://github.com/JuliaWeb/HTTP.jl/pull/1102 and adds a `acceptmany` function that returns a vector of accepted connections, if they are available.

I've run some benchmarks (this [commit](https://github.com/pankgeorg/FrameworkBenchmarks/commit/51aecffebbea13bf328e1d4696f061f79dccd928)) on this and it seems that it helps for the benchmarks that are connection intensive:

see latency-average for plaintext and json (the db related queries also benefit from [async query send](https://github.com/iamed2/LibPQ.jl/pull/280))

```
+-----------------------------------------------+
|       Type: fortune, Result: latencyAvg       |
+-------------------+---------+-----------------+
| concurrencyLevels | http-jl | http-jl-patched |
+-------------------+---------+-----------------+
|                16 |  4.37ms |          4.41ms |
|                32 |  4.53ms |          4.35ms |
|                64 |  5.43ms |          5.71ms |
|               128 |  6.72ms |          6.05ms |
|               256 | 26.63ms |         19.72ms |
|               512 | 41.97ms |         34.58ms |
+-------------------+---------+-----------------+

+--------------------------------------------------------+
|          Type: plaintext, Result: latencyAvg           |
+---------------------------+----------+-----------------+
| pipelineConcurrencyLevels |  http-jl | http-jl-patched |
+---------------------------+----------+-----------------+
|                       256 | 121.11ms |         69.99ms |
|                      1024 | 253.44ms |        130.26ms |
|                      4096 | 210.46ms |        158.88ms |
|                     16384 | 628.35ms |        526.72ms |
+---------------------------+----------+-----------------+

+-----------------------------------------------+
|          Type: db, Result: latencyAvg         |
+-------------------+---------+-----------------+
| concurrencyLevels | http-jl | http-jl-patched |
+-------------------+---------+-----------------+
|                16 |  2.90ms |          3.56ms |
|                32 |  3.69ms |          3.54ms |
|                64 |  4.85ms |          4.70ms |
|               128 |  5.28ms |          5.35ms |
|               256 | 26.99ms |         19.78ms |
|               512 | 37.59ms |         32.57ms |
+-------------------+---------+-----------------+

+------------------------------------------------+
|        Type: update, Result: latencyAvg        |
+-------------------+----------+-----------------+
| concurrencyLevels |  http-jl | http-jl-patched |
+-------------------+----------+-----------------+
|                16 |  47.18ms |         45.10ms |
|                32 | 217.47ms |        219.50ms |
|                64 | 434.74ms |        412.98ms |
|               128 | 622.48ms |        604.69ms |
|               256 | 865.47ms |        816.59ms |
+-------------------+----------+-----------------+

+------------------------------------------------+
|         Type: json, Result: latencyAvg         |
+-------------------+----------+-----------------+
| concurrencyLevels |  http-jl | http-jl-patched |
+-------------------+----------+-----------------+
|                16 | 163.85us |        153.34us |
|                32 | 163.61us |        150.35us |
|                64 |   1.40ms |        553.35us |
|               128 |   1.50ms |        486.40us |
|               256 |   6.25ms |          4.13ms |
|               512 |   7.99ms |          3.57ms |
+-------------------+----------+-----------------+

+---------------------------------------------+
|       Type: query, Result: latencyAvg       |
+----------------+----------+-----------------+
| queryIntervals |  http-jl | http-jl-patched |
+----------------+----------+-----------------+
|              1 |  35.18ms |         31.81ms |
|              5 | 132.25ms |        120.80ms |
|             10 | 257.01ms |        234.04ms |
|             15 | 373.05ms |        338.24ms |
|             20 | 486.86ms |        459.46ms |
+----------------+----------+-----------------+

+-----------------------------------------------+
|      Type: fortune, Result: totalRequests     |
+-------------------+---------+-----------------+
| concurrencyLevels | http-jl | http-jl-patched |
+-------------------+---------+-----------------+
|                16 |  54,946 |          54,549 |
|                32 | 106,102 |         110,678 |
|                64 | 178,001 |         171,313 |
|               128 | 179,736 |         199,352 |
|               256 | 219,430 |         241,545 |
|               512 | 234,065 |         248,983 |
+-------------------+---------+-----------------+

+----------------------------------------------------------+
|          Type: plaintext, Result: totalRequests          |
+---------------------------+------------+-----------------+
| pipelineConcurrencyLevels |    http-jl | http-jl-patched |
+---------------------------+------------+-----------------+
|                       256 |  9,638,599 |      10,832,911 |
|                      1024 | 10,132,321 |      12,119,105 |
|                      4096 |  8,297,343 |       8,745,954 |
|                     16384 |  6,745,883 |       7,421,888 |
+---------------------------+------------+-----------------+

+-----------------------------------------------+
|        Type: db, Result: totalRequests        |
+-------------------+---------+-----------------+
| concurrencyLevels | http-jl | http-jl-patched |
+-------------------+---------+-----------------+
|                16 |  82,778 |          67,685 |
|                32 | 130,414 |         138,148 |
|                64 | 205,705 |         205,374 |
|               128 | 228,337 |         224,848 |
|               256 | 263,888 |         285,058 |
|               512 | 279,247 |         295,292 |
+-------------------+---------+-----------------+

+-----------------------------------------------+
|      Type: update, Result: totalRequests      |
+-------------------+---------+-----------------+
| concurrencyLevels | http-jl | http-jl-patched |
+-------------------+---------+-----------------+
|                16 | 164,456 |         167,064 |
|                32 |  33,999 |          34,727 |
|                64 |  17,020 |          17,632 |
|               128 |  11,639 |          11,875 |
|               256 |   8,472 |           8,757 |
+-------------------+---------+-----------------+

+-------------------------------------------------+
|        Type: json, Result: totalRequests        |
+-------------------+-----------+-----------------+
| concurrencyLevels |   http-jl | http-jl-patched |
+-------------------+-----------+-----------------+
|                16 | 1,572,458 |       1,684,229 |
|                32 | 3,150,079 |       3,470,513 |
|                64 | 4,912,047 |       5,626,121 |
|               128 | 5,854,543 |       5,812,078 |
|               256 | 7,094,927 |       7,763,330 |
|               512 | 7,132,833 |       8,553,204 |
+-------------------+-----------+-----------------+

+--------------------------------------------+
|     Type: query, Result: totalRequests     |
+----------------+---------+-----------------+
| queryIntervals | http-jl | http-jl-patched |
+----------------+---------+-----------------+
|              1 | 281,056 |         293,010 |
|              5 |  62,317 |          65,484 |
|             10 |  30,851 |          32,613 |
|             15 |  20,595 |          22,229 |
|             20 |  15,926 |          16,422 |
+----------------+---------+-----------------+

```