### PR TITLE
Don't run the precompile workload on Julia 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         version:
           - 'min'
           - 'lts'
+          - '1.9'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -632,7 +632,7 @@ function Base.parse(::Type{T}, str::AbstractString)::T where T <: Message
 end
 
 # only run if precompiling
-if VERSION >= v"1.9.0-0" && ccall(:jl_generating_output, Cint, ()) == 1
+if VERSION >= v"1.10.0-" && ccall(:jl_generating_output, Cint, ()) == 1
     include("precompile.jl")
 end
 


### PR DESCRIPTION
I think the precompile workload is broken on Julia 1.9.

I think the easiest approach will just be to skip the precompile workload on Julia 1.9. We'll continue to run the precompile workload on Julia 1.10+.

Cross-reference: https://github.com/JuliaWeb/HTTP.jl/pull/1195#issuecomment-2496480235