### PR TITLE
Update readbytes! to avoid using internal API of IOBuffer less

### DIFF
--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -279,17 +279,10 @@ function Base.unsafe_read(http::Stream, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
-@noinline function bufcheck(buf::Base.GenericIOBuffer, n)
-    requested_buffer_capacity = (buf.append ? buf.size : (buf.ptr - 1)) + n
-    requested_buffer_capacity > length(buf.data) && throw(ArgumentError("Unable to grow response stream IOBuffer $(length(buf.data)) large enough for response body size: $requested_buffer_capacity"))
-end
-
 function Base.readbytes!(http::Stream, buf::Base.GenericIOBuffer, n=bytesavailable(http))
-    Base.ensureroom(buf, n)
-    # check if there's enough room in buf to write n bytes
-    bufcheck(buf, n)
-    data = buf.data
-    GC.@preserve data unsafe_read(http, pointer(data, (buf.append ? buf.size + 1 : buf.ptr)), n)
+    p, nbmax = Base.alloc_request(buf, n)
+    n = Int(GC.@preserve buf unsafe_read(http, p, min(nbmax, n)))
+    # TODO: use `Base.notify_filled(buf, n)` here, but only once it is identical to this:
     if buf.append
         buf.size += n
     else
@@ -326,7 +319,8 @@ function IOExtras.readuntil(http::Stream, f::Function)::ByteView
         bytes = IOExtras.readuntil(http.stream, f)
         update_ntoread(http, length(bytes))
         return bytes
-    catch
+    catch ex
+        ex isa EOFError() || rethrow()
         # if we error, it means we didn't find what we were looking for
         return UInt8[]
     end

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -281,8 +281,9 @@ end
 
 function Base.readbytes!(http::Stream, buf::Base.GenericIOBuffer, n=bytesavailable(http))
     p, nbmax = Base.alloc_request(buf, UInt(n))
-    GC.@preserve buf (n = unsafe_read(http, p, UInt(min(nbmax, n))))
-    # TODO: use `Base.notify_filled(buf, n)` here, but only once it is identical to this:
+    n = min(nbmax, n)
+    GC.@preserve buf unsafe_read(http, p, UInt(n))
+    # TODO: use `Base.notify_filled(buf, Int(n))` here, but only once it is identical to this:
     if buf.append
         buf.size += Int(n)
     else

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -280,8 +280,8 @@ function Base.unsafe_read(http::Stream, p::Ptr{UInt8}, n::UInt)
 end
 
 function Base.readbytes!(http::Stream, buf::Base.GenericIOBuffer, n=bytesavailable(http))
-    p, nbmax = Base.alloc_request(buf, n)
-    n = Int(GC.@preserve buf unsafe_read(http, p, min(nbmax, n)))
+    p, nbmax = Base.alloc_request(buf, UInt(n))
+    n = Int(GC.@preserve buf unsafe_read(http, p, UInt(min(nbmax, n))))
     # TODO: use `Base.notify_filled(buf, n)` here, but only once it is identical to this:
     if buf.append
         buf.size += n

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -281,12 +281,12 @@ end
 
 function Base.readbytes!(http::Stream, buf::Base.GenericIOBuffer, n=bytesavailable(http))
     p, nbmax = Base.alloc_request(buf, UInt(n))
-    n = Int(GC.@preserve buf unsafe_read(http, p, UInt(min(nbmax, n))))
+    GC.@preserve buf (n = unsafe_read(http, p, UInt(min(nbmax, n))))
     # TODO: use `Base.notify_filled(buf, n)` here, but only once it is identical to this:
     if buf.append
-        buf.size += n
+        buf.size += Int(n)
     else
-        buf.ptr += n
+        buf.ptr += Int(n)
         buf.size = max(buf.size, buf.ptr - 1)
     end
     return n

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -281,7 +281,7 @@ end
 
 function Base.readbytes!(http::Stream, buf::Base.GenericIOBuffer, n=bytesavailable(http))
     p, nbmax = Base.alloc_request(buf, UInt(n))
-    n = min(nbmax, n)
+    nbmax < n && throw(ArgumentError("Unable to grow response stream IOBuffer $nbmax large enough for response body size: $n"))
     GC.@preserve buf unsafe_read(http, p, UInt(n))
     # TODO: use `Base.notify_filled(buf, Int(n))` here, but only once it is identical to this:
     if buf.append
@@ -321,7 +321,7 @@ function IOExtras.readuntil(http::Stream, f::Function)
         update_ntoread(http, length(bytes))
         return bytes
     catch ex
-        ex isa EOFError() || rethrow()
+        ex isa EOFError || rethrow()
         # if we error, it means we didn't find what we were looking for
         # TODO: this seems very sketchy
         return UInt8[]


### PR DESCRIPTION
Note that this claims to be supported for all GenericIOBuffer, but Base only defines this function on a normal IOBuffer for which `pointer(data)` is contiguous space