### PR TITLE
docs v2.1: note that a manually-set Cookie header is no longer merged with the cookie jar

### DIFF
--- a/docs/src/guides/migration-1x.md
+++ b/docs/src/guides/migration-1x.md
@@ -187,6 +187,24 @@ Useful helpers include `HTTP.header`, `HTTP.headers`, `HTTP.hasheader`,
 `HTTP.headercontains`, `HTTP.setheader`, `HTTP.appendheader`, and
 `HTTP.removeheader`.
 
+## Cookies
+
+In 1.x, a manually-set `Cookie` request header was merged with the cookie jar, so hand-set
+cookies were preserved and augmented with jar / `Set-Cookie` state.
+
+Now, the `Cookie` header is built solely from the jar (plus the `cookies` keyword); a
+`Cookie` entry placed in `headers` is overwritten once the jar holds any cookie (i.e. after
+the first `Set-Cookie`). To send specific cookies:
+
+- use a `CookieJar` (e.g. via a `Client`) — recommended for multi-request sessions,
+  especially when the server **rotates** session cookies (a `Set-Cookie` on each response);
+- pass `cookies = Dict("name" => "value", ...)`;
+- or set `cookies = false` to send a raw `Cookie` header without jar management
+  (no `Set-Cookie` tracking).
+
+A static, hand-built `Cookie` header against a session-rotating server therefore succeeds
+once and is then superseded by the jar; prefer a `CookieJar` so rotation is tracked.
+
 ## Request Context
 
 In 1.x, middleware often treated request context as a plain dictionary. In 2.0,


### PR DESCRIPTION
Documents the cookie header behavior change reported in #1283: in 1.x a manually-set `Cookie` header was merged with the jar, whereas now it is built solely from the jar and overwritten once the jar holds a cookie. Adds a short "Cookies" section to `migration-1x.md` with the recommended approaches.

Closes #1283.

---

**Optional follow-up (your call — not in this PR): surface the silent overwrite with a `@warn`.**

A user-supplied `Cookie` header is currently dropped without notice once the jar is non-empty. A `@warn` would make it visible. Rough sketch in `src/http_client.jl` (the cookie layer that sets the header):

```julia
# capture whether the *caller* supplied a Cookie header, before the redirect/retry loop
user_cookie = HTTP.hasheader(request.headers, "Cookie")   # exact var/scope may differ
...
cookie_value = _cookie_header(cookiejar, cookies, current_secure, host, path)
if cookie_value !== nothing
    user_cookie && @warn "Manually-set `Cookie` header is overridden by the cookie jar; \
        pass cookies via a `CookieJar`/the `cookies` keyword, or use `cookies=false` to send a raw header." maxlog=1
    setheader(send_request.headers, "Cookie", cookie_value)
end
```

Caveat: it must distinguish a caller-supplied header from one carried across redirects/retries (hence capturing `user_cookie` once before the loop). Happy to turn this into a proper change — or add a `cookies=:manual`-style opt-out — if you think it's worth it.