### PR TITLE
Add CookieJar(entries) constructor for restoring saved cookies (#931)

### DIFF
--- a/src/http_cookies.jl
+++ b/src/http_cookies.jl
@@ -465,11 +465,17 @@ const normal_url_char = Bool[
 
 """
     CookieJar()
+    CookieJar(entries::Dict{String, Dict{String, Cookie}})
 
 Create an in-memory cookie jar suitable for attaching to `Client`.
 
 The jar applies standard domain/path/expiry rules when storing cookies from
 responses and when selecting cookies for future requests.
+
+Pass `entries` to start from previously saved cookies: `jar.entries` is the
+jar's storage (keyed by canonical host), so persisting a jar amounts to saving
+`jar.entries` and restoring it is `CookieJar(entries)`. The jar takes ownership
+of the passed dict; it is not copied.
 """
 struct CookieJar
     lock::ReentrantLock
@@ -477,6 +483,7 @@ struct CookieJar
 end
 
 CookieJar() = CookieJar(ReentrantLock(), Dict{String,Dict{String,Cookie}}())
+CookieJar(entries::Dict{String,Dict{String,Cookie}}) = CookieJar(ReentrantLock(), entries)
 Base.empty!(c::CookieJar) = lock(() -> empty!(c.entries), c.lock)
 
 function shouldsend(cookie::Cookie, https::Bool, host, path)::Bool

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -135,6 +135,22 @@ end
     @test !("expired" in [c.name for c in HT.getcookies!(jar, "https", "example.com", "/docs/page")])
 end
 
+@testset "HTTP CookieJar restores from saved entries (#931)" begin
+    # "save": populate a jar, then keep its entries storage
+    jar = HT.CookieJar()
+    headers = _set_cookie_headers("session=abc; Path=/", "theme=dark; Path=/")
+    HT.setcookies!(jar, "https", "example.com", "/", headers)
+    saved = jar.entries
+    # "load": a jar prepopulated from saved entries serves the same cookies
+    restored = HT.CookieJar(saved)
+    names = sort([c.name for c in HT.getcookies!(restored, "https", "example.com", "/")])
+    @test names == ["session", "theme"]
+    # and keeps applying normal jar semantics for later updates
+    delete_headers = _set_cookie_headers("session=gone; Path=/; Max-Age=-1")
+    HT.setcookies!(restored, "https", "example.com", "/", delete_headers)
+    @test [c.name for c in HT.getcookies!(restored, "https", "example.com", "/")] == ["theme"]
+end
+
 @testset "HTTP cookie helper validation and canonicalization" begin
     headers = HT.Headers()
     HT.appendheader(headers, "Cookie", "flag; named=value")


### PR DESCRIPTION
Fixes #931.

## What
Adds the convenience constructor suggested in #931:

```julia
CookieJar(entries::Dict{String, Dict{String, Cookie}}) = CookieJar(ReentrantLock(), entries)
```

so saving and restoring a cookie jar across sessions is symmetric: read `jar.entries` to save, `CookieJar(entries)` to restore. The docstring now documents both constructors and the save/load pattern (including that the jar takes ownership of the passed dict).

## Tests
Round-trip testset: populate a jar via `setcookies!`, rebuild a jar from its `entries`, verify `getcookies!` serves the same cookies, and that the restored jar keeps applying normal jar semantics (delete via `Max-Age=-1`). `http_cookie_tests.jl` 122/122 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
