### PR TITLE
Close connection without response on status code 444

### DIFF
--- a/test/server.jl
+++ b/test/server.jl
@@ -226,6 +226,19 @@ end # @testset
     @test TEST_COUNT[] == 4
 end # @testset
 
+@testset "444" begin
+    server = HTTP.listen!() do http
+        HTTP.setstatus(http, 444)
+    end
+    port = server.listener.hostport
+    try
+        errr = try HTTP.get("http://localhost:$(port)", retry=false) catch e e end
+        @test errr isa HTTP.RequestError && errr.error isa EOFError
+    finally
+        close(server)
+    end
+end
+
 @testset "access logging" begin
     local handler = (http) -> begin
         if http.message.target == "/internal-error"


### PR DESCRIPTION
This patch adds the ability for stream handlers to bail out on a request and tell the internal HTTP.jl code to simply close the connection and to ignore any remaining data to be read or written.

This is done by setting the response status code to the non-standard value 444, just like in nginx. If the status code is set to 444 when the request handler returns, the internal server code simply closes the connection. In particular this will skip calling `closeread` and `closewrite`, which both do some "consistency checks" that can't be avoided by using something like

```julia
HTTP.setstatus(http, 444)
close(http.stream)
```

inside the request handler function directly.