### PR TITLE
feat(websockets): add manual WebSockets.upgrade(f, stream) for mixed HTTP/WS servers

### DIFF
--- a/docs/src/api/websockets.md
+++ b/docs/src/api/websockets.md
@@ -36,6 +36,8 @@ HTTP.WebSockets.Server
 HTTP.WebSockets.listen!
 HTTP.WebSockets.listen
 HTTP.WebSockets.serve!
+HTTP.WebSockets.upgrade
+HTTP.WebSockets.isupgrade
 HTTP.WebSockets.server_addr
 HTTP.WebSockets.forceclose
 ```

--- a/docs/src/guides/migration-1x.md
+++ b/docs/src/guides/migration-1x.md
@@ -520,6 +520,32 @@ server = HTTP.WebSockets.listen!("127.0.0.1", 8080) do ws
 end
 ```
 
+To mix ordinary HTTP routes and WebSocket routes on a single server, upgrade an
+in-flight server stream by hand with `HTTP.WebSockets.upgrade`, the 2.0
+counterpart to the 1.x `WebSockets.upgrade(http)` helper. Guard the call with
+`HTTP.WebSockets.isupgrade` and upgrade before writing any response:
+
+```julia
+server = HTTP.listen!("127.0.0.1", 8080) do stream
+    if HTTP.WebSockets.isupgrade(stream.message)
+        HTTP.WebSockets.upgrade(stream) do ws
+            for msg in ws
+                HTTP.WebSockets.send(ws, msg)
+            end
+        end
+    else
+        HTTP.setstatus(stream, 200)
+        HTTP.startwrite(stream)
+        write(stream, "ok")
+    end
+end
+```
+
+`upgrade` runs its handler synchronously and closes the connection when the
+handler returns. It accepts the same `subprotocols`, `check_origin`,
+`maxframesize`, and `maxfragmentation` keywords as `listen!`. WebSocket upgrades
+over HTTP/2 are not supported.
+
 The WebSocket client accepts the handshake timeout controls
 `connect_timeout`, `request_timeout`, `response_header_timeout`,
 `read_idle_timeout`, and `write_idle_timeout`.

--- a/src/http_server.jl
+++ b/src/http_server.jl
@@ -1072,6 +1072,11 @@ function _serve_h1_conn!(server::Server, tracked::_ServerConn, reader_source)::N
             _set_read_deadline_for_body!(server, tracked.conn)
             if server.stream
                 stream = Stream(server, tracked, request)
+                # Expose the per-connection reader so a stream handler can hand
+                # the connection off to WebSockets.upgrade (which must recover any
+                # bytes buffered past the request). Server streams otherwise read
+                # the request body via stream.request_body, not stream.reader.
+                stream.reader = reader
                 try
                     server.handler(stream)
                     if !(@atomic :acquire stream.write_closed)

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -221,6 +221,14 @@ function isclosed(ws::WebSocket)::Bool
     return ws.readclosed && ws.writeclosed
 end
 
+"""
+    isupgrade(message) -> Bool
+
+Return `true` when `message` is a WebSocket upgrade. For a request this checks
+for a valid client upgrade handshake — use it to guard [`upgrade`](@ref) inside
+an `HTTP.listen!` stream handler. For a response it checks for a `101 Switching
+Protocols` handshake response.
+"""
 function isupgrade(message::Request)::Bool
     return ws_is_websocket_request(message)
 end

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -86,6 +86,8 @@ import ..write_response!
 import ..write_request!
 import .._is_transport_timeout
 import .._wrap_transport_timeout
+import ..Stream
+import .._clear_deadlines!
 
 include("http_websocket_codec.jl")
 
@@ -1114,9 +1116,7 @@ function _origin_allowed_default(request::Request)::Bool
     return lowercase(origin_host) == lowercase(request_host::String)
 end
 
-function _origin_allowed(server::Server, request::Request)::Bool
-    checker = server.check_origin
-    checker === nothing && return _origin_allowed_default(request)
+function _run_origin_check(checker, request::Request)::Bool
     origin = header(request.headers, "Origin", nothing)
     if applicable(checker, request, origin)
         result = checker(request, origin)
@@ -1129,7 +1129,17 @@ function _origin_allowed(server::Server, request::Request)::Bool
     return result
 end
 
