### PR TITLE
skip precompile workload if localhost cannot be resolved

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -633,7 +633,14 @@ end
 
 # only run if precompiling
 if VERSION >= v"1.9.0-0" && ccall(:jl_generating_output, Cint, ()) == 1
-    include("precompile.jl")
+    do_precompile = true
+    try
+        Sockets.getalladdrinfo("localhost")
+    catch ex
+        @debug "Skipping precompilation workload because localhost cannot be resolved. Check firewall settings" exception=(ex,catch_backtrace())
+        do_precompile = false
+    end
+    do_precompile && include("precompile.jl")
 end
 
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -26,11 +26,11 @@ try
             # listenany allows changing port if that one is already in use, so check the actual port
             _port = HTTP.port(server)
             url = "https://localhost:$_port"
-    
+
             env = ["JULIA_NO_VERIFY_HOSTS" => "localhost",
                 "JULIA_SSL_NO_VERIFY_HOSTS" => nothing,
                 "JULIA_ALWAYS_VERIFY_HOSTS" => nothing]
-        
+
             withenv(env...) do
                 @compile_workload begin
                     HTTP.get(url);


### PR DESCRIPTION
Fixes https://github.com/JuliaWeb/HTTP.jl/issues/1208

Or is there a way to work around it, not just skip it?