### PR TITLE
fix: prevent `HEAD` requests from writing body in streamhandler

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -58,7 +58,9 @@ function streamhandler(handler)
         request.response::Response = handler(request)
         request.response.request = request
         startwrite(stream)
-        write(stream, request.response.body)
+        if request.method != "HEAD"
+            write(stream, request.response.body)
+        end
         return
     end
 end

--- a/test/server.jl
+++ b/test/server.jl
@@ -313,4 +313,23 @@ end # @testset
     @test occursin(r"^\*/\* text/plain HEAD / HTTP/1\.1 HEAD / 127\.0\.0\.1 \d+ - HTTP/1\.1 \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.* \d+/.*/\d{4}:\d{2}:\d{2}:\d{2}.* 200 0$", logs[4].message)
 end
 
+@testset "HEAD request without body" begin
+    sometext = "This is a big body that we don't want returned during a head"
+    handler = req -> begin
+        return HTTP.Response(200, [], sometext)
+    end
+    server = HTTP.serve!(handler; listenany=true)
+    port = HTTP.port(server)
+
+    response = HTTP.head("http://localhost:$port")
+    @test response.status == 200
+    @test String(response.body) == ""
+
+    response = HTTP.get("http://localhost:$port")
+    @test response.status == 200
+    @test String(response.body) == sometext
+
+    close(server)
+end
+
 end # module


### PR DESCRIPTION
(Note: if you're using your own `streamhandler`, you're on your own)
fixes: https://github.com/JuliaWeb/HTTP.jl/issues/1112

with this fix, 3 connections fly over the same connection with cURL

```
curl -Ivvvvvvvvvvvvvvvv http://localhost:1234 http://localhost:1234 http://localhost:1234
*   Trying 127.0.0.1:1234...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 1234 (#0)
> HEAD / HTTP/1.1
> Host: localhost:1234
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK

<
* Connection #0 to host localhost left intact
* Found bundle for host localhost: 0x563e0dc11eb0 [serially]
* Can not multiplex, even if we wanted to!
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 1234 (#0)
> HEAD / HTTP/1.1
> Host: localhost:1234
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK

<
* Connection #0 to host localhost left intact
* Found bundle for host localhost: 0x563e0dc11eb0 [serially]
* Can not multiplex, even if we wanted to!
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 1234 (#0)
> HEAD / HTTP/1.1
> Host: localhost:1234
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK

<
* Connection #0 to host localhost left intact
```