### PR TITLE
Fix precompile workload shutdown

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 CodecZlib = "0.7"
 EnumX = "1"
 PrecompileTools = "1.2.1"
-Reseau = "1.1.1"
+Reseau = "1.2.1"
 URIs = "1.6.1"
 julia = "1.10"
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -353,33 +353,25 @@ function _run_precompile_workload_inner!()::Nothing
 end
 
 function _run_precompile_workload!()::Nothing
-    _precompile_trace("outer spawn")
-    task = Threads.@spawn _run_precompile_workload_inner!()
+    _precompile_trace("outer start")
     try
-        _precompile_trace("outer wait")
-        status = IOPoll.timedwait(() -> istaskdone(task), 20.0; pollint = 0.01)
-        _precompile_trace("outer wait status=$(status)")
-        if status == :timed_out
-            @try_ignore begin
-                _precompile_trace("outer timeout shutdown")
-                IOPoll.shutdown!()
-            end
-            @try_ignore begin
-                _precompile_trace("outer timeout interrupt")
-                Base.throwto(task, InterruptException())
-            end
-            _ = IOPoll.timedwait(() -> istaskdone(task), 2.0; pollint = 0.01)
-            error("HTTP precompile workload timed out")
-        end
-        _precompile_trace("outer fetch")
-        fetch(task)
+        _run_precompile_workload_inner!()
     finally
-        @try_ignore begin
-            _precompile_trace("outer shutdown")
-            IOPoll.shutdown!()
-        end
+        _precompile_shutdown!()
     end
     _precompile_trace("outer done")
+    return nothing
+end
+
+function _precompile_shutdown!()::Nothing
+    @try_ignore begin
+        _precompile_trace("outer host resolver shutdown")
+        HostResolvers.shutdown!()
+    end
+    @try_ignore begin
+        _precompile_trace("outer shutdown")
+        IOPoll.shutdown!()
+    end
     return nothing
 end
 
@@ -396,11 +388,19 @@ function _precompile_workload_enabled()::Bool
 
     # https://github.com/JuliaWeb/HTTP.jl/issues/1280
     is_julia_automerge() && return true
-    
+
+    return _precompile_host_resolver_available()
+end
+
+function _precompile_host_resolver_available()::Bool
     try
         return !isempty(HostResolvers.resolve_tcp_addrs("tcp", "localhost:0"))
     catch
         return false
+    finally
+        @try_ignore begin
+            HostResolvers.shutdown!()
+        end
     end
 end
 

--- a/test/precompile_tests.jl
+++ b/test/precompile_tests.jl
@@ -1,0 +1,5 @@
+@testset "HTTP precompile workload cleanup" begin
+    @test HTTP._precompile_host_resolver_available() isa Bool
+    @test HTTP._run_precompile_workload!() === nothing
+    @test HTTP._precompile_shutdown!() === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,7 @@ test_files = [
     "http2_server_tests.jl",
     "http_integration_tests.jl",
     "http_parity_tests.jl",
+    "precompile_tests.jl",
     "trim_compile_tests.jl",
 ]
 


### PR DESCRIPTION
## Summary
- Require Reseau 1.2.1, which includes explicit host resolver worker shutdown.
- Run the HTTP precompile workload synchronously instead of spawning it behind a timeout watchdog.
- Drain host resolver workers during both the workload enablement probe and outer workload cleanup before shutting down the I/O poller.

## RCA
The hang reported in #1252 was reproduced with cold depots on an actual Azure Linux VM. The failure was timing-sensitive: tracing or coverage could make the run complete, while the plain precompile path could leave cleanup split across the HTTP workload task, Reseau host resolver workers, and poller shutdown. The Reseau-side fix is released in v1.2.1; this PR updates HTTP to depend on that lifecycle fix and removes the HTTP-side watchdog shape that could mask the real cleanup ordering.

## Validation
- Fresh-depot precompile on Julia 1.12.5 resolved Reseau v1.2.1 and precompiled HTTP successfully.
- Fresh-depot `Pkg.test()` on Julia 1.12.5 passed.
- Azure Linux VM reproduction with the patched HTTP + Reseau path completed the cold precompile without trace flags, coverage, or disabling the workload.

Co-authored by Codex