### PR TITLE
Don't retry on internal exceptions

### DIFF
--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -1,6 +1,6 @@
 module RetryRequest
 
-using Sockets, LoggingExtras, MbedTLS, OpenSSL
+using Sockets, LoggingExtras, MbedTLS, OpenSSL, ExceptionUnwrapping
 using ..IOExtras, ..Messages, ..Strings, ..ExceptionRequest, ..Exceptions
 
 export retrylayer
@@ -67,7 +67,7 @@ function retrylayer(handler)
                         mark(req.body)
                     end
                 else
-                    @debugv 1 "🚷  No Retry: $(no_retry_reason(ex, req))"
+                    @debugv 1 "🚷  No Retry: $(no_retry_reason(unwrapped_ex, req))"
                 end
                 return s, retry
             end
@@ -76,12 +76,10 @@ function retrylayer(handler)
     end
 end
 
-isrecoverable(ex) = true
-isrecoverable(ex::ArgumentError) = false
-isrecoverable(ex::ErrorException) = false
-isrecoverable(ex::RequestError) = isrecoverable(ex.error)
-isrecoverable(ex::CapturedException) = isrecoverable(ex.ex)
-isrecoverable(ex::ConnectError) = isrecoverable(ex.error)
+isrecoverable(ex) = is_wrapped_exception(ex) ? isrecoverable(unwrap_exception(ex)) : false
+isrecoverable(::Union{Base.EOFError, Base.IOError, MbedTLS.MbedException, OpenSSL.OpenSSLError}) = true
+isrecoverable(ex::ArgumentError) = ex.msg == "stream is closed or unusable"
+isrecoverable(ex::CompositeException) = all(isrecoverable, ex.exceptions)
 # Treat all DNS errors except `EAI_AGAIN`` as non-recoverable
 # Ref: https://github.com/JuliaLang/julia/blob/ec8df3da3597d0acd503ff85ac84a5f8f73f625b/stdlib/Sockets/src/addrinfo.jl#L108-L112
 isrecoverable(ex::Sockets.DNSError) = (ex.code == Base.UV_EAI_AGAIN)
@@ -95,9 +93,11 @@ end
 
 function no_retry_reason(ex, req)
     buf = IOBuffer()
+    unwrapped_ex = unwrap_exception(ex)
     show(IOContext(buf, :compact => true), req)
     print(buf, ", ",
-        ex isa StatusError ? "HTTP $(ex.status): " :
+        unwrapped_ex isa StatusError ? "HTTP $(ex.status): " :
+        !isrecoverable(unwrapped_ex) ? "unrecoverable exception: " :
         !isbytes(req.body) ? "request streamed, " : "",
         !isbytes(req.response.body) ? "response streamed, " : "",
         !isidempotent(req) ? "$(req.method) non-idempotent" : "")

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -77,6 +77,9 @@ function retrylayer(handler)
 end
 
 isrecoverable(ex) = true
+isrecoverable(ex::ArgumentError) = false
+isrecoverable(ex::ErrorException) = false
+isrecoverable(ex::RequestError) = isrecoverable(ex.error)
 isrecoverable(ex::CapturedException) = isrecoverable(ex.ex)
 isrecoverable(ex::ConnectError) = isrecoverable(ex.error)
 # Treat all DNS errors except `EAI_AGAIN`` as non-recoverable

--- a/src/clientlayers/RetryRequest.jl
+++ b/src/clientlayers/RetryRequest.jl
@@ -67,7 +67,7 @@ function retrylayer(handler)
                         mark(req.body)
                     end
                 else
-                    @debugv 1 "🚷  No Retry: $(no_retry_reason(unwrapped_ex, req))"
+                    @debugv 1 "🚷  No Retry: $(no_retry_reason(ex, req))"
                 end
                 return s, retry
             end

--- a/test/resources/TestRequest.jl
+++ b/test/resources/TestRequest.jl
@@ -55,3 +55,25 @@ end
 HTTP.@client (first=[testouterrequestlayer], last=[testinnerrequestlayer]) (first=[testouterstreamlayer], last=[testinnerstreamlayer])
 
 end
+
+module ErrorRequest
+
+using HTTP
+
+function throwingrequestlayer(handler)
+    return function(req; request_exception=nothing, kw...)
+        !isnothing(request_exception) && throw(request_exception)
+        return handler(req; kw...)
+    end
+end
+
+function throwingstreamlayer(handler)
+    return function(stream; stream_exception=nothing, kw...)
+        !isnothing(stream_exception) && throw(stream_exception)
+        return handler(stream; kw...)
+    end
+end
+
+HTTP.@client (throwingrequestlayer,) (throwingstreamlayer,)
+
+end


### PR DESCRIPTION
Previously, we'd retry on exceptions happening inside layers, e.g. when cloudsign layer in CloudStore.jl decodes base64 encoded SAS tokens and if those are malformed we could get an `ArgumentException`