### PR TITLE
Fix redirect response bodies being written to response_stream

### DIFF
--- a/test/client.jl
+++ b/test/client.jl
@@ -287,6 +287,73 @@ end
         @test isok(HTTP.request(read_method, "https://$httpbin/redirect-to?url=http%3A%2F%2Fgoogle.com", socket_type_tls=tls))
     end
 
+    @testset "Client Redirect Response Stream" begin
+        # Test that redirect response bodies are not written to response_stream 
+        # (Issue #1165: https://github.com/JuliaWeb/HTTP.jl/issues/1165)
+        server = nothing
+        try
+            server = HTTP.listen!("127.0.0.1", 8123) do http
+                if http.message.target == "/final"
+                    HTTP.setstatus(http, 200)
+                    HTTP.startwrite(http)
+                    HTTP.write(http, "final_response")
+                else
+                    HTTP.setstatus(http, 301)
+                    HTTP.setheader(http, "Location" => "/final")
+                    HTTP.startwrite(http)
+                    HTTP.write(http, "redirect_response")
+                end
+                return
+            end
+
+            # Test with response_stream - should only contain final response
+            buffer = IOBuffer()
+            resp = HTTP.get("http://127.0.0.1:8123"; response_stream=buffer)
+            result = String(take!(buffer))
+            @test result == "final_response"
+            @test resp.status == 200
+
+            # Test multiple redirects - should only contain final response
+            server2 = HTTP.listen!("127.0.0.1", 8124) do http
+                if http.message.target == "/final"
+                    HTTP.setstatus(http, 200)
+                    HTTP.startwrite(http)
+                    HTTP.write(http, "final")
+                elseif http.message.target == "/redirect2"
+                    HTTP.setstatus(http, 302)
+                    HTTP.setheader(http, "Location" => "/final")
+                    HTTP.startwrite(http)
+                    HTTP.write(http, "second_redirect")
+                else
+                    HTTP.setstatus(http, 301)
+                    HTTP.setheader(http, "Location" => "/redirect2")
+                    HTTP.startwrite(http)
+                    HTTP.write(http, "first_redirect")
+                end
+                return
+            end
+
+            try
+                buffer2 = IOBuffer()
+                HTTP.get("http://127.0.0.1:8124"; response_stream=buffer2)
+                result2 = String(take!(buffer2))
+                @test result2 == "final"
+            finally
+                close(server2)
+            end
+
+            # Test with redirect=false - should include redirect body
+            buffer3 = IOBuffer()
+            resp3 = HTTP.get("http://127.0.0.1:8123"; response_stream=buffer3, redirect=false)
+            result3 = String(take!(buffer3))
+            @test result3 == "redirect_response"
+            @test resp3.status == 301
+
+        finally
+            server !== nothing && close(server)
+        end
+    end
+
     @testset "Client Basic Auth" begin
         @test isok(HTTP.get("https://user:pwd@$httpbin/basic-auth/user/pwd", socket_type_tls=tls))
         @test isok(HTTP.get("https://user:pwd@$httpbin/hidden-basic-auth/user/pwd", socket_type_tls=tls))

--- a/test/client.jl
+++ b/test/client.jl
@@ -288,7 +288,7 @@ end
     end
 
     @testset "Client Redirect Response Stream" begin
-        # Test that redirect response bodies are not written to response_stream 
+        # Test that redirect response bodies are not written to response_stream
         # (Issue #1165: https://github.com/JuliaWeb/HTTP.jl/issues/1165)
         server = nothing
         try


### PR DESCRIPTION
Note, written by Claude, hence the draft.

----

Fixes #1165

## Problem

When using `response_stream` with HTTP requests that involve redirects, both the redirect response body AND the final response body were being written to the stream. This is incorrect behavior - only the final response body should be written to the stream, and redirect response bodies should be ignored (similar to how curl handles redirects with "Ignoring the response-body").

## Root Cause

The issue was introduced in the version range v1.5.5...v1.6.3, specifically related to changes in PR #975 that fixed StatusError exception handling. While that fix was correct and necessary, it highlighted an existing issue in StreamRequest.jl:

- Redirect responses (3xx status codes) return `false` for `iserror(res)` but `true` for `isredirect(res)`
- In `readbody!()`, they were going through the normal "success" path and writing their bodies to `response_stream`
- When redirects are followed, these intermediate response bodies should be discarded, not written to the stream

## Solution

Modified StreamRequest.jl to:

1. **Added `willredirect()` function** that determines if a redirect response will actually be followed (using the same logic as `RedirectRequest` layer)
2. **Updated the condition** in `readbody!()` from `!iserror(res)` to `!iserror(res) && !willredirect(res)`
3. **Redirect responses that will be followed** are now treated like error responses - their bodies are read but stored in request context instead of written to `response_stream`

## Behavior

- ✅ **Redirect followed**: Only final response body written to `response_stream`
- ✅ **Multiple redirects**: Only final response body written to `response_stream`
- ✅ **`redirect=false`**: Redirect response body written to `response_stream` (correct)
- ✅ **Redirect limit reached**: Final redirect response body written to `response_stream` (correct)
- ✅ **No redirects**: Normal response body written to `response_stream` (unchanged)

## Testing

Added comprehensive test case in client.jl that covers:
- Basic redirect with `response_stream`
- Multiple redirects with `response_stream`
- Redirect disabled (`redirect=false`) with `response_stream`

The fix ensures HTTP.jl now matches the expected behavior described in the issue and aligns with how other HTTP clients (like curl) handle redirect response bodies in streaming mode.