### PR TITLE
"handler error": show request in log

### DIFF
--- a/src/Servers.jl
+++ b/src/Servers.jl
@@ -469,7 +469,7 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
                 Base.invokelatest(f, http)
                 # If `startwrite()` was never called, throw an error so we send a 500 and log this
                 if isopen(http) && !iswritable(http)
-                    error("Server never wrote a response")
+                    error("Server never wrote a response.\n\n$request")
                 end
                 @debugv 1 "closeread"
                 closeread(http)
@@ -483,7 +483,7 @@ function handle_connection(f, c::Connection, listener, readtimeout, access_log)
                 @logmsgv 1 level begin
                     msg = current_exceptions_to_string()
                     "handle_connection handler error. $msg"
-                end
+                end request
 
                 if isopen(http) && !iswritable(http)
                     request.response.status = 500


### PR DESCRIPTION
This will show the request that caused a handler error in the log.

For example, if I add `error("Test")` in my handler, I get this log:

```
┌ Error: handle_connection handler error. 
│ 
│ ===========================
│ HTTP Error message:
│ 
│ ERROR: Test
│ Stacktrace:
│  [1] error(s::String)
│    @ Base ./error.jl:35
│  [2] is_authenticated(session::Pluto.ServerSession, request::HTTP.Messages.Request)
│    @ Pluto ~/Documents/Pluto.jl/src/webserver/Authentication.jl:8
│  [3] (::Pluto.var"#385#395"{Pluto.ServerSession, Pluto.var"#280#282"{Pluto.var"#283#285"{HTTP.Handlers.Router{typeof(Pluto.default_404), typeof(HTTP.Handlers.default405), Nothing}}, Pluto.ServerSession}})(http::HTTP.Streams.Stream{HTTP.Messages.Request, HTTP.Connections.Connection{Sockets.TCPSocket}})
│    @ Pluto ~/Documents/Pluto.jl/src/webserver/WebServer.jl:193
│  [4] #invokelatest#2
│    @ ./essentials.jl:887 [inlined]
│  [5] invokelatest
│    @ ./essentials.jl:884 [inlined]
│  [6] handle_connection(f::Function, c::HTTP.Connections.Connection{Sockets.TCPSocket}, listener::HTTP.Servers.Listener{Nothing, Sockets.TCPServer}, readtimeout::Int64, access_log::Nothing)
│    @ HTTP.Servers ~/.julia/packages/HTTP/P8MWj/src/Servers.jl:469
│  [7] (::HTTP.Servers.var"#16#17"{Pluto.var"#385#395"{Pluto.ServerSession, Pluto.var"#280#282"{Pluto.var"#283#285"{HTTP.Handlers.Router{typeof(Pluto.default_404), typeof(HTTP.Handlers.default405), Nothing}}, Pluto.ServerSession}}, HTTP.Servers.Listener{Nothing, Sockets.TCPServer}, Set{HTTP.Connections.Connection}, Int64, Nothing, ReentrantLock, Base.Semaphore, HTTP.Connections.Connection{Sockets.TCPSocket}})()
│    @ HTTP.Servers ~/.julia/packages/HTTP/P8MWj/src/Servers.jl:401
│   request =
│    HTTP.Messages.Request:
│    """
│    GET / HTTP/1.1
│    Host: localhost:1234
│    Pragma: no-cache
│    Accept: */*
│    Sec-WebSocket-Key: S12qX44J2ZL/2yAUCTzNgA==
│    Sec-Fetch-Site: same-origin
│    Sec-WebSocket-Version: 13
│    Sec-WebSocket-Extensions: permessage-deflate
│    Cache-Control: no-cache
│    Sec-Fetch-Mode: websocket
│    Accept-Language: nl-NL,nl;q=0.9
│    Origin: http://localhost:1234
│    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Safari/605.1.15
│    Connection: Upgrade
│    Accept-Encoding: gzip, deflate
│    Upgrade: websocket
│    Sec-Fetch-Dest: websocket
│    Cookie: ******
│    
│    """
└ @ HTTP.Servers ~/.julia/packages/HTTP/P8MWj/src/Servers.jl:483
```

Instead of this:

```
┌ Error: handle_connection handler error. 
│ 
│ ===========================
│ HTTP Error message:
│ 
│ ERROR: Test
│ Stacktrace:
│  [1] error(s::String)
│    @ Base ./error.jl:35
│  [2] is_authenticated(session::Pluto.ServerSession, request::HTTP.Messages.Request)
│    @ Pluto ~/Documents/Pluto.jl/src/webserver/Authentication.jl:8
│  [3] (::Pluto.var"#385#395"{Pluto.ServerSession, Pluto.var"#280#282"{Pluto.var"#283#285"{HTTP.Handlers.Router{typeof(Pluto.default_404), typeof(HTTP.Handlers.default405), Nothing}}, Pluto.ServerSession}})(http::HTTP.Streams.Stream{HTTP.Messages.Request, HTTP.Connections.Connection{Sockets.TCPSocket}})
│    @ Pluto ~/Documents/Pluto.jl/src/webserver/WebServer.jl:193
│  [4] #invokelatest#2
│    @ ./essentials.jl:887 [inlined]
│  [5] invokelatest
│    @ ./essentials.jl:884 [inlined]
│  [6] handle_connection(f::Function, c::HTTP.Connections.Connection{Sockets.TCPSocket}, listener::HTTP.Servers.Listener{Nothing, Sockets.TCPServer}, readtimeout::Int64, access_log::Nothing)
│    @ HTTP.Servers ~/.julia/packages/HTTP/P8MWj/src/Servers.jl:469
│  [7] (::HTTP.Servers.var"#16#17"{Pluto.var"#385#395"{Pluto.ServerSession, Pluto.var"#280#282"{Pluto.var"#283#285"{HTTP.Handlers.Router{typeof(Pluto.default_404), typeof(HTTP.Handlers.default405), Nothing}}, Pluto.ServerSession}}, HTTP.Servers.Listener{Nothing, Sockets.TCPServer}, Set{HTTP.Connections.Connection}, Int64, Nothing, ReentrantLock, Base.Semaphore, HTTP.Connections.Connection{Sockets.TCPSocket}})()
│    @ HTTP.Servers ~/.julia/packages/HTTP/P8MWj/src/Servers.jl:401
└ @ HTTP.Servers ~/.julia/packages/HTTP/P8MWj/src/Servers.jl:483
```


I think this is useful debugging information! For example, I am currently trying to chase down the origin of a "Server never wrote a response" (like #1023 and #1156). Since my app is quite complex, it's really useful to know the path and method of the request that was handled wrong.