### PR TITLE
Support IOBuffer writes for HTTP streams

### DIFF
--- a/src/http_stream.jl
+++ b/src/http_stream.jl
@@ -2,7 +2,7 @@
 export startread
 export closeread
 
-import Base: bytesavailable, close, closewrite, eof, isopen, read, readavailable, readbytes!, write
+import Base: bytesavailable, close, closewrite, eof, isopen, read, readavailable, readbytes!, unsafe_write, write
 
 function _client_stream_request(
     method::Union{AbstractString,Symbol},
@@ -224,6 +224,13 @@ startread(stream::Stream{false}) = _server_startread(stream)
 
 isopen(stream::Stream{true}) = !(@atomic :acquire stream.read_closed) || !(@atomic :acquire stream.write_closed)
 isopen(stream::Stream{false}) = _server_isopen(stream)
+
+function unsafe_write(stream::Stream, p::Ptr{UInt8}, n::UInt)::UInt
+    n == 0 && return UInt(0)
+    data = Vector{UInt8}(undef, Int(n))
+    unsafe_copyto!(pointer(data), p, n)
+    return UInt(write(stream, data))
+end
 
 function write(stream::Stream{true}, data::Vector{UInt8})::Int
     (@atomic :acquire stream.started) && throw(ArgumentError("cannot write request body after response reading has started"))

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -1479,11 +1479,15 @@ end
         @test resp_get.status == 200
         @test resp_get.body === nothing
 
+        payload = "payload"
         resp_post = HT.open(:POST, "$(base_url)/open-post") do stream
-            write(stream, "payload")
+            buf = IOBuffer()
+            write(buf, payload)
+            seekstart(buf)
+            @test write(stream, buf) == ncodeunits(payload)
             meta = HT.startread(stream)
             @test meta.status == 200
-            @test String(read(stream)) == "payload"
+            @test String(read(stream)) == payload
         end
         @test resp_post.status == 200
         @test resp_post.body === nothing

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -889,9 +889,11 @@ end
 @testset "HTTP server stream handlers support IOBuffer writes" begin
     payload = "io-buffer-body"
     written = Channel{Int}(1)
+    empty_written = Channel{UInt}(1)
     server = HT.listen!("127.0.0.1", 0; listenany = true) do stream
             _ = HT.startread(stream)
             HT.setstatus(stream, 200)
+            put!(empty_written, Base.unsafe_write(stream, Ptr{UInt8}(0), UInt(0)))
             buf = IOBuffer()
             write(buf, payload)
             seekstart(buf)
@@ -903,6 +905,7 @@ end
         resp = HT.get("http://$(address)/")
         @test resp.status == 200
         @test String(resp.body) == payload
+        @test take!(empty_written) == UInt(0)
         @test take!(written) == ncodeunits(payload)
     finally
         _run_with_timeout(() -> HT.forceclose(server); label = "server forceclose")

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -886,6 +886,30 @@ end
     end
 end
 
+@testset "HTTP server stream handlers support IOBuffer writes" begin
+    payload = "io-buffer-body"
+    written = Channel{Int}(1)
+    server = HT.listen!("127.0.0.1", 0; listenany = true) do stream
+            _ = HT.startread(stream)
+            HT.setstatus(stream, 200)
+            buf = IOBuffer()
+            write(buf, payload)
+            seekstart(buf)
+            put!(written, write(stream, buf))
+            return nothing
+        end
+    address = HT.server_addr(server)
+    try
+        resp = HT.get("http://$(address)/")
+        @test resp.status == 200
+        @test String(resp.body) == payload
+        @test take!(written) == ncodeunits(payload)
+    finally
+        _run_with_timeout(() -> HT.forceclose(server); label = "server forceclose")
+        _run_with_timeout(() -> wait(server); label = "server task completion")
+    end
+end
+
 @testset "HTTP server stream handlers reject fixed-length mismatches before writing malformed bodies" begin
     server = HT.listen!("127.0.0.1", 0; listenany = true) do stream
             request = HT.startread(stream)


### PR DESCRIPTION
## Summary
- add `Base.unsafe_write` for `HTTP.Stream` by copying pointer data and delegating through the existing stream byte write path
- cover `IOBuffer` writes for server stream responses and `HTTP.open` request bodies

## Tests
- `julia --project=. -e 'include("test/http_server_http1_tests.jl")'`\n- `julia --project=. -e 'include("test/http_client_tests.jl")'`\n\nCo-authored by Codex