### PR TITLE
Backport to v1.9 some fixes for Julia master

### DIFF
--- a/src/Connections.jl
+++ b/src/Connections.jl
@@ -234,12 +234,12 @@ Read until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
 function IOExtras.readuntil(c::Connection, f::F #=Vector{UInt8} -> Int=#,
-                                        sizehint=4096)::ByteView where {F <: Function}
+                            sizehint=4096) where {F <: Function}
     buf = c.buffer
     if bytesavailable(buf) == 0
         read_to_buffer(c, sizehint)
     end
-    while (bytes = IOExtras.readuntil(buf, f)) == nobytes
+    while isempty(begin bytes = IOExtras.readuntil(buf, f) end)
         read_to_buffer(c, sizehint)
     end
     return bytes

--- a/src/IOExtras.jl
+++ b/src/IOExtras.jl
@@ -11,7 +11,7 @@ using Sockets
 using MbedTLS: SSLContext, MbedException
 using OpenSSL: SSLStream
 
-export bytes, isbytes, nbytes, ByteView, nobytes,
+export bytes, isbytes, nbytes, nobytes,
        startwrite, closewrite, startread, closeread, readuntil,
        tcpsocket, localport, safe_getpeername
 
@@ -104,7 +104,6 @@ function safe_getpeername(io)
 end
 
 
-const ByteView = typeof(view(UInt8[], 1:0))
 const nobytes = view(UInt8[], 1:0)
 
 readuntil(args...) = Base.readuntil(args...)
