### PR TITLE
docs: migrate examples from JSON3.jl to JSON.jl v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Documentation examples migrated from the deprecated JSON3.jl to JSON.jl v1.
+  Affects `docs/examples/simple_server.jl` and `docs/examples/cors_server.jl`.
+  No public API of HTTP.jl changes. ([#1249])
+### Fixed
+- `docs/examples/simple_server.jl` and `docs/examples/cors_server.jl` no longer
+  fail to parse on Julia ≥ 1.12: the leading description is now a `#=...=#`
+  block comment instead of a top-of-file string literal that the parser tried
+  to attach as a docstring to the following `using` statement. ([#1249])
+- `docs/examples/cors_server.jl`: the demonstration `HTTP.get` against an
+  intentionally bad path now passes `status_exception=false` so the script
+  can exercise the cors404 handler without raising. ([#1249])
 
 ## [v1.11.0] - 2025-12-20
 ### Added
@@ -703,3 +715,4 @@ See changes for 0.9.15: this release is equivalent to 0.9.15 with [#752] reverte
 [#1119]: https://github.com/JuliaWeb/HTTP.jl/issues/1119
 [#1126]: https://github.com/JuliaWeb/HTTP.jl/issues/1126
 [#1127]: https://github.com/JuliaWeb/HTTP.jl/issues/1127
+[#1249]: https://github.com/JuliaWeb/HTTP.jl/issues/1249

--- a/docs/examples/cors_server.jl
+++ b/docs/examples/cors_server.jl
@@ -1,10 +1,10 @@
-"""
+#=
 Server example that takes after the simple server, however,
 handles dealing with CORS preflight headers when dealing with more
 than just a simple request. For CORS details, see e.g. https://cors-errors.info/
-"""
+=#
 
-using HTTP, JSON3, StructTypes, Sockets, UUIDs
+using HTTP, JSON, Sockets, UUIDs
 
 # modified Animal struct to associate with specific user
 mutable struct Animal
@@ -13,9 +13,8 @@ mutable struct Animal
     type::String
     name::String
     Animal() = new()
+    Animal(id, userId, type, name) = new(id, userId, type, name)
 end
-
-StructTypes.StructType(::Type{Animal}) = StructTypes.Mutable()
 
 # use a plain `Dict` as a "data store", outer Dict maps userId to user-specific Animals
 const ANIMALS = Dict{UUID, Dict{Int, Animal}}()
@@ -52,14 +51,14 @@ function JSONMiddleware(handler)
             ret = handler(req)
         else
             # replace request body with parsed Animal instance
-            req.body = JSON3.read(req.body, Animal)
+            req.body = JSON.parse(req.body, Animal)
             ret = handler(req)
         end
         # return a Response, if its a response already (from 404 and 405 handlers)
         if ret isa HTTP.Response
             return ret
         else # otherwise serialize any Animal as json string and wrap it in Response
-            return HTTP.Response(200, CORS_RES_HEADERS, ret === nothing ? "" : JSON3.write(ret))
+            return HTTP.Response(200, CORS_RES_HEADERS, ret === nothing ? "" : JSON.json(ret))
         end
     end
 end
@@ -133,19 +132,19 @@ server = HTTP.serve!(ANIMAL_ROUTER |> JSONMiddleware |> CorsMiddleware, Sockets.
 
 # using our server
 resp = HTTP.post("http://localhost:8080/api/zoo/v1/users")
-userId = JSON3.read(resp.body, UUID)
+userId = JSON.parse(resp.body, UUID)
 x = Animal()
 x.userId = userId
 x.type = "cat"
 x.name = "pete"
 # create 1st animal
-resp = HTTP.post("http://localhost:8080/api/zoo/v1/users/$(userId)/animals", [], JSON3.write(x))
-x2 = JSON3.read(resp.body, Animal)
+resp = HTTP.post("http://localhost:8080/api/zoo/v1/users/$(userId)/animals", [], JSON.json(x))
+x2 = JSON.parse(resp.body, Animal)
 # retrieve it back
 resp = HTTP.get("http://localhost:8080/api/zoo/v1/users/$(userId)/animals/$(x2.id)")
-x3 = JSON3.read(resp.body, Animal)
+x3 = JSON.parse(resp.body, Animal)
 # try bad path
-resp = HTTP.get("http://localhost:8080/api/zoo/v1/badpath")
+resp = HTTP.get("http://localhost:8080/api/zoo/v1/badpath"; status_exception=false)
 
 # close the server which will stop the HTTP server from listening
 close(server)

--- a/docs/examples/simple_server.jl
+++ b/docs/examples/simple_server.jl
@@ -1,8 +1,8 @@
-"""
-A simple example of creating a server with HTTP.jl. It handles creating, deleting, 
+#=
+A simple example of creating a server with HTTP.jl. It handles creating, deleting,
 updating, and retrieving Animals from a dictionary through 4 different routes
-"""
-using HTTP, JSON3, StructTypes, Sockets
+=#
+using HTTP, JSON, Sockets
 
 # modified Animal struct to associate with specific user
 mutable struct Animal
@@ -11,9 +11,8 @@ mutable struct Animal
     type::String
     name::String
     Animal() = new()
+    Animal(id, userId, type, name) = new(id, userId, type, name)
 end
-
-StructTypes.StructType(::Type{Animal}) = StructTypes.Mutable()
 
 # use a plain `Dict` as a "data store"
 const ANIMALS = Dict{Int, Animal}()
@@ -26,22 +25,22 @@ end
 
 # "service" functions to actually do the work
 function createAnimal(req::HTTP.Request)
-    animal = JSON3.read(req.body, Animal)
+    animal = JSON.parse(req.body, Animal)
     animal.id = getNextId()
     ANIMALS[animal.id] = animal
-    return HTTP.Response(200, JSON3.write(animal))
+    return HTTP.Response(200, JSON.json(animal))
 end
 
 function getAnimal(req::HTTP.Request)
     animalId = HTTP.getparams(req)["id"]
     animal = ANIMALS[parse(Int, animalId)]
-    return HTTP.Response(200, JSON3.write(animal))
+    return HTTP.Response(200, JSON.json(animal))
 end
 
 function updateAnimal(req::HTTP.Request)
-    animal = JSON3.read(req.body, Animal)
+    animal = JSON.parse(req.body, Animal)
     ANIMALS[animal.id] = animal
-    return HTTP.Response(200, JSON3.write(animal))
+    return HTTP.Response(200, JSON.json(animal))
 end
 
 function deleteAnimal(req::HTTP.Request)
@@ -65,11 +64,11 @@ x = Animal()
 x.type = "cat"
 x.name = "pete"
 # create 1st animal
-resp = HTTP.post("http://localhost:8080/api/zoo/v1/animals", [], JSON3.write(x))
-x2 = JSON3.read(resp.body, Animal)
+resp = HTTP.post("http://localhost:8080/api/zoo/v1/animals", [], JSON.json(x))
+x2 = JSON.parse(resp.body, Animal)
 # retrieve it back
 resp = HTTP.get("http://localhost:8080/api/zoo/v1/animals/$(x2.id)")
-x3 = JSON3.read(resp.body, Animal)
+x3 = JSON.parse(resp.body, Animal)
 
 # close the server which will stop the HTTP server from listening
 close(server)

--- a/test/examples_no_json3.jl
+++ b/test/examples_no_json3.jl
@@ -1,0 +1,26 @@
+using Test
+
+const EXAMPLES_DIR = normpath(joinpath(@__DIR__, "..", "docs", "examples"))
+
+@testset "examples — no deprecated JSON3" begin
+    @test isdir(EXAMPLES_DIR)
+
+    example_files = String[]
+    for (root, _dirs, files) in walkdir(EXAMPLES_DIR)
+        for f in files
+            if endswith(f, ".jl")
+                push!(example_files, joinpath(root, f))
+            end
+        end
+    end
+
+    @test !isempty(example_files)
+
+    for path in example_files
+        contents = read(path, String)
+        @testset "$(relpath(path, EXAMPLES_DIR))" begin
+            @test !occursin("JSON3", contents)
+            @test !occursin("StructTypes", contents)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ isok(r) = r.status == 200
         "httpversion.jl",
         "websockets/autobahn.jl",
         "websockets/multiple_writers.jl",
+        "examples_no_json3.jl",
     ]
     # ARGS can be most easily passed like this:
     # import Pkg; Pkg.test("HTTP"; test_args=`ascii.jl parser.jl`)


### PR DESCRIPTION
Closes #1249.

JSON3.jl is deprecated. Migrate the two bundled REST-server examples to JSON.jl v1 per the official migration guide:

  - JSON3.read(body, T) -> JSON.parse(body, T)
  - JSON3.write(x)      -> JSON.json(x)
  - StructTypes.StructType(::Type{T}) = StructTypes.Mutable() -> removed
    (JSON.jl v1 auto-detects struct fields)

Add an explicit positional inner constructor `Animal(id, userId, type, name)` to both examples so JSON.jl v1's StructUtils can construct the struct from its parsed fields. The existing zero-arg `Animal()` constructor is preserved because the in-script client section still uses `x = Animal(); x.type = ...`.

Add a regression test (test/examples_no_json3.jl) that walks docs/examples/ and asserts no .jl file references the JSON3 or StructTypes modules. This test was written first, observed to fail on the unmigrated tree (the TDD red step required by the project constitution), and turned green by the migration.

Two pre-existing example bugs were fixed along the way because they blocked end-to-end validation of the migration on Julia >= 1.12:

  - The leading `"""..."""` description in both files used to be parsed as a docstring attached to the following `using` statement, which Julia 1.12 rejects with "cannot document the following expression". Convert both to `#=...=#` block comments.
  - cors_server.jl's intentional bad-path probe (`HTTP.get(".../badpath")`) raised on the 404 because HTTP.jl raises on error statuses by default. Pass `status_exception=false` so the example exercises the cors404 handler as intended.

Both fixes are documented under `### Fixed` in CHANGELOG.md alongside the main `### Changed` migration entry.

No public API of HTTP.jl changes. Project.toml [deps] is unchanged; JSON.jl remains a test/extras dependency only.