### PR TITLE
Make multipart parsing more forgiving: start-of-line and casing

### DIFF
--- a/src/parsemultipart.jl
+++ b/src/parsemultipart.jl
@@ -122,7 +122,7 @@ end
 
 const content_disposition_regex = Parsers.RegexAndMatchData[]
 function content_disposition_regex_f()
-    r = Parsers.RegexAndMatchData(r"^Content-Disposition:[ \t]*form-data;[ \t]*(.*)\r\n"x)
+    r = Parsers.RegexAndMatchData(r"^[Cc]ontent-[Dd]isposition:[ \t]*form-data;[ \t]*(.*)\r\n"mx)
     Parsers.init!(r)
 end
 


### PR DESCRIPTION
I had a multipart response i wanted to parse, and julia failed to parse it. These changes let it parse:
1. The content-disposition was the _second_ line in each part, with the content-type coming first, so the `^` was failing to parse.
2. The `content-type:` key was lower-cased, not Title-Cased as expected.

Dunno if these are generally correct, but they worked in my case.