### PR TITLE
Fix HTTP auto fallback on h2 ALPN rejection

### DIFF
--- a/src/http2_client.jl
+++ b/src/http2_client.jl
@@ -872,9 +872,11 @@ function _make_tls_config_for_h2(
     address::String,
     server_name::Union{Nothing,String}=nothing,
     handshake_timeout_ns::Int64=Int64(0),
+    allow_h1_alpn::Bool=false,
 )::TLS.Config
     host, _ = HostResolvers.split_host_port(address)
     effective_server_name = server_name === nothing ? host : server_name
+    default_protocols = allow_h1_alpn ? ["h2", "http/1.1"] : ["h2"]
     if config === nothing
         return TLS.Config(
             effective_server_name,
@@ -885,7 +887,7 @@ function _make_tls_config_for_h2(
             nothing,
             nothing,
             nothing,
-            ["h2"],
+            default_protocols,
             UInt16[],
             handshake_timeout_ns,
             TLS.TLS1_2_VERSION,
@@ -897,9 +899,9 @@ function _make_tls_config_for_h2(
     # If the user supplied an explicit ALPN list, honor it verbatim. Forcing
     # "h2" into a user-restricted list would let the connection negotiate h2
     # against an h1+h2 server even when the caller asked us to pin h1 only.
-    # An empty list still defaults to ["h2"] because the only reason to call
-    # this helper is to attempt an h2 handshake.
-    protocols = isempty(config.alpn_protocols) ? ["h2"] : copy(config.alpn_protocols)
+    # An empty list uses the caller's h2-attempt default: high-level :auto also
+    # offers h1 so TLS can complete and fall back when the peer declines h2.
+    protocols = isempty(config.alpn_protocols) ? default_protocols : copy(config.alpn_protocols)
     effective_handshake_timeout_ns = _min_nonzero_ns(config.handshake_timeout_ns, handshake_timeout_ns)
     effective_server_name = if server_name === nothing
         config.server_name === nothing ? host : config.server_name::String

--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -427,6 +427,7 @@ function _acquire_h2_conn!(
     secure::Bool,
     request::Union{Nothing,Request}=nothing,
     server_name::Union{Nothing,String}=nothing,
+    allow_h1_alpn::Bool=false,
 )::H2Connection
     key = _h2_key(plan)
     base_host_resolver = client.transport.host_resolver
@@ -465,6 +466,7 @@ function _acquire_h2_conn!(
                 address,
                 server_name,
                 tls_handshake_timeout_ns,
+                allow_h1_alpn,
             )
         else
             nothing
@@ -727,7 +729,15 @@ function _do_incoming!(
                 if use_h2
                     conn = nothing
                     try
-                        conn = _acquire_h2_conn!(client, proxy_plan, current_address, current_secure, send_request, current_server_name)
+                        conn = _acquire_h2_conn!(
+                            client,
+                            proxy_plan,
+                            current_address,
+                            current_secure,
+                            send_request,
+                            current_server_name,
+                            protocol == :auto,
+                        )
                         _h2_roundtrip_incoming!(conn::H2Connection, send_request; pending_slot_claimed=true)
                     catch err
                         _drop_h2_conn!(client, proxy_plan, conn)

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -339,6 +339,7 @@ end
             req1 = HT.read_request(HT._ConnReader(conn1))
             push!(seen_methods, req1.method)
             push!(seen_targets, req1.target)
+            _ = _read_all_body_bytes_client(req1.body)
             headers1 = HT.Headers()
             HT.setheader(headers1, "Location", "/final")
             HT.setheader(headers1, "Connection", "close")

--- a/test/http_integration_tests.jl
+++ b/test/http_integration_tests.jl
@@ -86,7 +86,6 @@ end
             tls_config = TL.Config(
                 verify_peer = false,
                 server_name = "localhost",
-                alpn_protocols = ["h2", "http/1.1"],
             ),
             max_idle_per_host = 4,
             max_idle_total = 4,

--- a/test/http_parity_tests.jl
+++ b/test/http_parity_tests.jl
@@ -59,6 +59,7 @@ end
         try
             req1 = HT.read_request(HT._ConnReader(conn1))
             push!(seen_methods, req1.method)
+            _ = _read_all_parity(req1.body)
             headers = HT.Headers()
             HT.setheader(headers, "Location", "/next")
             HT.setheader(headers, "Connection", "close")
@@ -74,6 +75,7 @@ end
         try
             req2 = HT.read_request(HT._ConnReader(conn2))
             push!(seen_methods, req2.method)
+            _ = _read_all_parity(req2.body)
             resp2 = HT.Response(200, HT.BytesBody(UInt8[0x6f, 0x6b]); content_length = 2, request = req2)
             io2 = IOBuffer()
             HT.write_response!(io2, resp2)


### PR DESCRIPTION
## Summary
- offer `http/1.1` alongside `h2` for the default high-level `protocol=:auto` h2 probe
- keep explicit `protocol=:h2` strict and continue honoring user-specified ALPN lists verbatim
- update the TLS auto fallback integration test so it covers the default client ALPN path
- drain POST bodies in redirect test servers before close, avoiding Windows TCP resets with current Reseau

## Root Cause
`protocol=:auto` attempted h2 with a default ALPN list of only `["h2"]`. Some h1-only servers reject that during TLS with `no_application_protocol` before HTTP can observe an ALPN mismatch and run the existing h1 fallback.

The Windows CI failures on the first drafts resolved `Reseau v1.1.3` and exposed unrelated test harness races: redirect test servers sent `Connection: close` responses for POST requests without draining the request body, which can reset the TCP connection on Windows.

## Validation
- `julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; test_args=["http_integration_tests.jl", "http2_client_tests.jl"])'` (test driver ran the full suite)
- `julia --project=. --startup-file=no --history-file=no test/http_client_tests.jl`
- `julia --project=. --startup-file=no --history-file=no test/http_parity_tests.jl`
- live #1265 endpoint with default `protocol=:auto` returns `200` over HTTP/1.1

Refs #1265

Co-authored by Codex
