### PR TITLE
Fix Handlers.getcookies erroring

### DIFF
--- a/src/Handlers.jl
+++ b/src/Handlers.jl
@@ -496,6 +496,6 @@ are expected to be stored in the `req.context[:cookies]` of the
 request context as implemented in the [`HTTP.Handlers.cookie_middleware`](@ref)
 middleware.
 """
-getcookies(req) = get(() => Cookie[], req.context, :cookies)
+getcookies(req) = get(() -> Cookie[], req.context, :cookies)
 
 end # module

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -77,4 +77,8 @@ using HTTP, Test
     @test r(HTTP.Request("GET", "/api/widgets/abc/subwidget")) == 15
     @test r(HTTP.Request("GET", "/api/widgets/abc/subwidgetname")) == 16
 
+    cookie = HTTP.Cookie("abc", "def")
+    req = HTTP.Request("GET", "/")
+    req.context[:cookies] = [cookie]
+    @test HTTP.getcookies(req)[1] == cookie
 end


### PR DESCRIPTION
Hi!

Presently if you do HTTP.getcookies(req), you get:
`ERROR: MethodError: no method matching get(::Pair{Tuple{}, Vector{HTTP.Cookies.Cookie}}, ::Dict{Symbol, Any}, ::Symbol)`

This is because the definition of getcookies contained `() => Cookie[]` instead of `() -> Cookie[]`.

This PR fixes the error and proposes a basic test to verify that we can call `getcookies` on a request without an error.