### PR TITLE
Track retry count on the request context + expose retry_attempts (#1011, #1019)

### DIFF
--- a/docs/src/api/client.md
+++ b/docs/src/api/client.md
@@ -16,6 +16,7 @@ HTTP.Transport
 HTTP.Client
 HTTP.RetryBucket
 HTTP.RequestRetryError
+HTTP.retry_attempts
 HTTP.roundtrip!
 HTTP.request
 HTTP.get

--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -775,6 +775,7 @@ function _do_incoming!(
                         scheduled, next_token, delay_ns = _arm_request_retry!(retry_controller, current_address, current_request, retry_attempt, nothing)
                         if scheduled
                             _emit_trace(trace, RetryEvent(current_request, request_url, retry_attempt, retry_attempt + 1, redirect_count, delay_ns, nothing, err::Exception))
+                            get_request_context(current_request)[:retryattempt] = retry_attempt
                             retry_attempt += 1
                             retry_token = next_token
                             continue
@@ -809,6 +810,7 @@ function _do_incoming!(
                     scheduled, next_token, delay_ns = _arm_request_retry!(retry_controller, current_address, current_request, retry_attempt, status_response)
                     if scheduled
                         _emit_trace(trace, RetryEvent(current_request, request_url, retry_attempt, retry_attempt + 1, redirect_count, delay_ns, status_response, nothing))
+                        get_request_context(current_request)[:retryattempt] = retry_attempt
                         retry_attempt += 1
                         retry_token = next_token
                         @try_ignore begin
@@ -1008,7 +1010,27 @@ StatusError(response::Response) = StatusError(response.status, response)
 function Base.showerror(io::IO, err::StatusError)
     resp = err.response
     print(io, "http status error: ", err.status, " for ", resp.request.method, " ", resp.url)
+    retries = retry_attempts(resp)
+    retries > 0 && print(io, " (after ", retries, retries == 1 ? " retry" : " retries", ")")
     return nothing
+end
+
+"""
+    retry_attempts(x) -> Int
+
+Number of automatic retries the client performed for a request, `0` when the
+first attempt was the only one. Accepts the `Request` or a client `Response`
+(which consults its originating request).
+
+The count lives in the request's context under the `:retryattempt` key — the
+same location HTTP.jl 1.x used — so `get(req.context, :retryattempt, 0)`
+continues to work for migrated code.
+"""
+retry_attempts(request::Request)::Int = Int(get(get_request_context(request), :retryattempt, 0))
+
+function retry_attempts(response::Response)::Int
+    request = response.request
+    return request === nothing ? 0 : retry_attempts(request::Request)
 end
 
 """

--- a/test/http_retry_tests.jl
+++ b/test/http_retry_tests.jl
@@ -213,6 +213,71 @@ end
     end
 end
 
+@testset "HTTP retry_attempts reports client retries (#1011, #1019)" begin
+    # retried request: 503 -> 503 -> 200 with retries = 2
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    seen = Tuple{String, String, String}[]
+    scenarios = [
+        (status = 503, reason = "Service Unavailable", retry_after = "0"),
+        (status = 503, reason = "Service Unavailable", retry_after = "0"),
+        (status = 200, reason = "OK", body_text = "ok"),
+    ]
+    server_task = _serve_retry_sequence(listener, scenarios, seen)
+    try
+        response = HT.get("http://$(address)/attempts"; retries = 2, status_exception = false)
+        @test response.status == 200
+        @test HT.retry_attempts(response) == 2
+        @test HT.retry_attempts(response.request) == 2
+        # 1.x-compatible context location still works
+        @test get(HT.get_request_context(response.request), :retryattempt, 0) == 2
+        _wait_task_retry!(server_task)
+    finally
+        HTTP.@try_ignore NC.close(listener)
+    end
+
+    # no retries needed: count stays 0
+    listener2 = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr2 = NC.addr(listener2)::NC.SocketAddrV4
+    address2 = ND.join_host_port("127.0.0.1", Int(laddr2.port))
+    seen2 = Tuple{String, String, String}[]
+    server_task2 = _serve_retry_sequence(listener2, [(status = 200, reason = "OK", body_text = "ok")], seen2)
+    try
+        response = HT.get("http://$(address2)/noretry"; retries = 2)
+        @test response.status == 200
+        @test HT.retry_attempts(response) == 0
+        _wait_task_retry!(server_task2)
+    finally
+        HTTP.@try_ignore NC.close(listener2)
+    end
+
+    # exhausted retries: StatusError message reports the retry count
+    listener3 = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr3 = NC.addr(listener3)::NC.SocketAddrV4
+    address3 = ND.join_host_port("127.0.0.1", Int(laddr3.port))
+    seen3 = Tuple{String, String, String}[]
+    scenarios3 = [
+        (status = 503, reason = "Service Unavailable", retry_after = "0"),
+        (status = 503, reason = "Service Unavailable", retry_after = "0"),
+    ]
+    server_task3 = _serve_retry_sequence(listener3, scenarios3, seen3)
+    try
+        err = try
+            HT.get("http://$(address3)/exhausted"; retries = 1)
+            nothing
+        catch e
+            e
+        end
+        @test err isa HT.StatusError
+        @test err !== nothing && HT.retry_attempts((err::HT.StatusError).response) == 1
+        @test err !== nothing && occursin("(after 1 retry)", sprint(showerror, err::HT.StatusError))
+        _wait_task_retry!(server_task3)
+    finally
+        HTTP.@try_ignore NC.close(listener3)
+    end
+end
+
 @testset "HTTP request trace emits retry events" begin
     listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
     laddr = NC.addr(listener)::NC.SocketAddrV4


### PR DESCRIPTION
Fixes #1011, fixes #1019.

## Problem
Retry observability in 2.0 was live-only: the `trace` callback gets `RetryEvent.attempt` / `ResponseHeadEvent.attempt`, but nothing recorded the count anywhere readable **after** the request — `Response` has `redirect_count` but no attempt count, and a `StatusError` thrown after exhausting retries didn't mention them (#1019). #1011 asked for a public accessor.

## Change
- Each scheduled retry (both the error-retry and status-retry paths in `_do_incoming!`) stamps the running count into the request context under **`:retryattempt`** — the same key HTTP.jl **1.x** used, so `get(req.context, :retryattempt, 0)` keeps working verbatim for migrated code (the exact API sketched in #1011).
- New public accessor **`HTTP.retry_attempts(request_or_response)::Int`** (documented + added to the API reference). Request copies share the `RequestContext`, so the count survives the per-attempt request copying.
- `StatusError`'s `showerror` now appends **"(after N retries)"** when retries occurred (#1019), e.g. `http status error: 503 for GET http://… (after 2 retries)`.

## Tests
New testset covering: 503→503→200 with `retries=2` → `retry_attempts(response) == 2` (and via the 1.x context key); a no-retry success → `0`; exhausted retries → `StatusError` with `retry_attempts(err.response) == 1` and "(after 1 retry)" in the message. `http_retry_tests.jl` 78/78 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
