### PR TITLE
Wire WebSocket read_idle_timeout into the client read loop (#1062)

### DIFF
--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -56,8 +56,10 @@ import .._request_deadline_ns
 import .._request_connect_host_resolver
 import .._request_connect_phase_deadline_ns
 import .._request_connect_phase_timeout_ns
+import .._request_read_idle_timeout_ns
 import .._request_response_header_deadline_ns
 import .._request_write_deadline_ns
+import .._phase_deadline_ns
 import .._resolve_request_timeout_settings
 import .._apply_request_timeout_settings!
 import ..get_request_context
@@ -388,7 +390,9 @@ end
 
 # Set the read deadline directly on the underlying Reseau stream so an opt-in
 # WebSocket read idle timeout can be re-armed before each read.
-_ws_arm_read_deadline!(stream, deadline_ns::Int64) = TLS.set_read_deadline!(stream, deadline_ns)
+_ws_arm_read_deadline!(stream::TLS.Conn, deadline_ns::Int64) = TLS.set_read_deadline!(stream, deadline_ns)
+_ws_arm_read_deadline!(stream::TCP.Conn, deadline_ns::Int64) = TCP.set_read_deadline!(stream, deadline_ns)
+_ws_read_deadline_ns(timeout_ns::Int64)::Int64 = _phase_deadline_ns(timeout_ns, Int64(0))
 
 function _ws_read_loop!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYTES)::Nothing
     buffer_bytes > 0 || throw(ArgumentError("buffer_bytes must be > 0"))
@@ -399,7 +403,7 @@ function _ws_read_loop!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYT
             # after `read_idle_timeout` seconds with no data, resetting whenever a
             # frame arrives (#1062).
             ws.read_idle_timeout_ns > 0 &&
-                _ws_arm_read_deadline!(ws.stream, Int64(time_ns()) + ws.read_idle_timeout_ns)
+                _ws_arm_read_deadline!(ws.stream, _ws_read_deadline_ns(ws.read_idle_timeout_ns))
             # Read directly into the reusable `buf`. `readavailable` would
             # allocate a fresh Base.SZ_UNBUFFERED_IO (64KB) buffer on every
             # frame read (16× the bytes/RTT vs HTTP 1.x), driving GC pressure;
@@ -810,7 +814,7 @@ function _open_client_websocket(
                 subprotocol=negotiated,
                 maxframesize=maxframesize,
                 maxfragmentation=maxfragmentation,
-                read_idle_timeout_ns=read_idle_timeout > 0 ? round(Int64, read_idle_timeout * 1.0e9) : Int64(0),
+                read_idle_timeout_ns=_request_read_idle_timeout_ns(send_request),
                 is_client=true,
             )
             ws.handshake_request = send_request
@@ -871,11 +875,12 @@ end
 Open a client WebSocket connection to `url`.
 
 Keyword arguments cover handshake headers, redirect behavior, cookies, proxy
-selection, TLS verification, handshake timeout controls, and frame limits.
+selection, TLS verification, timeout controls, and frame limits.
 `request_timeout` applies an overall handshake deadline, while
