### PR TITLE
Restore merging a manual Cookie header with the jar (de-duped by name)

### DIFF
--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -587,6 +587,7 @@ function _cookie_header(
     secure::Bool,
     host::String,
     path::String,
+    manual::Vector{Cookie}=Cookie[],
 )::Union{Nothing,String}
     cookies === false && return nothing
     merged = Cookie[]
@@ -596,6 +597,22 @@ function _cookie_header(
     end
     if cookies !== true
         append!(merged, cookies::Vector{Cookie})
+    end
+    # Merge a caller-set `Cookie` request header with the managed cookies (this restores
+    # the pre-2.0 behaviour, where a manual header was not silently dropped), but
+    # de-duplicate by name so the wire header never carries the same name twice. Managed
+    # cookies (the jar plus any `cookies=` dict) win; the manual header only contributes
+    # names they do not already cover. This keeps a rotated jar cookie from being
+    # shadowed by a stale manual one and preserves path-scoped same-name cookies held in
+    # the jar. Use `cookies=false` to send a manual `Cookie` header verbatim.
+    if !isempty(manual)
+        managed = Set(c.name for c in merged)
+        for c in manual
+            if !(c.name in managed)
+                push!(merged, c)
+                push!(managed, c.name)
+            end
+        end
     end
     isempty(merged) && return nothing
     return stringify("", merged)
@@ -723,7 +740,8 @@ function _do_incoming!(
             use_h2 = _use_h2(client, current_secure, protocol) && proxy_plan.mode != _ProxyPlanMode.HTTP_FORWARD
             _emit_trace(trace, RequestEvent(send_request, request_url, retry_attempt, redirect_count, use_h2 ? :h2 : :h1))
             host, path = _host_path_from_request(current_address, current_request)
-            cookie_value = _cookie_header(cookiejar, cookies, current_secure, host, path)
+            manual_cookies = cookies === false ? Cookie[] : Cookies.readcookies(send_request.headers, "")
+            cookie_value = _cookie_header(cookiejar, cookies, current_secure, host, path, manual_cookies)
             cookie_value === nothing || setheader(send_request.headers, "Cookie", cookie_value)
             response = try
                 if use_h2
@@ -1937,9 +1955,11 @@ Keyword arguments:
   iterable chunks, and existing `HTTP.AbstractBody` values
 - `proxy`: explicit proxy override for this call; pass a proxy URL string, a
   `ProxyConfig`, or `nothing` to force direct connections
-- `cookies`: `true` to use the effective cookie jar, `false` to disable cookie
-  send/store for this call, or a dictionary of extra cookie name/value pairs to
-  append to jar-derived cookies
+- `cookies`: `true` (default) to use the effective cookie jar, `false` to disable
+  cookie send/store for this call, or a dictionary of extra cookie name/value pairs
+  to add. When the jar is active, it is merged with any manually-set `Cookie` header,
+  de-duplicated by name (jar / `cookies=` entries win); with `false` a manually-set
+  `Cookie` header is sent verbatim
 - `cookiejar`: optional cookie jar override for this call; explicit clients
   default to `client.cookiejar`, while implicit convenience calls default to the
   shared `HTTP.COOKIEJAR`

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -29,6 +29,7 @@ import ..TooManyRedirectsError
 import ..Client
 import ..CookieJar
 import ..COOKIEJAR
+import ..Cookies
 import .._ConnReader
 import .._USE_TRANSPORT_PROXY
 import .._close_conn!
@@ -760,7 +761,8 @@ function _open_client_websocket(
     for redirect_count in 0:redirect_policy.max_redirects
         send_request = _copy_request(current_request)
         host, path = _host_path_from_request(current_address, current_request)
-        cookie_value = _cookie_header(effective_cookiejar, normalized_cookies, current_secure, host, path)
+        manual_cookies = normalized_cookies === false ? Cookies.Cookie[] : Cookies.readcookies(send_request.headers, "")
+        cookie_value = _cookie_header(effective_cookiejar, normalized_cookies, current_secure, host, path, manual_cookies)
         cookie_value === nothing || setheader(send_request.headers, "Cookie", cookie_value)
         expected_accept = ws_compute_accept_key(header(send_request.headers, "Sec-WebSocket-Key")::String)
         attempt = _websocket_roundtrip!(req_client, current_address, send_request, current_secure, current_server_name, proxy_config)

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -236,3 +236,59 @@ end
     @test !any(cookie -> cookie.name == "stale", cookies)
     @test !haskey(jar.entries[key], HT.Cookies.id(stale))
 end
+
+@testset "_cookie_header merges a manual Cookie header (de-duped by name)" begin
+    host = "h.example.com"
+
+    # Serialize → parse back into (name, value) pairs using the library's own reader.
+    function _pairs(hdr)
+        hdr === nothing && return Tuple{String,String}[]
+        h = HT.Headers()
+        HT.appendheader(h, "Cookie", hdr)
+        return [(c.name, c.value) for c in HT.cookies(HT.Request("GET", "/"; headers = h))]
+    end
+
+    # Build a jar from (request-path => Set-Cookie) specs.
+    function seed(specs...)
+        jar = HT.CookieJar()
+        for (p, sc) in specs
+            HT.setcookies!(jar, "https", host, p, _set_cookie_headers(sc))
+        end
+        return jar
+    end
+
+    # cookies=false: the cookie layer must leave a manual header untouched.
+    @test HT._cookie_header(seed("/" => "sid=JAR; Path=/"), false, true, host, "/",
+                            [HT.Cookie("sid", "MANUAL")]) === nothing
+
+    # No jar, cookies=true: a manual header flows through unchanged.
+    @test _pairs(HT._cookie_header(nothing, true, true, host, "/",
+                                   [HT.Cookie("a", "1")])) == [("a", "1")]
+
+    # Duplicate names within the manual header collapse to the first occurrence.
+    @test _pairs(HT._cookie_header(nothing, true, true, host, "/",
+                                   [HT.Cookie("a", "1"), HT.Cookie("a", "2")])) == [("a", "1")]
+
+    # Disjoint names: jar and manual cookies are both sent.
+    p = _pairs(HT._cookie_header(seed("/" => "sid=JAR; Path=/"), true, true, host, "/",
+                                 [HT.Cookie("extra", "M")]))
+    @test ("sid", "JAR") in p && ("extra", "M") in p
+
+    # Same name: the managed (jar) cookie wins, the manual one is dropped, no duplicate.
+    @test _pairs(HT._cookie_header(seed("/" => "sid=JAR; Path=/"), true, true, host, "/",
+                                   [HT.Cookie("sid", "MANUAL")])) == [("sid", "JAR")]
+
+    # An explicit `cookies=` dict also wins over the manual header, by name.
+    p = _pairs(HT._cookie_header(seed("/" => "sid=JAR; Path=/"), [HT.Cookie("d", "1")],
+                                 true, host, "/", [HT.Cookie("sid", "X"), HT.Cookie("d", "X")]))
+    @test ("sid", "JAR") in p && ("d", "1") in p && !any(t -> t[2] == "X", p)
+
+    # Path-scoped same-name cookies in the jar (e.g. one2team's two JSESSIONIDs) are both
+    # preserved; a manual cookie of that name is dropped rather than shadowing either.
+    jar = seed("/" => "JSESSIONID=ROOT; Path=/", "/app" => "JSESSIONID=APP; Path=/app")
+    p = _pairs(HT._cookie_header(jar, true, true, host, "/app/page",
+                                 [HT.Cookie("JSESSIONID", "MANUAL")]))
+    jsess = [v for (n, v) in p if n == "JSESSIONID"]
+    @test Set(jsess) == Set(["ROOT", "APP"])
+    @test !("MANUAL" in jsess)
+end


### PR DESCRIPTION
Following @quinnj     https://github.com/JuliaWeb/HTTP.jl/pull/1284#issuecomment-4633592674, this PR restores the merge — but de-duplicated by name, which lands between 1.x and 2.1:

| | Behaviour | ≈ | Problem |
|---|---|---|---|
| **1.x** | merge the manual `Cookie` header with the jar | curl | can emit a name twice — [curl warns](https://curl.se/libcurl/c/CURLOPT_COOKIE.html) the doubled header may get the request rejected, and RFC 6265 §5.4 leaves the server's pick among same-name cookies undefined |
| **2.1** | build the header from the jar only, overwrite the manual one | Python `requests` | the manual header is silently dropped whenever the jar / `cookies=` dict is non-empty |
| **this PR** | merge, **de-duped by name** | — | neither: not dropped, never doubled |

`_cookie_header` currently does `stringify("", merged)`, dropping the request's existing `Cookie`. The patch re-reads it and appends only the names the jar / `cookies=` dict don't already cover — managed cookies win on a clash. Besides keeping a rotated jar cookie from being shadowed by a stale manual one, managed-wins preserves path-scoped same-name cookies held in the jar (e.g. a server that sets `JSESSIONID` on both `/` and `/app` keeps both, instead of a manual `JSESSIONID` collapsing them). `cookies=false` still sends a manual header verbatim.

Covers the HTTP request path and the websocket handshake, and documents the `cookies` keyword; tests in `test/http_cookie_tests.jl`. Closes #1283.

Open call: managed-wins vs manual-wins on a name clash — I went managed-wins for rotation safety; trivial to flip if you'd rather an explicit header win.