### PR TITLE
Introduce `connections_lock` to protect `Server.connections`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "1.10.4"
+version = "1.10.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -118,6 +118,8 @@ struct Server{L <: Listener}
     connections::Set{Connection}
     # server listenandserve loop task
     task::Task
+    # Protects the connections Set which is mutated in the listenloop
+    # while potentially being accessed by the close method at the same time
     connections_lock::ReentrantLock
 end
 


### PR DESCRIPTION
The `listenloop` deletes elements from the `connections` set, but if someone tries to close the server at the same time, this could lead to crashes.