### PR TITLE
Don't uses log-with-verbosity macros with `current_exceptions_to_string`

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -394,7 +394,7 @@ function listenloop(f, listener, conns, tcpisvalid,
                 verbose >= 0 && @infov 1 "Server on $(listener.hostname):$(listener.hostport) closing"
             else
                 msg = current_exceptions_to_string()
-                @errorv 2 "Server on $(listener.hostname):$(listener.hostport) errored. $msg"
+                @error "Server on $(listener.hostname):$(listener.hostport) errored. $msg"
                 # quick little sleep in case there's a temporary
                 # local error accepting and this might help avoid quickly re-erroring
                 sleep(0.05 + rand() * 0.05)
@@ -434,7 +434,7 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
                     write(c, Response(e.code == :HEADER_SIZE_EXCEEDS_LIMIT ? 431 : 400, string(e.code)))
                 end
                 msg = current_exceptions_to_string()
-                @debugv 1 "handle_connection startread error. $msg"
+                @warn "handle_connection startread error. $msg"
                 break
             end
 
@@ -462,7 +462,7 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
                 # anyone can do about it on this side. No reason to log an error in that case.
                 level = e isa Base.IOError && !isopen(c) ? Logging.Debug : Logging.Error
                 msg = current_exceptions_to_string()
-                @logmsgv 1 level "handle_connection handler error. $msg"
+                @warn "handle_connection handler error. $msg"
 
                 if isopen(http) && !iswritable(http)
                     request.response.status = 500
@@ -480,7 +480,7 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
     catch
         # we should be catching everything inside the while loop, but just in case
         msg = current_exceptions_to_string()
-        @errorv 1 "error while handling connection. $msg"
+        @error "error while handling connection. $msg"
     finally
         if readtimeout > 0
             wait_for_timeout[] = false

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -440,8 +440,10 @@ function upgrade(f::Function, http::Streams.Stream; suppress_close_error::Bool=f
         f(ws)
     catch e
         if !isok(e)
-            msg = current_exceptions_to_string()
-            suppress_close_error || @error "$(ws.id): Unexpected websocket server error. $msg"
+            if !suppress_close_error
+                msg = current_exceptions_to_string()
+                @error "$(ws.id): Unexpected websocket server error. $msg"
+            end
         end
         if !isclosed(ws)
             if e isa WebSocketError && e.message isa CloseFrameBody


### PR DESCRIPTION
So that all calls to `current_exceptions_to_string` are paired with `@warn` or `@error`, so that they will appear in logs that haven't set high verbosity and we can see on which path we are spending time in `current_exceptions_to_string`