### PR TITLE
Percent-decode userinfo before building Basic auth header (RFC 3986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Percent-decode `userinfo` before building the `Basic` auth header (RFC 3986); fixes wrong credentials for request URLs and proxies containing percent-encoded characters.
+
 ## [v2.0.0] - 2026-04-27
 HTTP.jl 2.0 is a major rewrite of the package internals and public API. The
 release keeps the familiar `HTTP.request`, verb helpers, `HTTP.serve`, routing,

--- a/src/http_client_url.jl
+++ b/src/http_client_url.jl
@@ -183,9 +183,11 @@ end
 end
 
 @inline function _userinfo_basic_authorization(userinfo::AbstractString)::String
+    # Per RFC 3986 §3.2.1 the userinfo sub-components are percent-encoded; decode
+    # them before building the Basic credential (matches 1.x, curl and browsers).
     parts_split = split(userinfo, ':'; limit=2)
-    username = parts_split[1]
-    password = length(parts_split) == 2 ? parts_split[2] : ""
+    username = URIs.unescapeuri(parts_split[1])
+    password = length(parts_split) == 2 ? URIs.unescapeuri(parts_split[2]) : ""
     return "Basic " * _base64encode(string(username, ":", password))
 end
 

--- a/test/http_client_proxy_tests.jl
+++ b/test/http_client_proxy_tests.jl
@@ -280,6 +280,20 @@ end
     @test merged.no_proxy !== nothing
 end
 
+@testset "percent-encoded userinfo is decoded for Basic auth" begin
+    # RFC 3986 §3.2.1: userinfo sub-components are percent-encoded and must be
+    # decoded before forming the Basic credential ("%40" -> "@", "%24" -> "\$").
+    # Affects both proxy credentials and request-URL credentials (same code path).
+    proxy = HT.ProxyURL("http://user:p%40ss%24@proxy.local:8080")
+    @test (proxy.all::HT._ProxyTarget).authorization == "Basic " * Base64.base64encode("user:p@ss\$")
+    # an encoded username ("%2B" -> "+") is decoded as well
+    enc_user = HT.ProxyURL("http://a%2Bb:secret@proxy.local:8080")
+    @test (enc_user.all::HT._ProxyTarget).authorization == "Basic " * Base64.base64encode("a+b:secret")
+    # request URL userinfo (not a proxy) is decoded too
+    @test HT._parse_http_url("https://user:p%40ss@api.local/path").authorization ==
+          "Basic " * Base64.base64encode("user:p@ss")
+end
+
 @testset "HTTP proxy no_proxy matching" begin
     matcher = HT.NoProxy("example.com,.internal.local,127.0.0.1,10.0.0.0/8,[::1],*.svc.local,1.2.3.4:8443")
     @test HT._matches_no_proxy(matcher, "example.com", 80)


### PR DESCRIPTION
Fixes #1258

Percent-decode each `userinfo` component via `URIs.unescapeuri` before building the `Basic` credential. No-op for non-encoded userinfo, so existing behavior is preserved. Test added in `test/http_client_proxy_tests.jl` (encoded password, encoded username, request-URL userinfo).