### PR TITLE
Do not migrate tasks to a different thread pool

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "1.10.3"
+version = "1.10.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -22,7 +22,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodecZlib = "0.7"
-ConcurrentUtilities = "2.2"
+ConcurrentUtilities = "2.4"
 ExceptionUnwrapping = "0.1"
 LoggingExtras = "0.4.9,1"
 MbedTLS = "0.6.8, 0.7, 1"


### PR DESCRIPTION
This depends on [ConcurrentUtilities#32](https://github.com/JuliaServices/ConcurrentUtilities.jl/pull/32).  Therefore, I don't expect unit tests to pass until [ConcurrentUtilities#32](https://github.com/JuliaServices/ConcurrentUtilities.jl/pull/32) is merged, and a new version of ConcurrentUtilities is released.

Together with [ConcurrentUtilities#32](https://github.com/JuliaServices/ConcurrentUtilities.jl/pull/32), this fixes #1153. 