### PR TITLE
feat(websockets): add isready(ws) to poll for buffered messages

### DIFF
--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -11,7 +11,7 @@ with [`WebSocket`](@ref) values directly rather than the lower-level
 """
 module WebSockets
 
-import Base: close, iterate
+import Base: close, iterate, isready
 
 import ..Headers
 import ..HTTPError
@@ -515,6 +515,19 @@ function receive(ws::WebSocket)
     end
     return take!(ws.readchannel)
 end
+
+"""
+    isready(ws) -> Bool
+
+Return `true` when at least one complete message is buffered and can be read with
+[`receive`](@ref) without blocking, and `false` otherwise. Useful for polling a
+WebSocket for incoming messages without committing to a blocking `receive`.
+
+A `false` result does not imply the connection is closed — more messages may
+still arrive. Conversely, messages buffered before the connection closed remain
+`isready` and are returned by `receive` before it throws.
+"""
+isready(ws::WebSocket)::Bool = isready(ws.readchannel)
 
 function Base.iterate(ws::WebSocket, st=nothing)
     # Note: do not early-return on isclosed(ws) here: messages may still be

--- a/test/http_websocket_integration_tests.jl
+++ b/test/http_websocket_integration_tests.jl
@@ -213,3 +213,23 @@ end
     stream = HT.Stream(bad)
     @test_throws W.WebSocketError W.upgrade(ws -> nothing, stream)
 end
+
+@testset "HTTP.WebSockets.isready reports buffered messages" begin
+    server = W.listen!("127.0.0.1", 0) do ws
+        msg = W.receive(ws)
+        W.send(ws, msg)
+    end
+    try
+        address = W.server_addr(server)
+        W.open("ws://$address/isready") do ws
+            @test !isready(ws)                                    # nothing buffered yet
+            W.send(ws, "ping")
+            @test timedwait(() -> isready(ws), 5.0) != :timed_out # echo arrives in the channel
+            @test isready(ws)                                     # a message is ready; receive won't block
+            @test W.receive(ws) == "ping"
+            @test !isready(ws)                                    # drained
+        end
+    finally
+        close(server)
+    end
+end


### PR DESCRIPTION
Closes #1169.

Adds `Base.isready(ws::WebSocket)`, which returns `true` when a complete message is buffered and ready to read with `receive(ws)` without blocking — a public, non-blocking way to check for incoming WebSocket messages. Previously this was only reachable by poking the internal read channel.

```julia
HTTP.WebSockets.open(url) do ws
    if isready(ws)
        msg = HTTP.WebSockets.receive(ws)   # guaranteed not to block
    end
end
```

`isready` semantics match `Channel`: `false` doesn't imply the connection is closed (more may arrive), and messages buffered before close stay `isready` and are returned by `receive` before it throws. Includes a docstring + integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)