-`response_header_timeout`, `read_idle_timeout`, and `write_idle_timeout`
-configure the underlying HTTP handshake phases. When called with a function,
-the socket is closed automatically with status code `1000` when `f` returns.
+`response_header_timeout` and `write_idle_timeout` configure HTTP handshake
+phases. `read_idle_timeout` bounds both handshake response-header reads and
+post-upgrade inbound WebSocket inactivity. When called with a function, the
+socket is closed automatically with status code `1000` when `f` returns.
 """
 function open(
     url::AbstractString;

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -388,8 +388,7 @@ end
 
 # Set the read deadline directly on the underlying Reseau stream so an opt-in
 # WebSocket read idle timeout can be re-armed before each read.
-_ws_arm_read_deadline!(stream::TLS.Conn, deadline_ns::Int64) = TLS.set_read_deadline!(stream, deadline_ns)
-_ws_arm_read_deadline!(stream::TCP.Conn, deadline_ns::Int64) = TCP.set_read_deadline!(stream, deadline_ns)
+_ws_arm_read_deadline!(stream, deadline_ns::Int64) = TLS.set_read_deadline!(stream, deadline_ns)
 
 function _ws_read_loop!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYTES)::Nothing
     buffer_bytes > 0 || throw(ArgumentError("buffer_bytes must be > 0"))

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -166,6 +166,7 @@ mutable struct WebSocket{S,C}
     fragment_payload::Vector{UInt8}
     fragment_count::Int
     closebody::Union{Nothing,CloseFrameBody}
+    read_idle_timeout_ns::Int64
 end
 
 function WebSocket(
@@ -174,6 +175,7 @@ function WebSocket(
     subprotocol::Union{Nothing,AbstractString}=nothing,
     maxframesize::Integer=typemax(Int),
     maxfragmentation::Integer=DEFAULT_MAX_FRAG,
+    read_idle_timeout_ns::Integer=0,
     is_client::Bool=true,
 ) where {S,C}
     maxframesize > 0 || throw(ArgumentError("maxframesize must be > 0"))
@@ -199,6 +201,7 @@ function WebSocket(
         UInt8[],
         0,
         nothing,
+        Int64(read_idle_timeout_ns),
     )
     return ws
 end
@@ -383,11 +386,21 @@ function _process_incoming_frame!(ws::WebSocket, frame::WsFrame)::Nothing
     return nothing
 end
 
+# Set the read deadline directly on the underlying Reseau stream so an opt-in
+# WebSocket read idle timeout can be re-armed before each read.
+_ws_arm_read_deadline!(stream::TLS.Conn, deadline_ns::Int64) = TLS.set_read_deadline!(stream, deadline_ns)
+_ws_arm_read_deadline!(stream::TCP.Conn, deadline_ns::Int64) = TCP.set_read_deadline!(stream, deadline_ns)
+
 function _ws_read_loop!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYTES)::Nothing
     buffer_bytes > 0 || throw(ArgumentError("buffer_bytes must be > 0"))
     buf = Vector{UInt8}(undef, buffer_bytes)
     try
         while true
+            # Opt-in read idle timeout: re-arm before each read so it fires only
+            # after `read_idle_timeout` seconds with no data, resetting whenever a
+            # frame arrives (#1062).
+            ws.read_idle_timeout_ns > 0 &&
+                _ws_arm_read_deadline!(ws.stream, Int64(time_ns()) + ws.read_idle_timeout_ns)
             # Read directly into the reusable `buf`. `readavailable` would
             # allocate a fresh Base.SZ_UNBUFFERED_IO (64KB) buffer on every
             # frame read (16× the bytes/RTT vs HTTP 1.x), driving GC pressure;
@@ -402,7 +415,13 @@ function _ws_read_loop!(ws::WebSocket, buffer_bytes::Int=DEFAULT_READ_BUFFER_BYT
             _queue_close!(ws, CloseFrameBody(1006, ""))
         end
     catch err
-        close_body = if err isa WebSocketInvalidPayloadError
+        # A read idle timeout surfaces as IOPoll.DeadlineExceededError over TCP, or
+        # wrapped in a TLS.TLSError (`.cause`) over TLS.
+        read_timed_out = err isa IOPoll.DeadlineExceededError ||
+            (err isa TLS.TLSError && (err::TLS.TLSError).cause isa IOPoll.DeadlineExceededError)
+        close_body = if read_timed_out
+            CloseFrameBody(1006, "websocket read idle timeout")
+        elseif err isa WebSocketInvalidPayloadError
             CloseFrameBody(1007, "invalid websocket payload")
         elseif err isa WebSocketProtocolError
             CloseFrameBody(1002, "websocket protocol error")
@@ -792,6 +811,7 @@ function _open_client_websocket(
                 subprotocol=negotiated,
                 maxframesize=maxframesize,
                 maxfragmentation=maxfragmentation,
+                read_idle_timeout_ns=read_idle_timeout > 0 ? round(Int64, read_idle_timeout * 1.0e9) : Int64(0),
                 is_client=true,
             )
             ws.handshake_request = send_request

--- a/test/http_websocket_client_tests.jl
+++ b/test/http_websocket_client_tests.jl
@@ -143,6 +143,8 @@ end
         @test (timeout_config::HT._RequestTimeoutConfig).response_header_timeout_ns == 250_000_000
         @test timeout_config.read_idle_timeout_ns == 250_000_000
         @test timeout_config.write_idle_timeout_ns == 250_000_000
+        @test ws.read_idle_timeout_ns == 250_000_000
+        @test W._ws_read_deadline_ns(typemax(Int64)) == typemax(Int64)
         @test W.receive(ws) == "hello"
         W.send(ws, "pong")
         err = try

--- a/test/http_websocket_integration_tests.jl
+++ b/test/http_websocket_integration_tests.jl
@@ -233,3 +233,32 @@ end
         close(server)
     end
 end
+
+@testset "HTTP.WebSockets client read_idle_timeout fires on silence (#1062)" begin
+    # The read idle timeout resets on each received message and fires only after
+    # `read_idle_timeout` seconds with no data: it must not interrupt an active
+    # stream, but must surface a silently-stalled connection.
+    server = W.listen!("127.0.0.1", 0) do ws
+        W.send(ws, "hello")
+        sleep(3)                       # stay silent so the client idle timeout fires first
+    end
+    try
+        url = "ws://$(W.server_addr(server))/"
+        msgs = String[]
+        err = nothing
+        try
+            W.open(url; read_idle_timeout = 1.0, suppress_close_error = true) do ws
+                push!(msgs, String(W.receive(ws)))   # "hello" arrives during activity
+                W.receive(ws)                          # no more data -> idle timeout
+            end
+        catch e
+            err = e
+        end
+        @test msgs == ["hello"]
+        @test err isa W.WebSocketError
+        @test err !== nothing && (err::W.WebSocketError).message.code == 1006
+        @test err !== nothing && occursin("idle timeout", (err::W.WebSocketError).message.reason)
+    finally
+        close(server)
+    end
+end

--- a/test/http_websocket_server_tests.jl
+++ b/test/http_websocket_server_tests.jl
@@ -152,6 +152,36 @@ end
     end
 end
 
+@testset "HTTP.WebSockets client read_idle_timeout over wss (#1062)" begin
+    server = W.listen!(
+        "127.0.0.1",
+        0;
+        tls_config = TL.Config(verify_peer = false, cert_file = _TLS_CERT_PATH, key_file = _TLS_KEY_PATH),
+    ) do ws
+        W.send(ws, "hello")
+        sleep(3)                       # stay silent so the client idle timeout fires first
+    end
+    try
+        address = W.server_addr(server)
+        msgs = String[]
+        err = nothing
+        try
+            W.open("wss://$address/"; read_idle_timeout = 1.0, require_ssl_verification = false, suppress_close_error = true) do ws
+                push!(msgs, String(W.receive(ws)))   # "hello" arrives during activity
+                W.receive(ws)                          # no more data -> idle timeout
+            end
+        catch e
+            err = e
+        end
+        @test msgs == ["hello"]
+        @test err isa W.WebSocketError
+        @test err !== nothing && (err::W.WebSocketError).message.code == 1006
+        @test err !== nothing && occursin("idle timeout", (err::W.WebSocketError).message.reason)
+    finally
+        close(server)
+    end
+end
+
 @testset "HTTP.WebSockets server subprotocol negotiation" begin
     server = W.listen!("127.0.0.1", 0; subprotocols = ["chat"]) do ws
         W.send(ws, "ok")


### PR DESCRIPTION
Fixes #1062.

## Problem
`HTTP.WebSockets.open` accepts a `read_idle_timeout` keyword, but for a live session it was a **silent no-op**: the connection's read deadline is cleared right after the handshake, so the read loop never enforced it. A WebSocket that goes silent (server only pushes, then stalls) would block `receive` forever — and #1062 (and #1070's discussion) specifically asked for a timeout that **resets on each received message**.

## Fix
The read loop re-arms the underlying Reseau stream's read deadline before each read when `read_idle_timeout > 0` (mirroring how the HTTP response-body path implements `read_idle_timeout`). So the timeout:
- **resets on every frame** → never interrupts an active stream, and
- **fires after `read_idle_timeout` s of silence** → surfaces a stalled connection as `WebSocketError(1006, "websocket read idle timeout")`.

Default `read_idle_timeout = 0` is unchanged (no timeout). Server- and upgrade-side WebSockets are unaffected (they pass the `0` default).

## Tests
Added an integration test: a client with `read_idle_timeout = 1.0` receives a message during activity (no spurious timeout) and then surfaces the idle timeout after silence — verified reliable across repeated runs. Full WS suite green locally (client 18, server 31, codec 88, integration 42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
