### PR TITLE
Fix trailing task precompilation issue on 1.9. Run CI on 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         version:
           - 'min'
           - 'lts'
+          - '1.9' # test because we know there's a precompilation issue that should be fixed
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         version:
           - 'min'
           - 'lts'
-          - '1.9' # test because we know there's a precompilation issue that should be fixed
+          - '1.9' # test because we know there was a precompilation issue on 1.9 issues/1202
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -35,5 +35,6 @@ using PrecompileTools: @setup_workload, @compile_workload
     end
 
     HTTP.forceclose(server)
+    yield() # needed on 1.9 to avoid some issue where it seems a task doesn't stop before serialization
     server = nothing
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaWeb/HTTP.jl/issues/1202
See https://github.com/JuliaWeb/HTTP.jl/pull/1195#issuecomment-2496480235

https://github.com/JuliaWeb/HTTP.jl/pull/1200 shows that without this, things go bad on 1.9

The print that it was causing is weird.. just seems to show a task object.. 

But it seems to be something like 1.9 not yielding for tasks to exit before serialization, so do it explicitly.