@@ -114,8 +113,8 @@ Read from an `IO` stream until `find_delimiter(bytes)` returns non-zero.
 Return view of bytes up to the delimiter.
 """
 function readuntil(buf::IOBuffer,
-                    find_delimiter::F #= Vector{UInt8} -> Int =#
-                   )::ByteView where {F <: Function}
+                   find_delimiter::F #= Vector{UInt8} -> Int =#
+                   ) where {F <: Function}
     l = find_delimiter(view(buf.data, buf.ptr:buf.size))
     if l == 0
         return nobytes

--- a/src/Streams.jl
+++ b/src/Streams.jl
@@ -320,14 +320,15 @@ function readall!(http::Stream, buf::Base.GenericIOBuffer=PipeBuffer())
     return n
 end
 
-function IOExtras.readuntil(http::Stream, f::Function)::ByteView
+function IOExtras.readuntil(http::Stream, f::Function)
     UInt(ntoread(http)) == 0 && return Connections.nobytes
     try
         bytes = IOExtras.readuntil(http.stream, f)
         update_ntoread(http, length(bytes))
         return bytes
-    catch
+    catch ex
         # if we error, it means we didn't find what we were looking for
+        # TODO: this seems very sketchy
         return UInt8[]
     end
 end

--- a/src/clientlayers/StreamRequest.jl
+++ b/src/clientlayers/StreamRequest.jl
@@ -143,9 +143,6 @@ function readbody(stream::Stream, res::Response, decompress::Union{Nothing, Bool
     end
 end
 
-# 2 most common types of IOBuffers
-const IOBuffers = Union{IOBuffer, Base.GenericIOBuffer{SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}}}
-
 function readbody!(stream::Stream, res::Response, buf_or_stream, lock)
     n = 0
     if !iserror(res)

--- a/test/websockets/autobahn.jl
+++ b/test/websockets/autobahn.jl
@@ -66,7 +66,7 @@ end
             end
 
             report = JSON.parsefile(joinpath(DIR, "reports/clients/index.json"))
-            for (k, v) in pairs(report["main"])
+            @testset "$k" for (k, v) in pairs(report["main"])
                 @test v["behavior"] in ("OK", "NON-STRICT", "INFORMATIONAL")
             end
         end

--- a/test/websockets/autobahn.jl
+++ b/test/websockets/autobahn.jl
@@ -65,8 +65,9 @@ end
                 end
             end
 
-            report = JSON.parsefile(joinpath(DIR, "reports/clients/index.json"))
-            @testset "$k" for (k, v) in pairs(report["main"])
+            report = JSON.parsefile(joinpath(DIR, "reports/clients/index.json"))["main"]
+            @testset "$k" for k in sort(collect(keys(report)))
+                v = report[k]
                 @test v["behavior"] in ("OK", "NON-STRICT", "INFORMATIONAL")
             end
         end


### PR DESCRIPTION
Trying to make HTTP.jl v1.9 work on Julia v1.12

Backports:
- https://github.com/JuliaWeb/HTTP.jl/pull/1146
- https://github.com/JuliaWeb/HTTP.jl/pull/1149
- https://github.com/JuliaWeb/HTTP.jl/pull/1148

---

Using v1.12 with HTTP.jl v1.9.19 we have seen:

```
2025-01-17 13:00:59   """Underlying error:
2025-01-17 13:00:59   TaskFailedException
2025-01-17 13:00:59   
2025-01-17 13:00:59       nested task error: MethodError: Cannot `convert` an object of type 
2025-01-17 13:00:59         SubArray{UInt8,1,Memory{UInt8},Tuple{UnitRange{Int64}},true} to an object of type 
2025-01-17 13:00:59         SubArray{UInt8,1,Vector{UInt8},Tuple{UnitRange{Int64}},true}
2025-01-17 13:00:59       The function `convert` exists, but no method is defined for this combination of argument types.
2025-01-17 13:00:59       
2025-01-17 13:00:59       Closest candidates are:
2025-01-17 13:00:59         SubArray{T, N, P, I, L}(::Any, !Matched::Any, !Matched::Any, !Matched::Any) where {T, N, P, I, L}
2025-01-17 13:00:59          @ Base subarray.jl:19
2025-01-17 13:00:59         convert(::Type{T}, !Matched::RAI_Common.Alg.SemiringElement{T}) where T
2025-01-17 13:00:59          @ RAI_Common ~/packages/RAI_Common/src/Alg.jl:84
2025-01-17 13:00:59         convert(::Type{T}, !Matched::T) where T
2025-01-17 13:00:59          @ Base Base_compiler.jl:133
2025-01-17 13:00:59         ...
2025-01-17 13:00:59       
2025-01-17 13:00:59       Stacktrace:
2025-01-17 13:00:59        [1] readuntil(buf::IOBuffer, find_delimiter::typeof(HTTP.Parsers.find_end_of_header))
2025-01-17 13:00:59          @ HTTP.IOExtras ~/julia-depot-path/.julia/packages/HTTP/1MepD/src/IOExtras.jl:125
2025-01-17 13:00:59        [2] readuntil(c::HTTP.Connections.Connection{Sockets.TCPSocket}, f::typeof(HTTP.Parsers.find_end_of_header), sizehint::Int64)
2025-01-17 13:00:59          @ HTTP.Connections ~/julia-depot-path/.julia/packages/HTTP/1MepD/src/Connections.jl:242
2025-01-17 13:00:59        [3] readuntil(c::HTTP.Connections.Connection{Sockets.TCPSocket}, f::typeof(HTTP.Parsers.find_end_of_header))
2025-01-17 13:00:59          @ HTTP.Connections ~/julia-depot-path/.julia/packages/HTTP/1MepD/src/Connections.jl:238
2025-01-17 13:00:59        [4] readheaders(io::HTTP.Connections.Connection{Sockets.TCPSocket}, message::HTTP.Messages.Response)
2025-01-17 13:00:59          @ HTTP.Messages ~/julia-depot-path/.julia/packages/HTTP/1MepD/src/Messages.jl:533
2025-01-17 13:00:59        [5] startread(http::HTTP.Streams.Stream{HTTP.Messages.Response, HTTP.Connections.Connection{Sockets.TCPSocket}})
2025-01-17 13:00:59          @ HTTP.Streams ~/julia-depot-path/.julia/packages/HTTP/1MepD/src/Streams.jl:153
2025-01-17 13:00:59        [6] macro expansion
2025-01-17 13:00:59          @ ~/julia-depot-path/.julia/packages/HTTP/1MepD/src/clientlayers/StreamRequest.jl:52 [inlined]
2025-01-17 13:00:59        [7] (::HTTP.StreamRequest.var"#6#7"{Nothing, HTTP.Streams.Stream{HTTP.Messages.Response, HTTP.Connections.Connection{Sockets.TCPSocket}}, HTTP.Messages.Request, HTTP.Messages.Response, Float64, ReentrantLock})()
2025-01-17 13:00:59          @ HTTP.StreamRequest ~/julia-depot-path/.julia/packages/ConcurrentUtilities/j1gVM/src/ConcurrentUtilities.jl:9
```
The offending line is https://github.com/JuliaWeb/HTTP.jl/blob/0cfe5ceba76fb18a73e44fafc64ab30997cc0001/src/IOExtras.jl#L118 

Note the return type conversion `::ByteView` on the function definition, fixed by https://github.com/JuliaWeb/HTTP.jl/pull/1149

