### PR TITLE
Require URIs.jl >= 1.6, and bump version from 1.10.16 to 1.10.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ MbedTLS = "0.6.8, 0.7, 1"
 OpenSSL = "1.3"
 PrecompileTools = "1.2.1"
 SimpleBufferStream = "1.1"
-URIs = "1.3"
+URIs = "1.6" # We need URIs >= 1.6 to ensure we have https://github.com/JuliaWeb/URIs.jl/pull/66
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 authors = ["Jacob Quinn", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
-version = "1.10.16"
+version = "1.10.17"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
I imagine that there are quite a few people that:
1. Do have HTTP.jl as a direct dep in their `Project.toml` file.
2. Do not have URIs.jl as a direct dep.

In order for those people to _guarantee_ that they get the fix from https://github.com/JuliaWeb/URIs.jl/pull/66, they'd need to add URIs.jl as a direct dep.

This PR presents an alternative option. The idea is that we release a new version of HTTP.jl (HTTP.jl version 1.10.17) that requires URIs.jl 1.6. Then, people that currently have HTTP.jl as a direct dep will only need to set the following `[compat]` entry in their `Project.toml` file:

```toml
[compat]
HTTP = "1.10.17"
```

And this will guarantee that they get the fix from https://github.com/JuliaWeb/URIs.jl/pull/66.

After merging this PR, I suggest that we register HTTP.jl version 1.10.17.