### PR TITLE
ci: fail fast on hangs + de-flake Windows (timeout, concurrency, watchdog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,21 @@ on:
   pull_request:
   release:
 
+# Cancel superseded in-progress runs for the same PR. Pushes to master/release
+# use the unique run_id as the group, so those are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    # Fail fast on a hung job instead of running to GitHub's 6h default. Clean
+    # jobs finish in <=11m; 25m leaves headroom for cache-cold precompilation.
+    timeout-minutes: 25
+    # Prerelease Julia is informational; don't let it block merges.
+    continue-on-error: ${{ matrix.version == 'pre' }}
     strategy:
       fail-fast: false
       matrix:

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -46,32 +46,42 @@ function HT.body_close!(body::_BlockingResponseBody)
     return nothing
 end
 
+# Both raw-socket helpers bound their reads with socket read deadlines, but on
+# Windows a blocked `readavailable` is not always interrupted by the deadline,
+# so the loop never gets back to its own timeout check and the read hangs
+# indefinitely. Wrap the whole exchange in `_run_with_timeout`, a task-level
+# watchdog that does not depend on socket deadlines, so a stuck read fails the
+# test in seconds instead of hanging the job until CI's wall-clock limit.
 function _raw_http_request(port::Integer, request::AbstractString; settle_s::Float64 = 0.5, close_write::Bool = true)::String
-    sock = ND.connect("tcp", "127.0.0.1:$(Int(port))")
-    try
-        write(sock, Vector{UInt8}(codeunits(String(request))))
-        if close_write
-            HT.@try_ignore begin
-                NC.closewrite(sock)
+    return _run_with_timeout(; timeout_s = max(8.0, settle_s + 4.0), label = "raw http request (port $(port))") do
+        sock = ND.connect("tcp", "127.0.0.1:$(Int(port))")
+        try
+            write(sock, Vector{UInt8}(codeunits(String(request))))
+            if close_write
+                HT.@try_ignore begin
+                    NC.closewrite(sock)
+                end
             end
+            return _read_until_quiet(
+                sock;
+                timeout_s = max(2.0, settle_s + 1.0),
+                quiet_timeout_s = min(0.25, max(0.05, settle_s)),
+            )
+        finally
+            NC.close(sock)
         end
-        return _read_until_quiet(
-            sock;
-            timeout_s = max(2.0, settle_s + 1.0),
-            quiet_timeout_s = min(0.25, max(0.05, settle_s)),
-        )
-    finally
-        NC.close(sock)
     end
 end
 
 function _raw_http_request_until_close(port::Integer, request::AbstractString; timeout_s::Float64 = 3.0)::Tuple{String, Bool}
-    sock = ND.connect("tcp", "127.0.0.1:$(Int(port))")
-    try
-        write(sock, Vector{UInt8}(codeunits(String(request))))
-        return _read_until_close(sock; timeout_s)
-    finally
-        NC.close(sock)
+    return _run_with_timeout(; timeout_s = timeout_s + 4.0, label = "raw http request until close (port $(port))") do
+        sock = ND.connect("tcp", "127.0.0.1:$(Int(port))")
+        try
+            write(sock, Vector{UInt8}(codeunits(String(request))))
+            return _read_until_close(sock; timeout_s)
+        finally
+            NC.close(sock)
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

CI turnaround has been unreliable: runs occasionally hang for **up to GitHub's 6-hour default** while every other job finishes in minutes. Investigation across recent runs shows this is **not steady slowness** — on a healthy run Windows is the *fastest* tier:

| Run | macOS | Ubuntu | Windows |
|---|---|---|---|
| Clean | 7m | 10–11m | **6–6.5m** |
| Hung | 9m ✓ | 8–10m ✓ | **36m → cancelled** |
| Hung | 7m ✓ | 10–11m ✓ | **360m (6h cap)** |

The problem is an **intermittent hard hang in a Windows job**, with nothing to bound it: no `timeout-minutes`, and no `concurrency` cancellation (superseded PR runs pile up).

**Root cause of the hang:** the raw-socket test helpers in `http_server_http1_tests.jl` bound their reads with socket read deadlines (`set_read_deadline!`), but on Windows a blocked `readavailable` is not reliably interrupted by the deadline, so control never returns to the loop's own timeout check and the read hangs forever. The last healthy run before silence was always `HTTP server stream handler emits chunked trailers` → the next raw read hung.

## Changes

**`ci.yml`**
- `timeout-minutes: 25` on the test job — a hang now fails in minutes, not hours (clean jobs ≤11m, so generous headroom for cache-cold precompiles).
- `concurrency` group with `cancel-in-progress: true` — a new push cancels superseded PR runs. `master`/release pushes use the unique `run_id` as the group key, so they are **never** cancelled.
- `continue-on-error` for `version: 'pre'` — prerelease Julia is informational and the windows/pre combo is the most frequent hanger; it shouldn't block merges.

**`test/http_server_http1_tests.jl`**
- Wrap `_raw_http_request` and `_raw_http_request_until_close` in the existing `_run_with_timeout` task-level watchdog (`Threads.@spawn` + `timedwait`), which does not depend on socket deadlines. A stuck read now fails the test in seconds instead of hanging the job. This covers all 10 call sites at once and is behavior-neutral on Linux/macOS (verified locally — full `http_server_http1_tests.jl` suite passes, including the previously-hanging chunked-trailers testset).

## Impact

Worst-case turnaround drops from **~6 hours → ~25 minutes**, superseded runs stop piling up, and the actual Windows hang is converted into a fast, legible test failure.

## Note on branch protection

The `continue-on-error` change makes `pre` non-blocking at the **run** level. If `Julia pre - *` jobs are currently listed as **required status checks** in branch protection, they should be removed from the required list in repo settings — that's a settings change this PR can't make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