-function _upgrade_response(request::Request, server::Server)::Response
+function _origin_allowed(server::Server, request::Request)::Bool
+    checker = server.check_origin
+    checker === nothing && return _origin_allowed_default(request)
+    return _run_origin_check(checker, request)
+end
+
+function _upgrade_response(
+    request::Request;
+    subprotocols::AbstractVector{<:AbstractString}=String[],
+    check_origin::Union{Nothing,Function}=nothing,
+)::Response
     uppercase(request.method) == "GET" || return Response(400, BytesBody(Vector{UInt8}("websocket upgrade required")); content_length=26, headers=Headers())
     _ws_headers_have_token(request.headers, "Upgrade", "websocket", false) || return Response(400, BytesBody(Vector{UInt8}("websocket upgrade required")); content_length=26, headers=Headers())
     _ws_headers_have_token(request.headers, "Connection", "upgrade", false) || return Response(400, BytesBody(Vector{UInt8}("websocket upgrade required")); content_length=26, headers=Headers())
@@ -1138,16 +1148,130 @@ function _upgrade_response(request::Request, server::Server)::Response
     strip(version) == "13" || return Response(400, BytesBody(Vector{UInt8}("websocket upgrade required")); content_length=26, headers=Headers())
     raw_key = header(request.headers, "Sec-WebSocket-Key", nothing)
     raw_key === nothing && return Response(400, BytesBody(Vector{UInt8}("missing websocket key")); content_length=21, headers=Headers())
-    _origin_allowed(server, request) || return Response(403, BytesBody(Vector{UInt8}("websocket origin rejected")); content_length=25, headers=Headers())
+    allowed = check_origin === nothing ? _origin_allowed_default(request) : _run_origin_check(check_origin, request)
+    allowed || return Response(403, BytesBody(Vector{UInt8}("websocket origin rejected")); content_length=25, headers=Headers())
     key = ws_get_request_sec_websocket_key(request)
     key === nothing && return Response(400, BytesBody(Vector{UInt8}("invalid websocket key")); content_length=21, headers=Headers())
     headers = Headers()
     setheader(headers, "Upgrade", "websocket")
     setheader(headers, "Connection", "Upgrade")
     setheader(headers, "Sec-WebSocket-Accept", ws_compute_accept_key(key::String))
-    selected = isempty(server.subprotocols) ? nothing : ws_select_subprotocol(request, server.subprotocols)
+    selected = isempty(subprotocols) ? nothing : ws_select_subprotocol(request, subprotocols)
     selected === nothing || setheader(headers, "Sec-WebSocket-Protocol", selected::String)
     return Response(101, EmptyBody(); headers=headers, content_length=0, request=request)
