### PR TITLE
test(server): fix intermittent Windows CI hang + add suite hang-watchdog

### DIFF
--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -111,34 +111,43 @@ function _read_until_deadline(conn::NC.Conn; timeout_s::Float64 = 1.0)::String
 end
 
 function _read_until_quiet(conn::NC.Conn; timeout_s::Float64 = 1.0, quiet_timeout_s::Float64 = 0.1)::String
-    buf = Vector{UInt8}(undef, 1024)
-    out = UInt8[]
-    deadline_ns = Int64(time_ns()) + round(Int64, timeout_s * 1.0e9)
-    saw_bytes = false
-    while true
-        remaining_ns = deadline_ns - Int64(time_ns())
-        remaining_ns <= 0 && break
-        read_timeout_s = saw_bytes ? min(quiet_timeout_s, remaining_ns / 1.0e9) : (remaining_ns / 1.0e9)
-        NC.set_read_deadline!(conn, Int64(time_ns()) + round(Int64, read_timeout_s * 1.0e9))
-        try
-            chunk = readavailable(conn)
-            n = length(chunk)
-            n == 0 && break
-            n > length(buf) && resize!(buf, n)
-            copyto!(buf, 1, chunk, 1, n)
-            append!(out, @view(buf[1:n]))
-            saw_bytes = true
-        catch err
-            if err isa IOP.DeadlineExceededError || err isa EOFError
-                break
+    # Task-level watchdog. The set_read_deadline! below is the intended timeout
+    # mechanism, but on Windows a re-armed read deadline can intermittently fail
+    # to wake a parked `readavailable`, stranding this loop indefinitely (Reseau
+    # IOCP issue JuliaServices/Reseau.jl#107). Bounding the whole read here turns
+    # a strand into a fast, legible failure instead of hanging the suite, and
+    # covers callers that invoke `_read_until_quiet` directly (not just via
+    # `_raw_http_request`).
+    return _run_with_timeout(; timeout_s = timeout_s + 5.0, label = "_read_until_quiet") do
+        buf = Vector{UInt8}(undef, 1024)
+        out = UInt8[]
+        deadline_ns = Int64(time_ns()) + round(Int64, timeout_s * 1.0e9)
+        saw_bytes = false
+        while true
+            remaining_ns = deadline_ns - Int64(time_ns())
+            remaining_ns <= 0 && break
+            read_timeout_s = saw_bytes ? min(quiet_timeout_s, remaining_ns / 1.0e9) : (remaining_ns / 1.0e9)
+            NC.set_read_deadline!(conn, Int64(time_ns()) + round(Int64, read_timeout_s * 1.0e9))
+            try
+                chunk = readavailable(conn)
+                n = length(chunk)
+                n == 0 && break
+                n > length(buf) && resize!(buf, n)
+                copyto!(buf, 1, chunk, 1, n)
+                append!(out, @view(buf[1:n]))
+                saw_bytes = true
+            catch err
+                if err isa IOP.DeadlineExceededError || err isa EOFError
+                    break
+                end
+                if HT._is_peer_close_error(err::Exception)
+                    break
+                end
+                rethrow(err)
             end
-            if HT._is_peer_close_error(err::Exception)
-                break
-            end
-            rethrow(err)
         end
+        return String(out)
     end
-    return String(out)
 end
 
 function _read_until_close(conn::NC.Conn; timeout_s::Float64 = 1.0)::Tuple{String, Bool}
@@ -763,7 +772,9 @@ end
         write(sock, Vector{UInt8}(codeunits("GET / HTTP/1.1\r\nHost: $(address)\r\n\r\n")))
         status = timedwait(() -> isready(timeout_seen), 5.0; pollint = 0.001)
         @test status != :timed_out
-        @test take!(timeout_seen)
+        # Only take! when the channel is ready: if the write-timeout did not fire
+        # (status timed out), take! on an empty channel would hang forever.
+        status == :timed_out || @test take!(timeout_seen)
     finally
         HT.@try_ignore begin
             NC.close(sock)

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -773,6 +773,61 @@ end
     end
 end
 
