### PR TITLE
Don't serialize server errors to client.

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -467,7 +467,6 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
                 if isopen(http) && !iswritable(http)
                     request.response.status = 500
                     startwrite(http)
-                    write(http, sprint(showerror, e))
                     closewrite(http)
                 end
                 c.state = CLOSING

--- a/test/client.jl
+++ b/test/client.jl
@@ -611,7 +611,7 @@ end
         shouldfail[] = true
         seekstart(req_body)
         resp = HTTP.get("http://localhost:8080/retry"; body=req_body, response_stream=res_body, retry=false, status_exception=false)
-        @test String(take!(res_body)) == "500 unexpected error"
+        @test resp.status == 500
         # even if StatusError, we should still get the right response body
         shouldfail[] = true
         seekstart(req_body)
@@ -620,7 +620,6 @@ end
         catch e
             @test e isa HTTP.StatusError
             @test e.status == 500
-            @test String(take!(res_body)) == "500 unexpected error"
         end
         # don't throw a 500, but set status to status we don't retry by default
         shouldfail[] = false


### PR DESCRIPTION
Server side errors may contain just about anything, such as e.g. secrets, and, therefore, it seems like a bad idea to unconditionally send these back to the client. In general, there is nothing a client can do about an internal server error even if the specific internal error message is known. The server developer can already see the error in server logs so there isn't really any loss of information.

If the current behavior is actually desired it can be achieved by an outer `try-catch` in the handler function. (Of course, an outer `try-catch` can also be used to make sure that a server side error never ends up at the client, but it is better to be safe by default.)

Concrete example with a server that itself sends a request to another upstream server that requires authentication:
```julia
using HTTP

function handle_request(http::HTTP.Stream)
    target = http.message.target
    if target == "/upstream"
        while !eof(http)
            @show readavailable(http)
        end
        HTTP.startwrite(http)
        error()
    else
        # Fetch something from another server and send back to client. This will err
        body = "hello, world"
        r = HTTP.post("http://localhost:8123/upstream", ["Authorization" => "hunter2"], body)
    end
end

server = HTTP.listen!(handle_request, "127.0.0.1", 8123)
```

This is the output from curl:
```
$ curl localhost:8123
HTTP.RequestError:
HTTP.Request:
HTTP.Messages.Request:
"""
POST /upstream HTTP/1.1
Authorization: hunter2                     # !!
Host: localhost:8123
Accept: */*
User-Agent: HTTP.jl/1.9.4
Content-Length: 12
Accept-Encoding: gzip

hello, world"""Underlying error:
EOFError: read end of file
```