### PR TITLE
fix version check for public declarations

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -66,7 +66,7 @@ include("http_websockets.jl")
 # not repeated here. The version guard keeps the source parseable on Julia 1.10
 # (the `public` keyword does not exist there); `eval(Expr(:public, …))` is valid
 # syntax on all versions, so only the evaluation is gated.
-@static if VERSION >= v"1.11.0-DEV.469"
+@static if Base.VERSION >= v"1.11.0-DEV.469"
     Core.eval(@__MODULE__, Expr(:public,
         Symbol("@client"),
         :AbstractBody, :AddressInUseError, :CallbackBody, :CanceledError, :Client,

--- a/src/http_handlers.jl
+++ b/src/http_handlers.jl
@@ -485,7 +485,7 @@ getcookies(req) = get(() -> Cookie[], req.context, :cookies)
 
 # `handlertimeout` is documented public API but not exported; mark it public on
 # Julia versions that support the mechanism (the source stays parseable on 1.10).
-@static if VERSION >= v"1.11.0-DEV.469"
+@static if Base.VERSION >= v"1.11.0-DEV.469"
     Core.eval(@__MODULE__, Expr(:public, :handlertimeout))
 end
 

--- a/src/http_websockets.jl
+++ b/src/http_websockets.jl
@@ -1795,7 +1795,7 @@ end
 
 # Documented public API of this submodule (accessed as `HTTP.WebSockets.name`).
 # Version-gated like the main module so the source parses on Julia 1.10.
-@static if VERSION >= v"1.11.0-DEV.469"
+@static if Base.VERSION >= v"1.11.0-DEV.469"
     Core.eval(@__MODULE__, Expr(:public,
         :CloseFrameBody, :Conn, :Server, :WebSocket, :WebSocketError, :forceclose,
         :isupgrade, :listen, :listen!, :open, :ping, :pong, :receive, :send, :serve!,


### PR DESCRIPTION
fix public declarations for julia 1.10 by replacing `VERSION` by `Base.VERSION`