### PR TITLE
Use Base.alloc_request instead of implementing it directly

### DIFF
--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -224,9 +224,10 @@ function read_to_buffer(c::Connection, sizehint=4096)
     # Read from stream into buffer.
     n = min(sizehint, bytesavailable(c.io))
     buf = c.buffer
-    Base.ensureroom(buf, n)
-    GC.@preserve buf unsafe_read(c.io, pointer(buf.data, buf.size + 1), n)
+    p, n = Base.alloc_request(buf, UInt(n))
+    GC.@preserve buf unsafe_read(c.io, p, min(n, bytesavailable(c.io)))
     buf.size += n
+    nothing
 end
 
 """

--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -219,7 +219,7 @@ function read_to_buffer(c::Connection, sizehint=4096)
     n = min(sizehint, bytesavailable(c.io))
     buf = c.buffer
     p, n = Base.alloc_request(buf, UInt(n))
-    n = GC.@preserve buf unsafe_read(c.io, p, min(n, bytesavailable(c.io)))
+    GC.@preserve buf (n = unsafe_read(c.io, p, min(n, bytesavailable(c.io))))
     Base.notify_filled(buf, Int(n))
     nothing
 end

--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -210,12 +210,6 @@ end
 function read_to_buffer(c::Connection, sizehint=4096)
     buf = c.buffer
 
-    # Reset the buffer if it is empty.
-    if bytesavailable(buf) == 0
-        buf.size = 0
-        buf.ptr = 1
-    end
-
     # Wait for data.
     if eof(c.io)
         throw(EOFError())
@@ -225,8 +219,8 @@ function read_to_buffer(c::Connection, sizehint=4096)
     n = min(sizehint, bytesavailable(c.io))
     buf = c.buffer
     p, n = Base.alloc_request(buf, UInt(n))
-    GC.@preserve buf unsafe_read(c.io, p, min(n, bytesavailable(c.io)))
-    buf.size += n
+    n = GC.@preserve buf unsafe_read(c.io, p, min(n, bytesavailable(c.io)))
+    Base.notify_filled(buf, Int(n))
     nothing
 end
 

--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -219,7 +219,8 @@ function read_to_buffer(c::Connection, sizehint=4096)
     n = min(sizehint, bytesavailable(c.io))
     buf = c.buffer
     p, n = Base.alloc_request(buf, UInt(n))
-    GC.@preserve buf (n = unsafe_read(c.io, p, min(n, bytesavailable(c.io))))
+    n = min(n, bytesavailable(c.io))
+    GC.@preserve buf unsafe_read(c.io, p, UInt(n))
     Base.notify_filled(buf, Int(n))
     nothing
 end


### PR DESCRIPTION
There is slightly better error handling in this function, which avoids relying as directly on implementation details of IOBuffer