+end
+
+_upgrade_response(request::Request, server::Server)::Response =
+    _upgrade_response(request; subprotocols=server.subprotocols, check_origin=server.check_origin)
+
+"""
+    upgrade(f, stream::HTTP.Stream; kwargs...)
+
+Upgrade an in-flight HTTP/1.1 server `stream` to a WebSocket connection and run
+`f(ws::WebSocket)`. This is the manual counterpart to [`listen!`](@ref): it lets
+a single `HTTP.listen!` / `HTTP.Router` server mix ordinary HTTP routes with
+WebSocket routes by upgrading the connection from inside a stream handler.
+
+Guard the call with [`isupgrade`](@ref) and call `upgrade` before writing any
+response to the stream:
+
+```julia
+HTTP.listen!("127.0.0.1", 8080) do stream
+    if HTTP.WebSockets.isupgrade(stream.message)
+        HTTP.WebSockets.upgrade(stream) do ws
+            for msg in ws
+                HTTP.WebSockets.send(ws, msg)
+            end
+        end
+    else
+        HTTP.setstatus(stream, 200)
+        HTTP.startwrite(stream)
+        write(stream, "ok")
+    end
+end
+```
+
+`f` runs synchronously; the connection is closed when it returns. Keyword
+arguments mirror [`listen!`](@ref): `subprotocols`, `check_origin`,
+`maxframesize`, and `maxfragmentation`. WebSocket upgrades over HTTP/2 are not
+supported.
+"""
+function upgrade(
+    f::Function,
+    stream::Stream;
+    subprotocols::AbstractVector{<:AbstractString}=String[],
+    check_origin::Union{Nothing,Function}=nothing,
+    maxframesize::Integer=typemax(Int),
+    maxfragmentation::Integer=DEFAULT_MAX_FRAG,
+)
+    stream.tracked === nothing &&
+        throw(WebSocketError(CloseFrameBody(1011, "stream cannot be upgraded: not an HTTP/1.1 server stream")))
+    (stream.message.proto_major != UInt8(1) || stream.h2_conn !== nothing) &&
+        throw(WebSocketError(CloseFrameBody(1011, "WebSocket upgrade over HTTP/2 is not supported")))
+
+    conn = stream.tracked.conn
+    response = _upgrade_response(stream.message; subprotocols=subprotocols, check_origin=check_origin)
+    _write_ws_response!(conn, response)
+
+    # We have written the handshake response directly to the connection, so take
+    # ownership of it away from the normal HTTP/1 server loop: mark the stream's
+    # read/write sides closed (so the loop's post-handler closewrite/closeread
+    # become no-ops) and request connection close (so the loop does not try to
+    # read another request off what is now a WebSocket).
+    @atomic :release stream.response_started = true
+    @atomic :release stream.write_closed = true
+    @atomic :release stream.read_closed = true
+    stream.response.close = true
+
+    if response.status != 101
+        _close_ws_server_conn!(conn)
+        throw(WebSocketError(CloseFrameBody(1002, "websocket upgrade rejected with status $(response.status)")))
+    end
+
+    # The server loop armed a body read-deadline before invoking the handler and
+    # only clears it after the handler returns (i.e. after this whole session);
+    # clear it now so a long-lived socket is not torn down mid-session.
+    _clear_deadlines!(conn)
+
+    buffered = stream.reader isa _ConnReader ? _take_conn_reader_buffer!(stream.reader::_ConnReader) : UInt8[]
+    close_transport! = let conn = conn
+        () -> _close_ws_server_conn!(conn)
+    end
+    ws = WebSocket(
+        conn,
+        close_transport!,
+        subprotocol=header(response.headers, "Sec-WebSocket-Protocol"),
+        maxframesize=maxframesize,
+        maxfragmentation=maxfragmentation,
+        is_client=false,
+    )
+    ws.handshake_request = stream.message
+    ws.handshake_response = response
+    if !isempty(buffered)
+        ws_on_incoming_data!(frame -> _process_incoming_frame!(ws, frame), ws.codec, buffered)
+        _flush_ws_output!(ws)
+    end
+    _start_read_task!(ws)
+    try
+        f(ws)
+    catch err
+        if !isclosed(ws)
+            if err isa WebSocketError
+                close(ws, (err::WebSocketError).message)
+            else
+                close(ws, CloseFrameBody(1011, "unexpected server websocket error"))
+            end
+        end
+        isok(err) || rethrow(err)
+    finally
+        if !isclosed(ws)
+            body = ws.closebody === nothing ? CloseFrameBody(1000, "") : ws.closebody::CloseFrameBody
+            @try_ignore begin
+                close(ws, body)
+            end
+        end
+    end
+    return nothing
 end
 
 function _serve_ws_session!(server::Server, conn, request::Request, response::Response)::Nothing

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -111,34 +111,43 @@ function _read_until_deadline(conn::NC.Conn; timeout_s::Float64 = 1.0)::String
 end
 
 function _read_until_quiet(conn::NC.Conn; timeout_s::Float64 = 1.0, quiet_timeout_s::Float64 = 0.1)::String
-    buf = Vector{UInt8}(undef, 1024)
-    out = UInt8[]
-    deadline_ns = Int64(time_ns()) + round(Int64, timeout_s * 1.0e9)
-    saw_bytes = false
-    while true
-        remaining_ns = deadline_ns - Int64(time_ns())
-        remaining_ns <= 0 && break
-        read_timeout_s = saw_bytes ? min(quiet_timeout_s, remaining_ns / 1.0e9) : (remaining_ns / 1.0e9)
-        NC.set_read_deadline!(conn, Int64(time_ns()) + round(Int64, read_timeout_s * 1.0e9))
-        try
-            chunk = readavailable(conn)
-            n = length(chunk)
-            n == 0 && break
-            n > length(buf) && resize!(buf, n)
-            copyto!(buf, 1, chunk, 1, n)
-            append!(out, @view(buf[1:n]))
-            saw_bytes = true
-        catch err
-            if err isa IOP.DeadlineExceededError || err isa EOFError
-                break
+    # Task-level watchdog. The set_read_deadline! below is the intended timeout
+    # mechanism, but on Windows a re-armed read deadline can intermittently fail
+    # to wake a parked `readavailable`, stranding this loop indefinitely (Reseau
+    # IOCP issue JuliaServices/Reseau.jl#107). Bounding the whole read here turns
+    # a strand into a fast, legible failure instead of hanging the suite, and
+    # covers callers that invoke `_read_until_quiet` directly (not just via
+    # `_raw_http_request`).
+    return _run_with_timeout(; timeout_s = timeout_s + 5.0, label = "_read_until_quiet") do
+        buf = Vector{UInt8}(undef, 1024)
+        out = UInt8[]
+        deadline_ns = Int64(time_ns()) + round(Int64, timeout_s * 1.0e9)
+        saw_bytes = false
+        while true
+            remaining_ns = deadline_ns - Int64(time_ns())
+            remaining_ns <= 0 && break
+            read_timeout_s = saw_bytes ? min(quiet_timeout_s, remaining_ns / 1.0e9) : (remaining_ns / 1.0e9)
+            NC.set_read_deadline!(conn, Int64(time_ns()) + round(Int64, read_timeout_s * 1.0e9))
+            try
+                chunk = readavailable(conn)
+                n = length(chunk)
+                n == 0 && break
+                n > length(buf) && resize!(buf, n)
+                copyto!(buf, 1, chunk, 1, n)
+                append!(out, @view(buf[1:n]))
+                saw_bytes = true
+            catch err
+                if err isa IOP.DeadlineExceededError || err isa EOFError
+                    break
+                end
+                if HT._is_peer_close_error(err::Exception)
+                    break
+                end
+                rethrow(err)
             end
