### PR TITLE
WebSockets: cut receive-side allocations + pin reader to a home thread

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Jacob Quinn", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HTTP"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "2.0.1"
+version = "2.0.0"
 authors = ["Jacob Quinn", "contributors: https://github.com/JuliaWeb/HTTP.jl/graphs/contributors"]
 
 [deps]

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -312,7 +312,10 @@ function _process_incoming_frame!(ws::WebSocket, frame::WsFrame)::Nothing
     end
     op = frame.opcode
     fin = frame.fin
-    frame_payload = copy(frame.payload)
+    # `frame.payload` is already a fresh owned Vector (the decoder builds each
+    # frame with `copy(dec.payload_buf)`) and the frame is discarded right after
+    # this call, so we can take it directly instead of copying a second time.
+    frame_payload = frame.payload
     if op == UInt8(WsOpcode.PING) || op == UInt8(WsOpcode.PONG)
         return nothing
     end
@@ -385,11 +388,12 @@ function _ws_read_loop!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYT
     buf = Vector{UInt8}(undef, buffer_bytes)
     try
         while true
-            chunk = readavailable(ws.stream)
-            n = length(chunk)
+            # Read directly into the reusable `buf`. `readavailable` would
+            # allocate a fresh Base.SZ_UNBUFFERED_IO (64KB) buffer on every
+            # frame read (16× the bytes/RTT vs HTTP 1.x), driving GC pressure;
+            # `readbytes!(...; all=false)` does one socket read into `buf`.
+            n = readbytes!(ws.stream, buf, length(buf); all=false)
             n == 0 && break
-            n > length(buf) && resize!(buf, n)
-            copyto!(buf, 1, chunk, 1, n)
             ws_on_incoming_data!(frame -> _process_incoming_frame!(ws, frame), ws.codec, @view buf[1:n])
             _flush_ws_output!(ws)
             ws.readclosed && break
@@ -425,7 +429,12 @@ end
 
 function _start_read_task!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYTES)::Nothing
     ws.readtask !== nothing && return nothing
-    ws.readtask = Threads.@spawn _ws_read_loop!(ws, buffer_bytes)
+    # Sticky (`@async`, not `Threads.@spawn`): pin the reader to a home thread.
+    # The poller wakes it via `schedule(task)`; a migratable reader would be
+    # woken into the global pool, forcing a cold parked-worker wake whose cost
+    # scales with nthreads (catastrophic at -t 32). Requires Reseau's `pollwait!`
+    # to preserve task stickiness (it must not reset `task.sticky = false`).
+    ws.readtask = @async _ws_read_loop!(ws, buffer_bytes)
     return nothing
 end
 


### PR DESCRIPTION
Three changes to the server WebSocket receive path, found while profiling Bonito's HTTP.jl 2.0 migration under high thread counts.

**1. `_ws_read_loop!`: read into the reusable buffer instead of allocating per frame.** `readavailable(ws.stream)` allocated a fresh `Base.SZ_UNBUFFERED_IO` (64KB) buffer on every frame read, 16× the bytes/message vs HTTP 1.x. Switched to `readbytes!(ws.stream, buf, length(buf); all=false)`, which does one socket read into the buffer the loop already owns.

**2. `_process_incoming_frame!`: drop a redundant copy.** The decoder already builds each frame with `copy(dec.payload_buf)` (owned), and the frame is discarded right after this call, so the extra `copy(frame.payload)` seems wasted.

**3. `_start_read_task!`: spawn the reader sticky (`@async`) instead of `Threads.@spawn`.** The Reseau poller wakes the reader via `schedule(task)`; a migratable reader is woken into the global run-queue, which under `-t N` forces a cold parked-worker wake whose cost scales with the thread count. Pinning the reader to a home thread keeps the wake cheap.

The thread-scaling story, root cause, and benchmark live in https://github.com/JuliaServices/Reseau.jl/pull/112). That change preserves the reader's stickiness, so #3 only takes effect once it lands. **3** is harmless on current Reseau (the `@async` reader just gets un-stuck, i.e. current behavior), and the two PRs can merge in either order.

Allocation impact on its own (independent of the scaling fix): 
per-RTT allocations 69.5KB -> 3.9KB, GC pauses (50k-message burst) 5–12 -> 0, raw WS server→client drain 2.0M -> 5.4M msg/s. 
Benchmarks on the unreleased Bonito@v5 branch (which has some other performance optimizations): 

 | Metric (@ -t 32) | Bonito@v5 (http@1.11) | http2 (2.0) | http2+fix (2.0) |
  |---|---|---|---|
  | RTT median | ~50 µs | 245 to 318 µs | ~60 µs |
  | RTT p95 | ~95 µs | 5.4 to 7.4 ms | ~105 µs |
  | s2j (server→JS) | ~100k | ~116k | ~110k |
  | j2s (JS→server) | ~90k | ~40k | ~85k |
  | bytes / RTT | ~4.2 KB | 69.5 KB | ~3.9 KB |
  | GC pauses / 50k burst | 0 | 5 to 12 | 0 |


Sadly there are still some (smaller) performance regressions with this PR.