### PR TITLE
Support Julia 1.12.0-beta1

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -31,8 +31,8 @@ try
                 "JULIA_SSL_NO_VERIFY_HOSTS" => nothing,
                 "JULIA_ALWAYS_VERIFY_HOSTS" => nothing]
 
-            withenv(env...) do
-                @compile_workload begin
+            @compile_workload begin
+                withenv(env...) do
                     HTTP.get(url);
                 end
             end

--- a/test/httpversion.jl
+++ b/test/httpversion.jl
@@ -16,8 +16,11 @@
 
 # Important that we can parse a string into a `HTTPVersion` without allocations,
 # as we do this for every request/response. Similarly if we then want a `VersionNumber`.
-@test @allocated(HTTPVersion("1.1")) == 0
-@test @allocated(VersionNumber(HTTPVersion("1.1"))) == 0
+function test_allocated()
+    @test @allocated(HTTPVersion("1.1")) == 0
+    @test @allocated(VersionNumber(HTTPVersion("1.1"))) == 0
+end
+test_allocated()
 
 # Test comparisons with `VersionNumber`s
 req = HTTP.Request("GET", "http://httpbin.org/anything")


### PR DESCRIPTION
* Move `withenv` call inside `@compile_workload` (as recommended [here](https://github.com/JuliaWeb/HTTP.jl/issues/1218#issuecomment-2790416069)).
* Move `@allocated` tests into a function to let CI pass.

Fixes #1218.