-            if HT._is_peer_close_error(err::Exception)
-                break
-            end
-            rethrow(err)
         end
+        return String(out)
     end
-    return String(out)
 end
 
 function _read_until_close(conn::NC.Conn; timeout_s::Float64 = 1.0)::Tuple{String, Bool}
@@ -763,7 +772,9 @@ end
         write(sock, Vector{UInt8}(codeunits("GET / HTTP/1.1\r\nHost: $(address)\r\n\r\n")))
         status = timedwait(() -> isready(timeout_seen), 5.0; pollint = 0.001)
         @test status != :timed_out
-        @test take!(timeout_seen)
+        # Only take! when the channel is ready: if the write-timeout did not fire
+        # (status timed out), take! on an empty channel would hang forever.
+        status == :timed_out || @test take!(timeout_seen)
     finally
         HT.@try_ignore begin
             NC.close(sock)

--- a/test/http_websocket_integration_tests.jl
+++ b/test/http_websocket_integration_tests.jl
@@ -158,3 +158,58 @@ end
         _close_ws_quiet!(task)
     end
 end
+
+@testset "HTTP.WebSockets.upgrade mixes HTTP and WebSocket routes" begin
+    # Manual upgrade from a normal HTTP.listen! stream handler (1.x parity): one
+    # server serves both a normal HTTP route and a WebSocket route. read_timeout
+    # is short to prove upgrade() clears the server's per-request read deadline.
+    server = HT.listen!("127.0.0.1", 0; listenany = true, read_timeout = 1) do stream
+        if W.isupgrade(stream.message)
+            W.upgrade(stream) do ws
+                for msg in ws
+                    W.send(ws, msg)
+                end
+            end
+        else
+            HT.setstatus(stream, 200)
+            HT.startwrite(stream)
+            write(stream, "ok")
+        end
+    end
+    try
+        address = "127.0.0.1:$(HT.port(server))"
+        # normal HTTP route on the same server
+        r = HT.get("http://$address/"; status_exception = false)
+        @test r.status == 200
+        @test String(r.body) == "ok"
+        # WebSocket route: text + binary echo
+        W.open("ws://$address/ws") do ws
+            W.send(ws, "hello")
+            @test W.receive(ws) == "hello"
+            W.send(ws, UInt8[1, 2, 3])
+            @test W.receive(ws) == UInt8[1, 2, 3]
+        end
+        # upgrade() must clear the per-request read deadline: a pause longer than
+        # read_timeout (1s) must not tear down the WebSocket session.
+        W.open("ws://$address/ws") do ws
+            W.send(ws, "a")
+            @test W.receive(ws) == "a"
+            sleep(1.5)
+            W.send(ws, "b")
+            @test W.receive(ws) == "b"
+        end
+        # server still serves normal HTTP after the WebSocket sessions
+        r2 = HT.get("http://$address/"; status_exception = false)
+        @test r2.status == 200
+        @test String(r2.body) == "ok"
+    finally
+        HT.forceclose(server)
+    end
+end
+
+@testset "HTTP.WebSockets.upgrade rejects non-upgradeable streams" begin
+    # A client-style stream has no tracked server connection and cannot be upgraded.
+    bad = HT.Request("GET", "/"; headers = ["Host" => "127.0.0.1"])
+    stream = HT.Stream(bad)
+    @test_throws W.WebSocketError W.upgrade(ws -> nothing, stream)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,39 @@ const ND = Reseau.HostResolvers
 const NC = Reseau.TCP
 const IP = Reseau.IOPoll
 
