### PR TITLE
fix missing characters in normal_url_char

### DIFF
--- a/src/http_cookies.jl
+++ b/src/http_cookies.jl
@@ -462,7 +462,7 @@ const normal_url_char = Bool[
     true, true, true, true, true, true, true, false,         # 120-127: x y z { | } ~ DEL
 ]
 
-@inline isurlchar(c) = c > '\u80' ? true : normal_url_char[Int(c)+1]
+@inline isurlchar(c) = c ≥ '\u80' ? true : normal_url_char[Int(c)+1]
 
 """
     CookieJar()

--- a/src/http_cookies.jl
+++ b/src/http_cookies.jl
@@ -458,8 +458,8 @@ const normal_url_char = Bool[
     true, true, true, true, true, true, true, true,          # 88-95: X Y Z [ \ ] ^ _
     true, true, true, true, true, true, true, true,          # 96-103: ` a b c d e f g
     true, true, true, true, true, true, true, true,          # 104-111: h i j k l m n o
-    true, true, true, true, true, true, true, false,         # 112-119: p q r s t u v w
-    true, true, true, false, false, false, true, false,      # 120-127: x y z { | } ~ DEL
+    true, true, true, true, true, true, true, true,          # 112-119: p q r s t u v w
+    true, true, true, true, true, true, true, false,         # 120-127: x y z { | } ~ DEL
 ]
 
 @inline isurlchar(c) = c > '\u80' ? true : normal_url_char[Int(c)+1]

--- a/src/http_cookies.jl
+++ b/src/http_cookies.jl
@@ -444,21 +444,22 @@ end
 sanitizeCookiePath(v) = filter(validcookiepathbyte, v)
 
 const normal_url_char = Bool[
-    false, false, false, false, false, false, false, false,
-    false, true, false, false, true, false, false, false,
-    false, false, false, false, false, false, false, false,
-    false, false, false, false, false, false, false, false,
-    false, true, true, false, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, false,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, true,
-    true, true, true, true, true, true, true, false,
+    false, false, false, false, false, false, false, false,  # 0-7
+    false, true, false, false, true, false, false, false,    # 8-15
+    false, false, false, false, false, false, false, false,  # 16-23
+    false, false, false, false, false, false, false, false,  # 24-31
+    false, true, true, false, true, true, true, true,        # 32-39: space ! " # $ % & '
+    true, true, true, true, true, true, true, true,          # 40-47: ( ) * + , - . /
+    true, true, true, true, true, true, true, true,          # 48-55: 0-7
+    true, true, true, true, true, true, true, false,         # 56-63: 8 9 : ; < = > ?
+    true, true, true, true, true, true, true, true,          # 64-71: @ A B C D E F G
+    true, true, true, true, true, true, true, true,          # 72-79: H I J K L M N O
+    true, true, true, true, true, true, true, true,          # 80-87: P Q R S T U V W
+    true, true, true, true, true, true, true, true,          # 88-95: X Y Z [ \ ] ^ _
+    true, true, true, true, true, true, true, true,          # 96-103: ` a b c d e f g
+    true, true, true, true, true, true, true, true,          # 104-111: h i j k l m n o
+    true, true, true, true, true, true, true, false,         # 112-119: p q r s t u v w
+    true, true, true, false, false, false, true, false,      # 120-127: x y z { | } ~ DEL
 ]
 
 @inline isurlchar(c) = c > '\u80' ? true : normal_url_char[Int(c)+1]

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -317,7 +317,7 @@ end
     # that 'w' (codepoint 119) was mapped to the DEL entry (false), causing
     # cookies named e.g. "w" to be silently dropped too.
 
-    @test HTTP.isurlchar('w') && HTTP.isurlchar('{') && HTTP.isurlchar('|') && HTTP.isurlchar('}') && !HTTP.isurlchar('\x7f')
+    @test HT.isurlchar('w') && HT.isurlchar('{') && HT.isurlchar('|') && HT.isurlchar('}') && !HTTP.isurlchar('\x7f')
 
     jar = HT.CookieJar()
 

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -316,8 +316,8 @@ end
     # The table was also missing the 112–119 row, shifting the final row up so
     # that 'w' (codepoint 119) was mapped to the DEL entry (false), causing
     # cookies named e.g. "w" to be silently dropped too.
-
-    @test HT.isurlchar('w') && HT.isurlchar('{') && HT.isurlchar('|') && HT.isurlchar('}') && !HTTP.isurlchar('\x7f')
+    isurlchar = HTTP.Cookies.isurlchar
+    @test isurlchar('w') && isurlchar('{') && isurlchar('|') && isurlchar('}') && !isurlchar('\x7f')
 
     jar = HT.CookieJar()
 

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -317,7 +317,7 @@ end
     # that 'w' (codepoint 119) was mapped to the DEL entry (false), causing
     # cookies named e.g. "w" to be silently dropped too.
 
-    @test isurlchar('w') && isurlchar('{') && isurlchar('|') && isurlchar('}') && !isurlchar('\x7f')
+    @test HTTP.isurlchar('w') && HTTP.isurlchar('{') && HTTP.isurlchar('|') && HTTP.isurlchar('}') && !HTTP.isurlchar('\x7f')
 
     jar = HT.CookieJar()
 

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -236,3 +236,35 @@ end
     @test !any(cookie -> cookie.name == "stale", cookies)
     @test !haskey(jar.entries[key], HT.Cookies.id(stale))
 end
+
+@testset "HTTP cookie name chars above ASCII 119 regression (BoundsError fix)" begin
+    # Regression test: the old normal_url_char table had only 120 entries, so any
+    # cookie name containing a char with codepoint >= 120 (x, y, z, {, |, }, ~)
+    # caused a BoundsError inside isurlchar, silently dropping the cookie.
+    # The table was also missing the 112–119 row, shifting the final row up so
+    # that 'w' (codepoint 119) was mapped to the DEL entry (false), causing
+    # cookies named e.g. "w" to be silently dropped too.
+
+    @test isurlchar('w') && isurlchar('{') && isurlchar('|') && isurlchar('}') && !isurlchar('\x7f')
+
+    jar = HT.CookieJar()
+
+    # xsrf_token: name contains 'x' (codepoint 120) — previously threw BoundsError
+    headers = _set_cookie_headers("xsrf_token=abc123; Path=/")
+    HT.setcookies!(jar, "https", "example.com", "/", headers)
+    stored = HT.getcookies!(jar, "https", "example.com", "/")
+    names = [c.name for c in stored]
+    @test "xsrf_token" in names
+    xsrf = stored[findfirst(c -> c.name == "xsrf_token", stored)]
+    @test xsrf.value == "abc123"
+
+    # Cookie names that are single chars in the formerly-broken range
+    for ch in ('x', 'y', 'z', '{', '|', '}', '~', 'w')
+        jar2 = HT.CookieJar()
+        HT.setcookies!(jar2, "https", "example.com", "/",
+            _set_cookie_headers("$(ch)=1; Path=/"))
+        got = HT.getcookies!(jar2, "https", "example.com", "/")
+        @test length(got) == 1
+        @test got[1].name == string(ch)
+    end
+end

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -317,7 +317,7 @@ end
     # that 'w' (codepoint 119) was mapped to the DEL entry (false), causing
     # cookies named e.g. "w" to be silently dropped too.
     isurlchar = HTTP.Cookies.isurlchar
-    @test isurlchar('w') && isurlchar('{') && isurlchar('|') && isurlchar('}') && !isurlchar('\x7f')
+    @test isurlchar('w') && isurlchar('{') && isurlchar('|') && isurlchar('}') && !isurlchar('\x7f') && isurlchar('\u80')
 
     jar = HT.CookieJar()
 


### PR DESCRIPTION
Just received an error during cookie processing. It seems that a line of characters was missing.
I completed the array with the help of Claude