### PR TITLE
Add public isrecoverable(::Exception) for retry classification (#1245)

### DIFF
--- a/docs/src/api/client.md
+++ b/docs/src/api/client.md
@@ -17,6 +17,7 @@ HTTP.Client
 HTTP.RetryBucket
 HTTP.RequestRetryError
 HTTP.retry_attempts
+HTTP.isrecoverable
 HTTP.roundtrip!
 HTTP.request
 HTTP.get

--- a/src/http_client_retry.jl
+++ b/src/http_client_retry.jl
@@ -76,6 +76,26 @@ end
 
 _retryable_request_error(err::RequestRetryError)::Bool = _retryable_request_error(err.err)
 
+"""
+    isrecoverable(err::Exception) -> Bool
+
+Return `true` when `err` represents a transient transport or protocol failure
+that is safe to retry — the same classification HTTP.jl's built-in retry policy
+applies to request-path exceptions. Recoverable cases include connection resets
+and EOFs (`EOFError`, `IOPoll.NetClosingError`), socket errors (`SystemError`),
+malformed responses (`ParseError`), and dial/handshake timeouts
+(`HostResolvers.DialTimeoutError`, `TLS.TLSHandshakeTimeoutError`), including the
+underlying causes of wrapped `HostResolvers.OpError`/`TLS.TLSError` exceptions.
+A request *deadline* being exceeded (`IOPoll.DeadlineExceededError`) is treated
+as non-recoverable, as is anything else.
+
+Accepts either the underlying exception or the [`RequestRetryError`](@ref)
+wrapper passed to a `retry_if` callback. This is the public replacement for
+HTTP.jl 1.x's `HTTP.RetryRequest.isrecoverable`, intended for downstream
+packages that implement their own retry/backoff logic.
+"""
+isrecoverable(err::Exception)::Bool = _retryable_request_error(err)
+
 # RFC 9113 §8.7: requests on streams reset with REFUSED_STREAM or rejected by
 # GOAWAY are guaranteed unprocessed, hence safe to retry regardless of method
 # idempotency. The replayable-body gate in `_should_retry_request_attempt`

--- a/test/http_retry_tests.jl
+++ b/test/http_retry_tests.jl
@@ -574,3 +574,25 @@ end
     invalid_headers = HT.Headers(["Retry-After" => "nonsense"])
     @test HT._retry_after_delay_ns(invalid_headers) === nothing
 end
+
+@testset "isrecoverable classifies retryable request exceptions (#1245)" begin
+    # recoverable: transient transport / protocol failures
+    @test HT.isrecoverable(EOFError())
+    @test HT.isrecoverable(HT.ParseError("bad"))
+    @test HT.isrecoverable(SystemError("connect"))
+    @test HT.isrecoverable(ND.DialTimeoutError("host:80"))
+
+    # non-recoverable: a deadline being hit, and unrelated exceptions
+    @test !HT.isrecoverable(Reseau.IOPoll.DeadlineExceededError())
+    @test !HT.isrecoverable(ArgumentError("nope"))
+    @test !HT.isrecoverable(ErrorException("boom"))
+
+    # accepts the RequestRetryError wrapper handed to retry_if, unwrapping it
+    @test HT.isrecoverable(HT.RequestRetryError(EOFError()))
+    @test !HT.isrecoverable(HT.RequestRetryError(ArgumentError("nope")))
+
+    # matches the internal classifier the built-in policy uses
+    for err in (EOFError(), HT.ParseError("x"), ArgumentError("y"), Reseau.IOPoll.DeadlineExceededError())
+        @test HT.isrecoverable(err) == HT._retryable_request_error(err)
+    end
+end


### PR DESCRIPTION
Closes #1245.

Downstream packages (notably [GitHub.jl](https://github.com/JuliaWeb/GitHub.jl/pull/233), reported by @DilumAluthge / @ericphanson) used HTTP.jl 1.x's `HTTP.RetryRequest.isrecoverable(::Exception)` to decide whether a request-path exception is worth retrying. The 2.0 rewrite dropped that module, and the equivalent logic survived only in the private `_retryable_request_error`.

This exposes it as a documented, public **`HTTP.isrecoverable(::Exception)::Bool`** that delegates to the same classifier the built-in retry policy uses — same name as the 1.x API to ease migration. It recognizes the transient transport/protocol failures (connection resets/EOF, socket errors, parse errors, dial/TLS-handshake timeouts, and the unwrapped causes of `OpError`/`TLSError`), treats a hit request *deadline* as non-recoverable, and accepts either the raw exception or the `RequestRetryError` wrapper handed to a `retry_if` callback.

```julia
HTTP.isrecoverable(EOFError())                       # true
HTTP.isrecoverable(ArgumentError("nope"))            # false
HTTP.isrecoverable(HTTP.RequestRetryError(EOFError())) # true — unwraps the retry_if wrapper
```

Minimal surface: a thin public wrapper over the existing internal function (no logic change, internal call sites untouched), documented in the client API reference, with tests covering recoverable/non-recoverable classification, the wrapper, and parity with the internal classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