+@testset "HTTP server write timeout fires reliably under repetition (Windows write-timeout repro)" begin
+    # Looped, watchdog-bounded repro of the intermittent Windows hang in
+    # "HTTP server write timeout aborts stalled responses". Reseau's raw-conn
+    # deadlines were exonerated (single-arm, concurrent, and re-arm-per-write all
+    # pass on Windows), so this exercises the layer above: HTTP.jl's chunked
+    # server stream-write path (_server_write -> chunk framing ->
+    # _write_server_stream_bytes! -> per-chunk write-deadline re-arm). Each
+    # iteration counts a "strand" if the handler's stalled write does not surface
+    # a write-timeout within the watchdog, and fails fast instead of hanging.
+    iterations = 60
+    watchdog_s = 5.0
+    strands = 0
+    for _ in 1:iterations
+        timeout_seen = Channel{Bool}(1)
+        server = HT.Server(
+            address = "127.0.0.1:0",
+            stream = true,
+            write_timeout_ns = 200_000_000,
+            handler = stream -> begin
+                _ = HT.startread(stream)
+                HT.setstatus(stream, 200)
+                HT.startwrite(stream)
+                chunk = fill(UInt8('x'), 4 * 1024)   # small chunks: more frames + re-arms
+                try
+                    while true
+                        write(stream, chunk)
+                    end
+                catch err
+                    put!(timeout_seen, err isa IOP.DeadlineExceededError)
+                end
+                return nothing
+            end,
+        )
+        HT.listen!(server)
+        address = HT.server_addr(server)
+        sock = ND.connect("tcp", "127.0.0.1:$(HT.port(server))")
+        try
+            write(sock, Vector{UInt8}(codeunits("GET / HTTP/1.1\r\nHost: $(address)\r\n\r\n")))
+            status = timedwait(() -> isready(timeout_seen), watchdog_s; pollint = 0.001)
+            if status == :timed_out
+                strands += 1
+            else
+                @test take!(timeout_seen)
+            end
+        finally
+            HT.@try_ignore begin
+                NC.close(sock)
+            end
+            _run_with_timeout(() -> HT.forceclose(server); label = "server forceclose")
+            _run_with_timeout(() -> wait(server); label = "server task completion")
+        end
+    end
+    @test strands == 0
+end
+
 @testset "HTTP server ordinary handlers suppress bodies for HEAD" begin
     server = HT.serve!("127.0.0.1", 0; listenany = true) do request
             return HT.Response(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,38 @@ const ND = Reseau.HostResolvers
 const NC = Reseau.TCP
 const IP = Reseau.IOPoll
 
+# --- Hang diagnostic watchdog ---------------------------------------------
+# An intermittent hang strikes various timeout/network tests on Windows CI, in a
+# different testset each run. If the suite exceeds this budget, dump every task's
+# backtrace so CI captures a stack trace pinpointing the stuck task, then hard-
+# exit before the job's wall-clock cap swallows the output. Tune/disable via
+# HTTP_HANG_WATCHDOG_S (<= 0 disables).
+const _HANG_WATCHDOG_BUDGET_S = parse(Float64, get(ENV, "HTTP_HANG_WATCHDOG_S", "1200"))
+function _arm_hang_watchdog()
+    _HANG_WATCHDOG_BUDGET_S > 0 || return nothing
+    Threads.@spawn begin
+        deadline = time() + _HANG_WATCHDOG_BUDGET_S
+        while time() < deadline
+            sleep(5.0)
+        end
+        try
+            println(stderr, "\n\n==== HTTP HANG WATCHDOG: suite exceeded $(_HANG_WATCHDOG_BUDGET_S)s ====")
+            println(stderr, "==== dumping all task backtraces to locate the stuck task ====")
+            flush(stdout)
+            flush(stderr)
+            ccall(:jl_print_task_backtraces, Cvoid, (Cint,), 0)
+            flush(stderr)
+        catch err
+            println(stderr, "==== HANG WATCHDOG: backtrace dump failed: ", err)
+            flush(stderr)
+        end
+        sleep(2.0)
+        ccall(:exit, Cvoid, (Cint,), 1)
+    end
+    return nothing
+end
+_arm_hang_watchdog()
+
 function _include_with_progress(path::AbstractString)
     _log_test_progress("[runtests] include START: $(path)")
     include(path)


### PR DESCRIPTION
## What this fixes

The intermittent **Windows CI hang** that struck a different timeout/network testset each run (and previously ran to the 6-hour cap before #1256 added a 25-minute timeout).

## Root cause (captured, not guessed)

A test-suite **hang watchdog** (added here in `runtests.jl`) dumped task backtraces when a Windows run exceeded its budget, pinpointing the stuck task:

```
readavailable      → Reseau 3_tcp.jl:883   (parked in waitread/pollwait!)
_read_until_quiet  → test/http_server_http1_tests.jl
@test              → idle-timeout testset
```

`_read_until_quiet` loops `set_read_deadline!` + `readavailable`; on Windows the **re-armed read deadline intermittently fails to wake the parked `readavailable`**, so it blocks forever. The idle-timeout testset called `_read_until_quiet` **directly** (unguarded), unlike `_raw_http_request` which #1256 already watchdog-wrapped — so nothing bounded it.

The underlying transport bug is filed as **JuliaServices/Reseau.jl#107** (it is *not* reproducible in isolation — four targeted Reseau repros pass cleanly on Windows; it needs the full integrated poller load, which is why it was so elusive).

## Changes

- **`runtests.jl`** — hang watchdog that dumps all task backtraces if the suite exceeds `HTTP_HANG_WATCHDOG_S` (default 1200s, under the 25-min job cap) and hard-exits, so any future Windows hang is self-diagnosing. *(This is how the root cause was found; worth keeping permanently.)*
- **`_read_until_quiet`** — bounded with the existing `_run_with_timeout` task watchdog, so a Reseau read-deadline strand fails fast instead of hanging. Covers direct callers and `_raw_http_request` callers.
- **write-timeout test** — guard the `take!` so a missed write-timeout can't block on an empty channel (a latent second hang).
- A looped, watchdog-bounded write-timeout repro testset (diagnostic; harmless, can stay as a regression guard).

## Result

Windows CI no longer hangs on this class of strand — a strand now surfaces as a fast, legible test failure with a backtrace, while the common case stays green. Verified locally on macOS (server suite passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
