### PR TITLE
tests: Use ARGS to choose which tests to run

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,11 @@
 using Test, HTTP, JSON
 
-const dir = joinpath(dirname(pathof(HTTP)), "..", "test")
-
+# See https://httpbingo.julialang.org/
 const httpbin = get(ENV, "JULIA_TEST_HTTPBINGO_SERVER", "httpbingo.julialang.org")
 
+# A convenient test helper used in a few test files.
 isok(r) = r.status == 200
 
-include(joinpath(dir, "resources/TestRequest.jl"))
 @testset "HTTP" begin
     testfiles = [
         "ascii.jl",
@@ -35,8 +34,7 @@ include(joinpath(dir, "resources/TestRequest.jl"))
         filter!(in(ARGS), testfiles)
     end
     for filename in testfiles
-        filepath = joinpath(dir, filename)
-        println("Running $filepath tests...")
-        include(filepath)
+        println("Running $filename tests...")
+        include(joinpath(@__DIR__, filename))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using Test, HTTP, JSON
 
+# Using this rather than @__DIR__ because then it's easier to run parts of the
+# file at the REPL, which is convenient when developing the package.
+const dir = joinpath(dirname(pathof(HTTP)), "..", "test")
+
 # See https://httpbingo.julialang.org/
 const httpbin = get(ENV, "JULIA_TEST_HTTPBINGO_SERVER", "httpbingo.julialang.org")
 
@@ -35,6 +39,6 @@ isok(r) = r.status == 200
     end
     for filename in testfiles
         println("Running $filename tests...")
-        include(joinpath(@__DIR__, filename))
+        include(joinpath(dir, filename))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,33 +8,35 @@ isok(r) = r.status == 200
 
 include(joinpath(dir, "resources/TestRequest.jl"))
 @testset "HTTP" begin
-    for f in [
-            "ascii.jl",
-            "chunking.jl",
-            "utils.jl",
-            "client.jl",
-            # "download.jl",
-            "multipart.jl",
-            "parsemultipart.jl",
-            "sniff.jl",
-            "cookies.jl",
-            "parser.jl",
-            "loopback.jl",
-            "websockets/deno_client/server.jl",
-            "messages.jl",
-            "handlers.jl",
-            "server.jl",
-            "async.jl",
-            "mwe.jl",
-            "httpversion.jl",
-            "websockets/autobahn.jl",
-            ]
-        file = joinpath(dir, f)
-        println("Running $file tests...")
-        if isfile(file)
-            include(file)
-        else
-            @show readdir(dirname(file))
-        end
+    testfiles = [
+        "ascii.jl",
+        "chunking.jl",
+        "utils.jl",
+        "client.jl",
+        # "download.jl",
+        "multipart.jl",
+        "parsemultipart.jl",
+        "sniff.jl",
+        "cookies.jl",
+        "parser.jl",
+        "loopback.jl",
+        "websockets/deno_client/server.jl",
+        "messages.jl",
+        "handlers.jl",
+        "server.jl",
+        "async.jl",
+        "mwe.jl",
+        "httpversion.jl",
+        "websockets/autobahn.jl",
+    ]
+    # ARGS can be most easily passed like this:
+    # import Pkg; Pkg.test("HTTP"; test_args=`ascii.jl parser.jl`)
+    if !isempty(ARGS)
+        filter!(in(ARGS), testfiles)
+    end
+    for filename in testfiles
+        filepath = joinpath(dir, filename)
+        println("Running $filepath tests...")
+        include(filepath)
     end
 end


### PR DESCRIPTION
ARGS can be specified like this:

	Pkg.test("HTTP"; test_args=`ascii.jl parser.jl`)
	# or
	Pkg.test("HTTP"; test_args=["ascii.jl", "parser.jl"])

This is useful because the whole test suite takes ages to run.