### PR TITLE
CI experiment: test PR 1261 with Reseau Windows IOCP branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="codex/windows-overlapped-tcp-io")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="215ce84d07dee30d2846a8db8b56de1491373641")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="674122b3487b7c7ffd845288110d90d957eee6ae")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="365d67ffb2727da1aaef3e2304070b5a6764ca6c")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
+      - name: Use Reseau Windows IOCP experiment
+        if: matrix.os == 'windows-latest'
+        run: julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.develop(PackageSpec(url="https://github.com/JuliaServices/Reseau.jl", rev="codex/windows-overlapped-tcp-io")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
     # Fail fast on a hung job instead of running to GitHub's 6h default. Clean
     # jobs finish in <=11m; 25m leaves headroom for cache-cold precompilation.
     timeout-minutes: 25
-    env:
-      RESEAU_IOCP_TRACE_ERRORS: '1'
     # Prerelease Julia is informational; don't let it block merges.
     continue-on-error: ${{ matrix.version == 'pre' }}
     strategy:
@@ -48,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="1a8e677fce94177b0b6b4294614742bdbc997bb7")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="a44a716ef0d38faa82a77adb0a282b329cd11b2b")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="db8f99bafe4956135f9c5f89dd1a46ad141487ff")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="a1eb2600c3976d550674623947eaac4d530c27a9")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="a44a716ef0d38faa82a77adb0a282b329cd11b2b")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="d5350e151f64fc40d98ada1f91b6ae455ee22bd0")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="d5350e151f64fc40d98ada1f91b6ae455ee22bd0")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="d5350e16e770515c58cc21f317424584c2336e35")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="codex/windows-overlapped-tcp-io")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="codex/windows-overlapped-tcp-io")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 25
     # Prerelease Julia is informational; don't let it block merges.
     continue-on-error: ${{ matrix.version == 'pre' }}
+    env:
+      RESEAU_IOCP_TRACE_ERRORS: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +48,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="215ce84d07dee30d2846a8db8b56de1491373641")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="7699fd8d92c6c855b67ffd4947e97e06a5616f85")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     # Fail fast on a hung job instead of running to GitHub's 6h default. Clean
     # jobs finish in <=11m; 25m leaves headroom for cache-cold precompilation.
     timeout-minutes: 25
+    env:
+      RESEAU_IOCP_TRACE_ERRORS: '1'
     # Prerelease Julia is informational; don't let it block merges.
     continue-on-error: ${{ matrix.version == 'pre' }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
     timeout-minutes: 25
     # Prerelease Julia is informational; don't let it block merges.
     continue-on-error: ${{ matrix.version == 'pre' }}
-    env:
-      RESEAU_IOCP_TRACE_ERRORS: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="7699fd8d92c6c855b67ffd4947e97e06a5616f85")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="674122b3487b7c7ffd845288110d90d957eee6ae")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.develop(PackageSpec(url="https://github.com/JuliaServices/Reseau.jl", rev="codex/windows-overlapped-tcp-io")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="codex/windows-overlapped-tcp-io")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="452c231b97f431d3818c9b1302264f3498ae98ac")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="1a8e677fce94177b0b6b4294614742bdbc997bb7")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="a1eb2600c3976d550674623947eaac4d530c27a9")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="452c231b97f431d3818c9b1302264f3498ae98ac")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: Use Reseau Windows IOCP experiment
         if: matrix.os == 'windows-latest'
