### PR TITLE
Harden raw HTTP/1 response probes

### DIFF
--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -829,6 +829,38 @@ end
     end
 end
 
+@testset "HTTP server ordinary handlers suppress bodies for 204 and 304" begin
+    server = HT.serve!("127.0.0.1", 0; listenany = true) do request
+            status = request.target == "/nocontent" ? 204 : 304
+            return HT.Response(
+                status,
+                HT.BytesBody(collect(codeunits("oops")));
+                content_length = 4,
+                request = request,
+            )
+        end
+    address = HT.server_addr(server)
+    try
+        for (target, status_line) in (
+            "/nocontent" => "HTTP/1.1 204 No Content",
+            "/notmodified" => "HTTP/1.1 304 Not Modified",
+        )
+            raw = _raw_http_request(HT.port(server), "GET $(target) HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n"; settle_s = 0.3)
+            lower_raw = lowercase(raw)
+            @test occursin(status_line, raw)
+            @test !occursin("content-length", lower_raw)
+            @test !occursin("transfer-encoding", lower_raw)
+            @test !occursin("oops", raw)
+            parts = split(raw, "\r\n\r\n"; limit = 2)
+            @test length(parts) == 2
+            @test parts[2] == ""
+        end
+    finally
+        _run_with_timeout(() -> HT.forceclose(server); label = "server forceclose")
+        _run_with_timeout(() -> wait(server); label = "server task completion")
+    end
+end
+
 @testset "HTTP server ordinary handlers receive buffered request bodies" begin
     seen_buffered = Channel{Bool}(2)
     server = HT.serve!("127.0.0.1", 0; listenany = true) do request

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -57,7 +57,7 @@ function _raw_http_request(
     request::AbstractString;
     settle_s::Float64 = 0.5,
     close_write::Bool = true,
-    wait_for_first_byte::Bool = false,
+    wait_for_first_byte::Bool = true,
 )::String
     return _run_with_timeout(; timeout_s = max(8.0, settle_s + 4.0), label = "raw http request (port $(port))") do
         sock = ND.connect("tcp", "127.0.0.1:$(Int(port))")
@@ -163,6 +163,9 @@ function _read_until_quiet(
                 end
                 rethrow(err)
             end
+        end
+        if wait_for_first_byte && !saw_bytes
+            error("timed out waiting for first response byte")
         end
         return String(out)
     end
@@ -902,11 +905,21 @@ end
         end
     address = HT.server_addr(server)
     try
-        overflow_raw = _raw_http_request(HT.port(server), "GET /overflow HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n"; settle_s = 0.3)
+        overflow_raw = _raw_http_request(
+            HT.port(server),
+            "GET /overflow HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n";
+            settle_s = 0.3,
+            wait_for_first_byte = false,
+        )
         @test !occursin("toolong", overflow_raw)
         @test !occursin("content-length: 2", lowercase(overflow_raw))
 
-        underflow_raw = _raw_http_request(HT.port(server), "GET /underflow HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n"; settle_s = 0.3)
+        underflow_raw = _raw_http_request(
+            HT.port(server),
+            "GET /underflow HTTP/1.1\r\nHost: $(address)\r\nConnection: close\r\n\r\n";
+            settle_s = 0.3,
+            wait_for_first_byte = false,
+        )
         @test !occursin("hi", underflow_raw)
         @test !occursin("content-length: 5", lowercase(underflow_raw))
     finally


### PR DESCRIPTION
## Summary
- make raw HTTP/1 request probes wait for first response bytes by default
- report missing first bytes as a clear harness error instead of returning an empty string
- keep malformed fixed-length probes explicit about accepting no response bytes

## Tests
- julia --project=. test/http_server_http1_tests.jl

Co-authored by Codex