### PR TITLE
feat(client): max_decompressed_size guard against decompression bombs

### DIFF
--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -1076,12 +1076,15 @@ function _status_throws(resp::Response)::Bool
     return resp.status >= 300 && !_is_redirect_status(resp.status)
 end
 
-function _read_all_response_bytes(io::IO)::Vector{UInt8}
+function _read_all_response_bytes(io::IO, limit::Int=0)::Vector{UInt8}
     out = UInt8[]
     buf = Vector{UInt8}(undef, 8192)
+    total = 0
     while true
         n = readbytes!(io, buf, length(buf))
         n == 0 && return out
+        total += n
+        limit > 0 && total > limit && throw(DecompressionLimitError(limit))
         append!(out, @view(buf[1:n]))
     end
 end
@@ -1105,18 +1108,19 @@ function _read_all_response_bytes(body::AbstractBody, content_length_hint::Int64
     end
 end
 
-function _copy_response_bytes!(dest::IO, io::IO)::Int64
+function _copy_response_bytes!(dest::IO, io::IO, limit::Int=0)::Int64
     buf = Vector{UInt8}(undef, 8192)
     total = Int64(0)
     while true
         n = readbytes!(io, buf, length(buf))
         n == 0 && return total
         total += n
+        limit > 0 && total > limit && throw(DecompressionLimitError(limit))
         write(dest, view(buf, 1:n))
     end
 end
 
-function _copy_response_bytes!(dest::AbstractVector{UInt8}, io::IO)::Int64
+function _copy_response_bytes!(dest::AbstractVector{UInt8}, io::IO, limit::Int=0)::Int64
     buf = Vector{UInt8}(undef, 8192)
     total = 0
     capacity = length(dest)
@@ -1124,6 +1128,7 @@ function _copy_response_bytes!(dest::AbstractVector{UInt8}, io::IO)::Int64
         n = readbytes!(io, buf, length(buf))
         n == 0 && break
         needed = total + n
+        limit > 0 && needed > limit && throw(DecompressionLimitError(limit))
         needed <= capacity || throw(ArgumentError("Unable to grow response stream IOBuffer $(capacity) large enough for response body size: $(needed)"))
         copyto!(dest, total + 1, buf, 1, n)
         total = needed
@@ -1358,68 +1363,19 @@ function Base.showerror(io::IO, err::DecompressionLimitError)
     return nothing
 end
 
-# IO wrapper that caps how many decompressed bytes may be read from `inner`,
-# throwing `DecompressionLimitError` once the running total exceeds `limit`.
-# Response bodies are read via chunked `readbytes!`, so the limit fires after at
-# most one extra chunk and memory stays bounded near `limit`.
-mutable struct _DecompressLimitReader{S<:IO} <: IO
-    inner::S
-    limit::Int
-    seen::Int
-end
-_DecompressLimitReader(inner::IO, limit::Integer) = _DecompressLimitReader{typeof(inner)}(inner, Int(limit), 0)
-
-@inline function _count_decompressed!(r::_DecompressLimitReader, n::Integer)::Nothing
-    r.seen += Int(n)
-    r.seen > r.limit && throw(DecompressionLimitError(r.limit))
-    return nothing
-end
-
-function Base.readbytes!(r::_DecompressLimitReader, dst::AbstractVector{UInt8}, nb::Integer=length(dst))::Int
-    n = readbytes!(r.inner, dst, nb)
-    _count_decompressed!(r, n)
-    return n
-end
-
-function Base.readavailable(r::_DecompressLimitReader)::Vector{UInt8}
-    chunk = readavailable(r.inner)
-    _count_decompressed!(r, length(chunk))
-    return chunk
-end
-
-function Base.read(r::_DecompressLimitReader)::Vector{UInt8}
-    out = UInt8[]
-    buf = Vector{UInt8}(undef, 65536)
-    while true
-        n = readbytes!(r.inner, buf, length(buf))
-        n == 0 && break
-        _count_decompressed!(r, n)
-        append!(out, @view(buf[1:n]))
-    end
-    return out
-end
-
-Base.eof(r::_DecompressLimitReader)::Bool = eof(r.inner)
-Base.bytesavailable(r::_DecompressLimitReader)::Int = bytesavailable(r.inner)
-Base.isopen(r::_DecompressLimitReader)::Bool = isopen(r.inner)
-Base.close(r::_DecompressLimitReader) = close(r.inner)
-
-function _response_body_reader(incoming::_IncomingResponse, decompress::Union{Nothing,Bool}, max_decompressed_size::Int=0)::Tuple{IO,Union{Nothing,Task}}
+function _response_body_reader(incoming::_IncomingResponse, decompress::Union{Nothing,Bool})::Tuple{IO,Union{Nothing,Task}}
     raw_stream = _BodyIO(incoming.rawbody)
     encoding = _response_content_encoding(incoming.head.headers, decompress)
-    decompressor = if encoding == :gzip
-        CodecZlib.GzipDecompressorStream(raw_stream)
+    if encoding == :gzip
+        return CodecZlib.GzipDecompressorStream(raw_stream), nothing
     elseif encoding == :deflate
-        CodecZlib.ZlibDecompressorStream(raw_stream)
-    else
-        return raw_stream, nothing
+        return CodecZlib.ZlibDecompressorStream(raw_stream), nothing
     end
-    reader = max_decompressed_size > 0 ? _DecompressLimitReader(decompressor, max_decompressed_size) : decompressor
-    return reader, nothing
+    return raw_stream, nothing
 end
 
-function _with_response_reader(f::F, incoming::_IncomingResponse, decompress::Union{Nothing,Bool}, max_decompressed_size::Int=0) where {F}
-    reader, _ = _response_body_reader(incoming, decompress, max_decompressed_size)
+function _with_response_reader(f::F, incoming::_IncomingResponse, decompress::Union{Nothing,Bool}) where {F}
+    reader, _ = _response_body_reader(incoming, decompress)
     try
         return f(reader)
     finally
@@ -1464,16 +1420,16 @@ function _consume_incoming_response!(
             rethrow()
         end
     end
-    return _with_response_reader(incoming, decompress, max_decompressed_size) do reader
+    return _with_response_reader(incoming, decompress) do reader
         if sink === nothing
-            body = _read_all_response_bytes(reader)
+            body = _read_all_response_bytes(reader, max_decompressed_size)
             return body, Int64(length(body))
         end
         if sink isa IO
-            n = _copy_response_bytes!(sink::IO, reader)
+            n = _copy_response_bytes!(sink::IO, reader, max_decompressed_size)
             return nothing, n
         end
-        n = _copy_response_bytes!(sink::AbstractVector{UInt8}, reader)
+        n = _copy_response_bytes!(sink::AbstractVector{UInt8}, reader, max_decompressed_size)
         if sink isa Vector{UInt8}
             return sink::Vector{UInt8}, n
         end

--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -1342,19 +1342,84 @@ function Base.close(io::_BodyIO)
     return nothing
 end
 
-function _response_body_reader(incoming::_IncomingResponse, decompress::Union{Nothing,Bool})::Tuple{IO,Union{Nothing,Task}}
-    raw_stream = _BodyIO(incoming.rawbody)
-    encoding = _response_content_encoding(incoming.head.headers, decompress)
-    if encoding == :gzip
-        return CodecZlib.GzipDecompressorStream(raw_stream), nothing
-    elseif encoding == :deflate
-        return CodecZlib.ZlibDecompressorStream(raw_stream), nothing
-    end
-    return raw_stream, nothing
+"""
+    DecompressionLimitError(limit)
+
+Thrown when an automatically decompressed response body exceeds the
+`max_decompressed_size` byte limit passed to the request. Guards against
+decompression bombs — small compressed payloads that inflate to exhaust memory.
+"""
+struct DecompressionLimitError <: Exception
+    limit::Int
 end
 
-function _with_response_reader(f::F, incoming::_IncomingResponse, decompress::Union{Nothing,Bool}) where {F}
-    reader, _ = _response_body_reader(incoming, decompress)
+function Base.showerror(io::IO, err::DecompressionLimitError)
+    print(io, "DecompressionLimitError: decompressed response body exceeded max_decompressed_size = ", err.limit, " bytes")
+    return nothing
+end
+
+# IO wrapper that caps how many decompressed bytes may be read from `inner`,
+# throwing `DecompressionLimitError` once the running total exceeds `limit`.
+# Response bodies are read via chunked `readbytes!`, so the limit fires after at
+# most one extra chunk and memory stays bounded near `limit`.
+mutable struct _DecompressLimitReader{S<:IO} <: IO
+    inner::S
+    limit::Int
+    seen::Int
+end
+_DecompressLimitReader(inner::IO, limit::Integer) = _DecompressLimitReader{typeof(inner)}(inner, Int(limit), 0)
+
+@inline function _count_decompressed!(r::_DecompressLimitReader, n::Integer)::Nothing
+    r.seen += Int(n)
+    r.seen > r.limit && throw(DecompressionLimitError(r.limit))
+    return nothing
+end
+
+function Base.readbytes!(r::_DecompressLimitReader, dst::AbstractVector{UInt8}, nb::Integer=length(dst))::Int
+    n = readbytes!(r.inner, dst, nb)
+    _count_decompressed!(r, n)
+    return n
+end
+
+function Base.readavailable(r::_DecompressLimitReader)::Vector{UInt8}
+    chunk = readavailable(r.inner)
+    _count_decompressed!(r, length(chunk))
+    return chunk
+end
+
+function Base.read(r::_DecompressLimitReader)::Vector{UInt8}
+    out = UInt8[]
+    buf = Vector{UInt8}(undef, 65536)
+    while true
+        n = readbytes!(r.inner, buf, length(buf))
+        n == 0 && break
+        _count_decompressed!(r, n)
+        append!(out, @view(buf[1:n]))
+    end
+    return out
+end
+
+Base.eof(r::_DecompressLimitReader)::Bool = eof(r.inner)
+Base.bytesavailable(r::_DecompressLimitReader)::Int = bytesavailable(r.inner)
+Base.isopen(r::_DecompressLimitReader)::Bool = isopen(r.inner)
+Base.close(r::_DecompressLimitReader) = close(r.inner)
+
+function _response_body_reader(incoming::_IncomingResponse, decompress::Union{Nothing,Bool}, max_decompressed_size::Int=0)::Tuple{IO,Union{Nothing,Task}}
+    raw_stream = _BodyIO(incoming.rawbody)
+    encoding = _response_content_encoding(incoming.head.headers, decompress)
+    decompressor = if encoding == :gzip
+        CodecZlib.GzipDecompressorStream(raw_stream)
+    elseif encoding == :deflate
+        CodecZlib.ZlibDecompressorStream(raw_stream)
+    else
+        return raw_stream, nothing
+    end
+    reader = max_decompressed_size > 0 ? _DecompressLimitReader(decompressor, max_decompressed_size) : decompressor
+    return reader, nothing
+end
+
+function _with_response_reader(f::F, incoming::_IncomingResponse, decompress::Union{Nothing,Bool}, max_decompressed_size::Int=0) where {F}
+    reader, _ = _response_body_reader(incoming, decompress, max_decompressed_size)
     try
         return f(reader)
     finally
@@ -1375,6 +1440,7 @@ function _consume_incoming_response!(
     incoming::_IncomingResponse,
     sink,
     decompress::Union{Nothing,Bool},
+    max_decompressed_size::Int=0,
 )::Tuple{Any,Int64}
     if _incoming_response_has_no_body(incoming) || !_should_decompress_response(incoming.head.headers, decompress)
         try
@@ -1398,7 +1464,7 @@ function _consume_incoming_response!(
             rethrow()
         end
     end
-    return _with_response_reader(incoming, decompress) do reader
+    return _with_response_reader(incoming, decompress, max_decompressed_size) do reader
         if sink === nothing
             body = _read_all_response_bytes(reader)
             return body, Int64(length(body))
@@ -1716,6 +1782,7 @@ function request(
     query=nothing,
     response_stream=nothing,
     decompress::Union{Nothing,Bool}=nothing,
+    max_decompressed_size::Integer=0,
     sse_callback=nothing,
     client::Union{Nothing,Client}=nothing,
     context::Union{Nothing,RequestContext}=nothing,
@@ -1841,7 +1908,7 @@ function request(
                     return sse_response
                 end
             end
-            final_body, final_length = _consume_incoming_response!(incoming, sink, decompress)
+            final_body, final_length = _consume_incoming_response!(incoming, sink, decompress, Int(max_decompressed_size))
             response = _finalize_request_response(incoming, final_body, final_length, resolved_request, parsed.url)
             final_response = response
             status_exception && _status_throws(response) && throw(StatusError(response))
@@ -1910,6 +1977,7 @@ Keyword arguments:
 - `query`: optional query string or key/value collection appended to the URL
 - `response_stream`: optional sink `IO` or byte buffer written with the final response body
 - `decompress`: `nothing`/`true` auto-decompress gzip and deflate responses, `false` leaves wire bytes untouched
+- `max_decompressed_size`: cap, in bytes, on an auto-decompressed response body; reading past it throws `DecompressionLimitError`, guarding against decompression bombs. `0` (default) disables the limit
 - `sse_callback`: callback receiving `(event)` or `(stream, event)` for
   successful SSE responses
 - `trace`: optional callback receiving request lifecycle events

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -2338,3 +2338,46 @@ end
         HT.forceclose(slow_server)
     end
 end
+
+@testset "max_decompressed_size guards against decompression bombs" begin
+    # ~4 MB of zeros compresses to a few KB of gzip — a small "bomb".
+    big = zeros(UInt8, 4_000_000)
+    gz = transcode(HTTP.CodecZlib.GzipCompressor, big)
+    @test length(gz) < 100_000   # confirm the payload really is small on the wire
+    server = HT.serve!("127.0.0.1", 0; listenany = true) do req
+        return HT.Response(200; headers = ["Content-Encoding" => "gzip"], body = gz)
+    end
+    try
+        base = "http://127.0.0.1:$(HT.port(server))/"
+
+        # No limit (default): the full body decompresses.
+        r = HT.get(base)
+        @test length(r.body) == length(big)
+
+        # Limit below the decompressed size: rejected before the bomb inflates.
+        err = try
+            HT.get(base; max_decompressed_size = 1024)
+            nothing
+        catch e
+            e
+        end
+        @test err isa HTTP.DecompressionLimitError
+        err isa HTTP.DecompressionLimitError && @test err.limit == 1024
+
+        # Limit at/above the decompressed size: succeeds.
+        r2 = HT.get(base; max_decompressed_size = length(big))
+        @test length(r2.body) == length(big)
+
+        # The limit also applies to a caller-owned IO sink.
+        sink = IOBuffer()
+        err2 = try
+            HT.get(base; response_stream = sink, max_decompressed_size = 1024)
+            nothing
+        catch e
+            e
+        end
+        @test err2 isa HTTP.DecompressionLimitError
+    finally
+        HT.forceclose(server)
+    end
+end


### PR DESCRIPTION
Closes #1178.

Auto-decompression (gzip/deflate) currently has no size limit, so a small compressed payload can inflate to exhaust memory (a decompression/zip bomb). This adds an opt-in `max_decompressed_size` request keyword:

```julia
# reject any response whose decompressed body exceeds 10 MiB
HTTP.get(url; max_decompressed_size = 10 * 1024 * 1024)
# -> throws HTTP.DecompressionLimitError before the body inflates
```

- `0` (default) keeps the current unbounded behavior — fully backward compatible.
- The cap wraps the decompressor stream and is checked on each chunked read, so it fires after at most one extra chunk; memory stays bounded near the limit rather than materializing the whole bomb first.
- Applies to both the default materialized `resp.body` and caller-owned `response_stream` sinks.
- New `HTTP.DecompressionLimitError` (with the offending `limit`) for callers to catch.

Tested with a ~4 MB-of-zeros gzip bomb (a few KB on the wire): rejected under a small limit, succeeds with no/large limit, and the limit is enforced on an `IOBuffer` sink too.

Note: scoped to HTTP response-body decompression (the documented OOM vector). WebSocket frame limits are separate (`maxframesize`, see #1181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)