### PR TITLE
Fix lost response body data. Fixes #1166

### DIFF
--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -119,7 +119,7 @@ function readuntil(buf::IOBuffer,
     if l == 0
         return nobytes
     end
-    bytes = view(buf.data, buf.ptr:buf.ptr + l - 1)
+    bytes = buf.data[buf.ptr:buf.ptr + l - 1]
     buf.ptr += l
     return bytes
 end


### PR DESCRIPTION
This creates one extra copy of the bytes instead of the view, but the result of `readuntil` is always being materialized as a `String` anyway, which was making a copy of the bytes before anyway (i.e. the behavior that changed was String(::View) copied the view bytes then made the string, and now we're explicitly making the copy and then the string is made).