+# --- Hang diagnostic watchdog ---------------------------------------------
+# An intermittent hang strikes various timeout/network tests on Windows CI, in a
+# different testset each run (root cause: Reseau IOCP read-deadline strand,
+# JuliaServices/Reseau.jl#107). If the suite exceeds this budget, dump every
+# task's backtrace so CI captures a stack trace pinpointing the stuck task, then
+# hard-exit before the job's wall-clock cap swallows the output. Tune/disable via
+# HTTP_HANG_WATCHDOG_S (<= 0 disables).
+const _HANG_WATCHDOG_BUDGET_S = parse(Float64, get(ENV, "HTTP_HANG_WATCHDOG_S", "1200"))
+function _arm_hang_watchdog()
+    _HANG_WATCHDOG_BUDGET_S > 0 || return nothing
+    Threads.@spawn begin
+        deadline = time() + _HANG_WATCHDOG_BUDGET_S
+        while time() < deadline
+            sleep(5.0)
+        end
+        try
+            println(stderr, "\n\n==== HTTP HANG WATCHDOG: suite exceeded $(_HANG_WATCHDOG_BUDGET_S)s ====")
+            println(stderr, "==== dumping all task backtraces to locate the stuck task ====")
+            flush(stdout)
+            flush(stderr)
+            ccall(:jl_print_task_backtraces, Cvoid, (Cint,), 0)
+            flush(stderr)
+        catch err
+            println(stderr, "==== HANG WATCHDOG: backtrace dump failed: ", err)
+            flush(stderr)
+        end
+        sleep(2.0)
+        ccall(:exit, Cvoid, (Cint,), 1)
+    end
+    return nothing
+end
+_arm_hang_watchdog()
+
 function _include_with_progress(path::AbstractString)
     _log_test_progress("[runtests] include START: $(path)")
     include(path)


### PR DESCRIPTION
## Summary

HTTP.jl 1.x let you upgrade an in-flight server stream to a WebSocket by hand
(`WebSockets.upgrade(f, http::Stream)`), which is how a single `HTTP.listen!` /
`HTTP.Router` server could serve both ordinary HTTP routes and WebSocket routes.
The 2.0 rewrite only shipped the standalone `WebSockets.listen!` accept loop, so
this manual path went missing. This PR restores it.

```julia
HTTP.listen!("127.0.0.1", 8080) do stream
    if HTTP.WebSockets.isupgrade(stream.message)
        HTTP.WebSockets.upgrade(stream) do ws
            for msg in ws
                HTTP.WebSockets.send(ws, msg)
            end
        end
    else
        HTTP.setstatus(stream, 200)
        HTTP.startwrite(stream)
        write(stream, "ok")
    end
end
```

## How it works

- Writes the 101 handshake straight to the connection, then takes the socket
  away from the HTTP/1 server loop using the existing `write_closed` /
  `read_closed` flags plus `response.close`, so the loop's post-handler
  teardown becomes a no-op and it stops reading further requests off what is now
  a WebSocket.
- Clears the per-request read deadline the server armed before invoking the
  handler, so a long-lived WebSocket isn't torn down mid-session (covered by a
  test that idles longer than `read_timeout`).
- Hands any bytes buffered past the handshake request to the WebSocket codec
  (mirrors the existing client handshake path).
- Rejects upgrades over HTTP/2 with a clear error.

## Changes

- **`WebSockets.upgrade(f, stream)`** — new public API.
- **`_upgrade_response`** parameterized by `subprotocols` / `check_origin`; the
  `Server` method is now a thin wrapper over it (no behavior change — existing
  server origin / subprotocol / invalid-key tests still pass).
- Server `Stream`s now retain their per-connection reader so `upgrade` can
  recover buffered bytes. Server body reads go through `request_body`, so
  `stream.reader` is otherwise unused on the server side.
- Migration guide section documenting `upgrade`.

## Tests

New integration tests: mixed HTTP + WS on one `listen!` (text + binary echo),
the read-deadline-clearing case, and rejection of non-upgradeable streams.
Existing WebSocket client / server / integration suites and the HTTP/1 server
suite still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