-        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="365d67ffb2727da1aaef3e2304070b5a6764ca6c")); Pkg.instantiate()'
+        run: julia --project=. --startup-file=no --history-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"; using Pkg; Pkg.add(PackageSpec(name="Reseau", url="https://github.com/JuliaServices/Reseau.jl", rev="db8f99bafe4956135f9c5f89dd1a46ad141487ff")); Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/http_transport.jl
+++ b/src/http_transport.jl
@@ -1687,7 +1687,9 @@ function _roundtrip_incoming!(
             if _request_write_done(write_state)
                 wait(writer_task::Task)
                 err = writer_err[]
-                err === nothing || throw(err::Exception)
+                if err !== nothing && !_request_write_head_written(write_state)
+                    throw(err::Exception)
+                end
             end
         else
             try

--- a/src/http_transport.jl
+++ b/src/http_transport.jl
@@ -1663,6 +1663,7 @@ function _roundtrip_incoming!(
                     )
                 catch err
                     writer_err[] = err isa Exception ? err : ProtocolError("request upload failed")
+                    _request_write_head_written(write_state) && return nothing
                     _request_write_allows_close(write_state) || return nothing
                     @try_ignore begin
                         _close_conn!(conn)
@@ -1713,6 +1714,10 @@ function _roundtrip_incoming!(
         end
         _set_conn_read_deadline!(conn, request_deadline)
         early_final = false
+        upload_err = has_request_body ? writer_err[] : nothing
+        if upload_err !== nothing && _request_upload_abort_error(upload_err::Exception)
+            early_final = true
+        end
         if _request_write_should_wait_for_continue(write_state) && _request_write_continue_state(write_state::_RequestWriteState) == _REQUEST_WRITE_CONTINUE_PENDING
             _request_write_mark_continue_suppressed!(write_state::_RequestWriteState)
             early_final = true

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -11,7 +11,7 @@ with [`WebSocket`](@ref) values directly rather than the lower-level
 """
 module WebSockets
 
-import Base: close, iterate
+import Base: close, iterate, isready
 
 import ..Headers
 import ..HTTPError
@@ -515,6 +515,19 @@ function receive(ws::WebSocket)
     end
     return take!(ws.readchannel)
 end
+
+"""
+    isready(ws) -> Bool
+
+Return `true` when at least one complete message is buffered and can be read with
+[`receive`](@ref) without blocking, and `false` otherwise. Useful for polling a
+WebSocket for incoming messages without committing to a blocking `receive`.
+
+A `false` result does not imply the connection is closed — more messages may
+still arrive. Conversely, messages buffered before the connection closed remain
+`isready` and are returned by `receive` before it throws.
+"""
+isready(ws::WebSocket)::Bool = isready(ws.readchannel)
 
 function Base.iterate(ws::WebSocket, st=nothing)
     # Note: do not early-return on isclosed(ws) here: messages may still be

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -339,6 +339,7 @@ end
             req1 = HT.read_request(HT._ConnReader(conn1))
             push!(seen_methods, req1.method)
             push!(seen_targets, req1.target)
+            _ = _read_all_body_bytes_client(req1.body)
             headers1 = HT.Headers()
             HT.setheader(headers1, "Location", "/final")
             HT.setheader(headers1, "Connection", "close")

--- a/test/http_parity_tests.jl
+++ b/test/http_parity_tests.jl
@@ -24,6 +24,14 @@ function _wait_task_parity!(task::Task; timeout_s::Float64 = 5.0)
     return nothing
 end
 
+function _write_response_parity!(conn::NC.Conn, response::HT.Response)
+    io = IOBuffer()
+    HT.write_response!(io, response)
+    write(conn, take!(io))
+    HTTP.@try_ignore closewrite(conn)
+    return nothing
+end
+
 @testset "HTTP parity framing guards" begin
     raw_204 = "HTTP/1.1 204 No Content\r\nContent-Length: 10\r\n\r\nignored"
     response_204 = HT._read_response(IOBuffer(codeunits(raw_204)))
@@ -64,10 +72,7 @@ end
             HT.setheader(headers, "Location", "/next")
             HT.setheader(headers, "Connection", "close")
             resp1 = HT.Response(307, HT.EmptyBody(); reason = "Temporary Redirect", headers = headers, content_length = 0, close = true, request = req1)
-            io1 = IOBuffer()
-            HT.write_response!(io1, resp1)
-            bytes1 = take!(io1)
-            write(conn1, bytes1)
+            _write_response_parity!(conn1, resp1)
         finally
             HTTP.@try_ignore NC.close(conn1)
         end
@@ -76,10 +81,7 @@ end
             req2 = HT.read_request(HT._ConnReader(conn2))
             push!(seen_methods, req2.method)
             resp2 = HT.Response(200, HT.BytesBody(UInt8[0x6f, 0x6b]); content_length = 2, request = req2)
-            io2 = IOBuffer()
-            HT.write_response!(io2, resp2)
-            bytes2 = take!(io2)
-            write(conn2, bytes2)
+            _write_response_parity!(conn2, resp2)
         finally
             HTTP.@try_ignore NC.close(conn2)
         end
@@ -112,9 +114,7 @@ end
             HT.setheader(headers, "Location", "/next")
             HT.setheader(headers, "Connection", "close")
             resp = HT.Response(307, HT.BytesBody(UInt8[0x72]); reason = "Temporary Redirect", headers = headers, content_length = 1, close = true, request = req)
-            io = IOBuffer()
-            HT.write_response!(io, resp)
-            write(conn, take!(io))
+            _write_response_parity!(conn, resp)
         finally
             HTTP.@try_ignore NC.close(conn)
         end
@@ -178,9 +178,7 @@ end
             HT.setheader(headers, "Location", "/next")
             HT.setheader(headers, "Connection", "close")
             resp1 = HT.Response(307, HT.EmptyBody(); reason = "Temporary Redirect", headers = headers, content_length = 0, close = true, request = req1)
-            io1 = IOBuffer()
-            HT.write_response!(io1, resp1)
-            write(conn1, take!(io1))
+            _write_response_parity!(conn1, resp1)
         finally
             HTTP.@try_ignore NC.close(conn1)
         end
@@ -190,9 +188,7 @@ end
             push!(seen_bodies, String(_read_all_parity(req2.body)))
             push!(seen_content_types, HT.header(req2.headers, "Content-Type"))
             resp2 = HT.Response(200, HT.BytesBody(UInt8[0x6f, 0x6b]); content_length = 2, request = req2)
-            io2 = IOBuffer()
-            HT.write_response!(io2, resp2)
-            write(conn2, take!(io2))
+            _write_response_parity!(conn2, resp2)
         finally
             HTTP.@try_ignore NC.close(conn2)
         end
@@ -223,9 +219,7 @@ end
             HT.setheader(headers, "Location", "/next")
             HT.setheader(headers, "Connection", "close")
             resp = HT.Response(307, HT.BytesBody(UInt8[0x72]); reason = "Temporary Redirect", headers = headers, content_length = 1, close = true, request = req)
-            io = IOBuffer()
-            HT.write_response!(io, resp)
-            write(conn, take!(io))
+            _write_response_parity!(conn, resp)
         finally
             HTTP.@try_ignore NC.close(conn)
         end

--- a/test/http_parity_tests.jl
+++ b/test/http_parity_tests.jl
@@ -58,6 +58,7 @@ end
         conn1 = NC.accept(listener)
         try
             req1 = HT.read_request(HT._ConnReader(conn1))
+            _ = _read_all_parity(req1.body)
             push!(seen_methods, req1.method)
             headers = HT.Headers()
             HT.setheader(headers, "Location", "/next")

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -898,18 +898,40 @@ end
 end
 
 @testset "HTTP server stream handler emits chunked trailers" begin
+    events_lock = ReentrantLock()
+    events = String[]
+    function mark_chunked_trailer_event!(event::String)
+        lock(events_lock)
+        try
+            push!(events, event)
+        finally
+            unlock(events_lock)
+        end
+        @info "chunked trailers stream event" event
+        return nothing
+    end
     server = HT.listen!("127.0.0.1", 0; listenany = true) do stream
+            mark_chunked_trailer_event!("handler-enter")
             _ = HT.startread(stream)
+            mark_chunked_trailer_event!("after-startread")
             _ = read(stream)
+            mark_chunked_trailer_event!("after-read")
             HT.setstatus(stream, 200)
             HT.startwrite(stream)
+            mark_chunked_trailer_event!("after-startwrite")
             write(stream, "hello")
+            mark_chunked_trailer_event!("after-write")
             HT.addtrailer(stream, "X-Trailer" => "ok")
+            mark_chunked_trailer_event!("after-addtrailer")
             return nothing
         end
     address = HT.server_addr(server)
     try
         raw = _raw_http_request(HT.port(server), "GET / HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n"; settle_s = 0.3)
+        observed_events = lock(events_lock) do
+            copy(events)
+        end
+        @info "chunked trailers raw response" raw = repr(raw) observed_events
         lower_raw = lowercase(raw)
         @test occursin("transfer-encoding: chunked", lower_raw)
         @test occursin("hello", raw)

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -898,40 +898,18 @@ end
 end
 
 @testset "HTTP server stream handler emits chunked trailers" begin
-    events_lock = ReentrantLock()
-    events = String[]
-    function mark_chunked_trailer_event!(event::String)
-        lock(events_lock)
-        try
-            push!(events, event)
-        finally
-            unlock(events_lock)
-        end
-        @info "chunked trailers stream event" event
-        return nothing
-    end
     server = HT.listen!("127.0.0.1", 0; listenany = true) do stream
-            mark_chunked_trailer_event!("handler-enter")
             _ = HT.startread(stream)
-            mark_chunked_trailer_event!("after-startread")
             _ = read(stream)
-            mark_chunked_trailer_event!("after-read")
             HT.setstatus(stream, 200)
             HT.startwrite(stream)
-            mark_chunked_trailer_event!("after-startwrite")
             write(stream, "hello")
-            mark_chunked_trailer_event!("after-write")
             HT.addtrailer(stream, "X-Trailer" => "ok")
-            mark_chunked_trailer_event!("after-addtrailer")
             return nothing
         end
     address = HT.server_addr(server)
     try
         raw = _raw_http_request(HT.port(server), "GET / HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n"; settle_s = 0.3)
-        observed_events = lock(events_lock) do
-            copy(events)
-        end
-        @info "chunked trailers raw response" raw = repr(raw) observed_events
         lower_raw = lowercase(raw)
         @test occursin("transfer-encoding: chunked", lower_raw)
         @test occursin("hello", raw)

--- a/test/http_websocket_integration_tests.jl
+++ b/test/http_websocket_integration_tests.jl
@@ -213,3 +213,23 @@ end
     stream = HT.Stream(bad)
     @test_throws W.WebSocketError W.upgrade(ws -> nothing, stream)
 end
+
+@testset "HTTP.WebSockets.isready reports buffered messages" begin
+    server = W.listen!("127.0.0.1", 0) do ws
+        msg = W.receive(ws)
+        W.send(ws, msg)
+    end
+    try
+        address = W.server_addr(server)
+        W.open("ws://$address/isready") do ws
+            @test !isready(ws)                                    # nothing buffered yet
+            W.send(ws, "ping")
+            @test timedwait(() -> isready(ws), 5.0) != :timed_out # echo arrives in the channel
+            @test isready(ws)                                     # a message is ready; receive won't block
+            @test W.receive(ws) == "ping"
+            @test !isready(ws)                                    # drained
+        end
+    finally
+        close(server)
+    end
+end


### PR DESCRIPTION
## Summary
- starts from PR #1261 head and pins Windows CI to JuliaServices/Reseau.jl#111 at `d5350e1`
- keeps the WebSocket `isready` tests intact; they pass before the transport-heavy suites
- includes two HTTP-side hardening/test changes discovered during validation:
  - defer request-upload write aborts after the request head has been sent so early final responses can still be read
  - make raw redirect parity test servers drain request bodies and gracefully finish response writes before close on Windows

## Findings
The old Windows hangs on #1261 were not caused by the WebSocket `isready` change. The failing stacks were blocked under Reseau `waitread` while HTTP was reading response status lines. Pinning the Reseau overlapped IOCP branch cleared the previous HTTP/1 server/client failures.

The only remaining HTTP failure after the Reseau fix was in our added raw parity redirect test. With temporary Reseau IOCP tracing enabled during investigation it showed Windows `WSAECONNRESET` (`raw_error = 10054`) when the test server wrote a response and immediately closed; finishing the write side before close made the test about redirect semantics instead of RST timing. The Reseau PR no longer keeps that temporary tracing code.

After trimming the Reseau diagnostics, Reseau CI run `26716840261` passed on head `d5350e16e770515c58cc21f317424584c2336e35`. HTTP run `26716908457` got past the corrected Reseau pin and passed Windows pre, Ubuntu 1/pre, macOS, and docs. The only Actions job failure was Windows Julia 1 in `HTTP/2 server handles concurrent streams on one connection` at `test/http2_server_tests.jl:862` because `elapsed < 1.75` observed `1.8410000801086426`. That is a tight HTTP/2 timing assertion, not the old Windows `waitread` hang.

## Verification
- `julia --project=. --startup-file=no --history-file=no -e 'include("test/http_client_tests.jl")'`
- `julia --project=. --startup-file=no --history-file=no -e 'include("test/http_server_http1_tests.jl")'`
- `julia --project=. --startup-file=no --history-file=no -e 'include("test/http_parity_tests.jl")'`
- `git diff --check`
- Earlier HTTP GitHub Actions run `26703203916` passed all Actions jobs, including both Windows lanes, against the pre-trim Reseau head
- Current trimmed-head validation run `26716908457` passed every Actions job except Windows Julia 1, which hit the HTTP/2 timing assertion above
- External Codecov patch/project checks may still fail on this draft experiment PR

## Related
- JuliaWeb/HTTP.jl#1261
- JuliaServices/Reseau.jl#111
- JuliaServices/Reseau.jl#107

Co-authored by Codex
