### PR TITLE
Encode space as '+' in application/x-www-form-urlencoded bodies (#1138)

### DIFF
--- a/src/http_request_bodies.jl
+++ b/src/http_request_bodies.jl
@@ -32,7 +32,12 @@ function _percent_encode_form_component(value)::String
     text = string(value)
     encoded = IOBuffer()
     for b in codeunits(text)
-        if _is_unreserved_form_byte(b)
+        if b == UInt8(' ')
+            # application/x-www-form-urlencoded serializes SP as '+' (WHATWG URL
+            # standard). A literal '+' is not an unreserved form byte, so it still
+            # percent-encodes to %2B below, keeping the round-trip unambiguous.
+            write(encoded, UInt8('+'))
+        elseif _is_unreserved_form_byte(b)
             write(encoded, b)
         else
             print(encoded, '%')

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -1374,7 +1374,7 @@ end
     try
         resp_dict = HT.post("$(base_url)/dict"; body = Dict("name" => "value with spaces"))
         @test resp_dict.status == 200
-        @test String(resp_dict.body) == "name=value%20with%20spaces"
+        @test String(resp_dict.body) == "name=value+with+spaces"
 
         resp_named = HT.post("$(base_url)/named"; body = (name = "value",))
         @test resp_named.status == 200
@@ -1402,7 +1402,7 @@ end
         @test String(resp_form.body) == "multipart"
 
         _wait_task_client!(server_task)
-        @test seen_bodies["/dict"] == "name=value%20with%20spaces"
+        @test seen_bodies["/dict"] == "name=value+with+spaces"
         @test seen_content_types["/dict"] == "application/x-www-form-urlencoded"
         @test seen_bodies["/named"] == "name=value"
         @test seen_content_types["/named"] == "application/x-www-form-urlencoded"

--- a/test/http_forms_tests.jl
+++ b/test/http_forms_tests.jl
@@ -207,8 +207,12 @@ end
     @test view_content_type === nothing
 
     bytes, content_type = HT._materialize_request_body_bytes(Dict("name" => "value with spaces"))
-    @test String(bytes) == "name=value%20with%20spaces"
+    @test String(bytes) == "name=value+with+spaces"   # x-www-form-urlencoded: SP -> '+' (#1138)
     @test content_type == "application/x-www-form-urlencoded"
+
+    # SP serializes as '+', while a literal '+' (and '&', '=') stays percent-encoded,
+    # so application/x-www-form-urlencoded round-trips unambiguously (#1138).
+    @test String(HT._form_urlencode(Dict("k" => "a +b&c=d"))) == "k=a+%2Bb%26c%3Dd"
 
     bytes_named, content_type_named = HT._materialize_request_body_bytes((name = "value",))
     @test String(bytes_named) == "name=value"


### PR DESCRIPTION
Fixes #1138.

## What
`application/x-www-form-urlencoded` request bodies encoded space as `%20`, but the [WHATWG URL standard](https://url.spec.whatwg.org/#urlencoded-serializing) requires space to be serialized as `+`. As reported (and confirmed by @iamed2 / @nguiard), some servers only translate `+`→space when parsing form bodies and leave `%20` literal, silently corrupting values.

## Change
`_percent_encode_form_component` (`src/http_request_bodies.jl`) now emits `+` for SP. The rest of the encoder is unchanged and already correct — in particular a literal `+` is *not* an unreserved form byte, so it still encodes to `%2B`, keeping the round-trip unambiguous:

| input value | before | after |
|---|---|---|
| `a b` | `a%20b` | **`a+b`** |
| `a+b` | `a%2Bb` | `a%2Bb` (unchanged) |
| `a&c=d` | `a%26c%3Dd` | `a%26c%3Dd` (unchanged) |

## Scope note
This affects **form bodies only**. URL **query-string** encoding (the `query=` kwarg) legitimately uses `%20` per RFC 3986 and is deliberately left untouched.

## Tests
- New round-trip assertion in `http_forms_tests.jl`: `_form_urlencode(Dict("k" => "a +b&c=d")) == "k=a+%2Bb%26c%3Dd"`.
- Updated the two existing assertions that codified the old `%20` form body.
- `http_forms_tests.jl` green locally (132/132); encoding verified empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
