### PR TITLE
Add case for empty set-cookie header list

### DIFF
--- a/src/cookies.jl
+++ b/src/cookies.jl
@@ -224,6 +224,9 @@ const RFC1123GMTFormat = gmtformat(Dates.RFC1123Format)
 function readsetcookies(h::Headers)
     result = Cookie[]
     for line in headers(h, "Set-Cookie")
+        if length(line) == 0
+            continue
+        end
         parts = split(strip(line), ';'; keepempty=false)
         if length(parts) == 1 && parts[1] == ""
             continue


### PR DESCRIPTION
I am encountering a `ERROR: LoadError: BoundsError: attempt to access 0-element Vector{SubString{String}} at index [1]` error when making calls to the acuitischeduling.com API.

It seems that `headers(h, "Set-Cookie")` can return an list of empty lists. This is a dirty workaround -- a HTTP.jl developer might find a better solution.