### PR TITLE
Disable proxying for the TLS precompilation workload

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -302,7 +302,7 @@ function _run_precompile_workload_inner!()::Nothing
         @assert String(deflate_resp.body) == "deflate:decoded"
 
         _precompile_trace("request tls")
-        tls_resp = get("https://$(tls_address)/secure"; require_ssl_verification=false, protocol=:h1, request_timeouts...)
+        tls_resp = get("https://$(tls_address)/secure"; proxy=ProxyConfig(), require_ssl_verification=false, protocol=:h1, request_timeouts...)
         @assert tls_resp.status == 200
         @assert String(tls_resp.body) == "tls:/secure"
 


### PR DESCRIPTION
Otherwise precompilation can fail when behind a proxy.

This is the error that was displayed:
```julia
┌ HTTP                                                                                                                 
│  ┌ Info: Ignoring an error that occurred during the precompilation workload                                                                                                                                                                 
│  │   exception =                                                                                                                                                                                                                            
│  │    http protocol error: proxy CONNECT failed with status 403                                                      
│  │    Stacktrace:                                                                                                                                                                                                                           
│  │      [1] _perform_http_connect_tunnel!(tcp::Reseau.TCP.Conn, proxy::HTTP._ProxyTarget, target_address::String, deadline_ns::Int64)                                                                                                        
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:842                                                                                                                                                                     
│  │      [2] _new_tcp_conn!(plan::HTTP._ProxyPlan, address::String, host_resolver::Reseau.HostResolvers.HostResolver{Reseau.HostResolvers.SingleflightResolver{Reseau.HostResolvers.SystemResolver}}, connect_deadline_ns::Int64)            
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:903                                                                                                                                                                                                                                                                                                                                                                                                                   
│  │      [3] _new_conn_tls!(transport::HTTP.Transport, plan::HTTP._ProxyPlan, address::String, server_name::String, host_resolver::Reseau.HostResolvers.HostResolver{Reseau.HostResolvers.SingleflightResolver{Reseau.HostResolvers.SystemResolver}}, connect_deadline_ns::Int64, tls_handshake_timeout_ns::Int64)                                                                                                                                                                            
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:964                                                                                                                                                                                                                                                                                                                                                                                                                   
│  │      [4] _new_conn!(transport::HTTP.Transport, plan::HTTP._ProxyPlan, address::String, secure::Bool, server_name::String, host_resolver::Reseau.HostResolvers.HostResolver{Reseau.HostResolvers.SingleflightResolver{Reseau.HostResolvers.SystemResolver}}, connect_deadline_ns::Int64, tls_handshake_timeout_ns::Int64)                                                                                                                                                                  
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:927                                                                                                                                                                                                                                                                                                                                                                                                                   
│  │      [5] _acquire_conn!(transport::HTTP.Transport, plan::HTTP._ProxyPlan, address::String, secure::Bool, server_name::String, acquire_deadline_ns::Int64, host_resolver::Reseau.HostResolvers.HostResolver{Reseau.HostResolvers.SingleflightResolver{Reseau.HostResolvers.SystemResolver}}, connect_deadline_ns::Int64, tls_handshake_timeout_ns::Int64)                                                                                                                                  
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:1051                                                                                                                                                                    
│  │      [6] _roundtrip_incoming!(transport::HTTP.Transport, address::String, request::HTTP.Request{HTTP.EmptyBody}, secure::Bool, server_name::String, proxy_config::HTTP.ProxyConfig, attempt::Int64)                                      
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:1682                                             
│  │      [7] _roundtrip_incoming!                                                                                     
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/http_transport.jl:1674 [inlined]                                                                                                                                                                                                                                                                                                                                                                                                             
│  │      [8] _do_incoming!(trace::Nothing, client::HTTP.Client{Nothing}, address::String, request::HTTP.Request{HTTP.EmptyBody}, secure::Bool, server_name::String, protocol::Symbol, redirect_policy::HTTP._RedirectPolicy{Nothing}, retry_controller::HTTP._RetryController{Nothing}, proxy_config::HTTP.ProxyConfig, cookies::Bool, cookiejar::HTTP.Cookies.CookieJar)                                                                                                                     
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_client.jl:789                                                                                                                                                                                                                                                                                                                                                                                                                      
│  │      [9] request(method::String, url::String, h::Vector{Pair{String, String}}, b::Nothing; headers::Vector{Pair{String, String}}, body::Nothing, basicauth::Nothing, retry::Bool, retries::Int64, retry_non_idempotent::Bool, retry_if::Nothing, respect_retry_after::Bool, retry_bucket::Bool, status_exception::Bool, redirect::Bool, redirect_limit::Nothing, redirect_method::Nothing, forwardheaders::Bool, proxy::HTTP._UseTransportProxy, cookies::Bool, cookiejar::Nothing, query::Nothing, response_stream::Nothing, decompress::Nothing, max_decompressed_size::Int64, sse_callback::Nothing, client::Nothing, context::Nothing, connect_timeout::Float64, request_timeout::Float64, response_header_timeout::Float64, read_idle_timeout::Float64, write_idle_timeout::Int64, expect_continue_timeout::Nothing, readtimeout::Nothing, copyheaders::Nothing, pool::Nothing, canonicalize_headers::Nothing, detect_content_type::Nothing, observelayers::Nothing, retry_delays::Nothing, retry_check::Nothing, sslconfig::Nothing, socket_type_tls::Nothing, logerrors::Nothing, logtag::Nothing, trace::Nothing, verbose::Nothing, require_ssl_verification::Bool, protocol::Symbol)                                           
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/http_client.jl:1908                                                
│  │     [10] request                                                                                                  
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/http_client.jl:1781 [inlined]                                           
│  │     [11] #get#106                                                                                                 
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/http_client.jl:2195 [inlined]                                           
│  │     [12] get (repeats 2 times)                                                                                    
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/http_client.jl:2194 [inlined]                                           
│  │     [13] _run_precompile_workload_inner!()                                                                        
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/precompile.jl:305                                                  
│  │     [14] _run_precompile_workload!()                                                                              
│  │        @ HTTP ~/.julia/packages/HTTP/tDXzI/src/precompile.jl:358                                                  
│  │     [15] macro expansion                                                                                          
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/precompile.jl:412 [inlined]                                             
│  │     [16] macro expansion                                                                                          
│  │        @ ~/.julia/packages/PrecompileTools/QUxvR/src/workloads.jl:70 [inlined]                                    
│  │     [17] macro expansion                                                                                          
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/precompile.jl:411 [inlined]                                             
│  │     [18] macro expansion                                                                                          
│  │        @ ~/.julia/packages/PrecompileTools/QUxvR/src/workloads.jl:118 [inlined]                                   
│  │     [19] top-level scope                                                                                          
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/precompile.jl:410                                                       
│  │     [20] include(mapexpr::Function, mod::Module, _path::String)                                                   
│  │        @ Base ./Base.jl:307                                                                                       
│  │     [21] IncludeInto                                                                                              
│  │        @ ./Base.jl:308 [inlined]                                                                                  
│  │     [22] top-level scope                                                                                          
│  │        @ ~/.julia/packages/HTTP/tDXzI/src/HTTP.jl:63                                                              
│  │     [23] include(mod::Module, _path::String)                                                                      
│  │        @ Base ./Base.jl:306                                                                                       
│  │     [24] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)              
│  │        @ Base ./loading.jl:3028                                                                                   
│  │     [25] top-level scope                                                                                          
│  │        @ stdin:5                                                                                                  
│  │     [26] eval(m::Module, e::Any)                                                                                  
│  │        @ Core ./boot.jl:489                                                                                       
│  │     [27] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)                   
│  │        @ Base ./loading.jl:2874                                                                                   
│  │     [28] include_string                                                                                           
│  │        @ ./loading.jl:2884 [inlined]                                                                              
│  │     [29] exec_options(opts::Base.JLOptions)                                                                       
│  │        @ Base ./client.jl:315                                                                                     
│  │     [30] _start()                                                                                                 
│  └        @ Base ./client.jl:550                                                                                     
└
```

Debugged and written with help from Claude :robot: 