### PR TITLE
Don't sniff a valid-JSON-prefix as application/json (#1084)

### DIFF
--- a/src/http_sniff.jl
+++ b/src/http_sniff.jl
@@ -209,7 +209,16 @@ function _sniff_match(::_SniffTextSig, data::AbstractVector{UInt8}, firstnonws::
 end
 
 function _sniff_match(::_SniffJSONSig, data::AbstractVector{UInt8}, firstnonws::Int)::Bool
-    return isjson(data, firstnonws - 1)[1]
+    matched, i = isjson(data, firstnonws - 1)
+    matched || return false
+    # A valid JSON *prefix* is not enough: e.g. "2A" parses the leading number
+    # but leaves trailing bytes. Require the remainder (within the sniff window)
+    # to be whitespace only, otherwise it isn't JSON.
+    stop = min(length(data), _SNIFF_MAX_LENGTH)
+    @inbounds for j in (i + 1):stop
+        data[j] in _SNIFF_WHITESPACE || return false
+    end
+    return true
 end
 
 const _SNIFF_SIGNATURES = Any[

--- a/test/http_forms_tests.jl
+++ b/test/http_forms_tests.jl
@@ -134,6 +134,19 @@ end
     for json in json_cases
         @test HT.sniff(IOBuffer(json)) == "application/json; charset=utf-8"
     end
+
+    # A valid JSON *prefix* followed by other bytes is not JSON (#1084):
+    # e.g. "2A" parses the leading number but leaves a trailing "A".
+    not_json_cases = [
+        "2A",
+        "12A",
+        "{\"a\":1}junk",
+        "[1,2,3]x",
+    ]
+    for payload in not_json_cases
+        @test HT.sniff(payload) == "text/plain; charset=utf-8"
+        @test HT.sniff(IOBuffer(payload)) == "text/plain; charset=utf-8"
+    end
 end
 
 @testset "HTTP multipart parsing extended cases" begin


### PR DESCRIPTION
Fixes #1084.

## Problem
`HTTP.sniff("2A")` returned `application/json` (likewise `"{\"a\":1}junk"`, `"12A"`, …). The JSON matcher accepted any input whose *leading* bytes parsed as a JSON value and discarded the position it consumed to — so a valid JSON **prefix** was enough.

## Fix
`_sniff_match(::_SniffJSONSig, …)` now keeps the index `isjson` consumed to and requires the remainder (within the 512-byte sniff window) to be whitespace only.

| input | before | after |
|---|---|---|
| `2A` | application/json | **text/plain** |
| `12A` | application/json | **text/plain** |
| `{"a":1}junk` | application/json | **text/plain** |
| `{"a":1}` / `[1,2,3]` / `123` / `  {…}  ` | application/json | application/json (unchanged) |

## Tests
Added not-JSON cases (`2A`, `12A`, `{"a":1}junk`, `[1,2,3]x`) next to the existing sniff coverage; `http_forms_tests` 142/142 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
