### PR TITLE
Add HTTP QUERY method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ r = HTTP.post(
 returned = JSON.parse(String(r.body))
 ```
 
+For safe, idempotent requests with content, HTTP.jl supports the RFC 10008
+`QUERY` method through `HTTP.query`:
+
+```julia
+r = HTTP.query(
+    "https://api.example.com/search";
+    headers = ["Content-Type" => "application/json"],
+    body = JSON.json(Dict("select" => ["name", "email"])),
+)
+```
+
 Stream directly into an `IO` sink with `response_stream`, or use `HTTP.open` when
 you want pull-based control over the response stream. The `do`-block form of
 `HTTP.open` returns the final `HTTP.Response`, not the value returned by the

--- a/docs/src/api/client.md
+++ b/docs/src/api/client.md
@@ -22,6 +22,7 @@ HTTP.roundtrip!
 HTTP.request
 HTTP.get
 HTTP.head
+HTTP.query
 HTTP.post
 HTTP.put
 HTTP.patch

--- a/docs/src/guides/client.md
+++ b/docs/src/guides/client.md
@@ -44,7 +44,7 @@ HTTP.forceclose(server)
 
 Useful top-level request helpers:
 
-- `HTTP.get`, `HTTP.head`, `HTTP.post`, `HTTP.put`, `HTTP.patch`, `HTTP.delete`, `HTTP.options`
+- `HTTP.get`, `HTTP.head`, `HTTP.query`, `HTTP.post`, `HTTP.put`, `HTTP.patch`, `HTTP.delete`, `HTTP.options`
 - `HTTP.request` for the fully general call shape
 - `HTTP.open` when you want streaming control instead of an eagerly consumed body
 
@@ -316,6 +316,30 @@ For `multipart/form-data` (file uploads), use [`HTTP.Form`](@ref):
 form = HTTP.Form(Dict("file" => open("upload.bin", "r"), "kind" => "binary"))
 HTTP.post("http://example.com/upload", [], form)
 ```
+
+### Sending QUERY requests
+
+RFC 10008 defines `QUERY` for safe, idempotent requests with content. Use
+`HTTP.query` when a request needs a body but has GET-like semantics:
+
+```julia
+HTTP.query(
+    "https://api.example.com/search";
+    headers = ["Content-Type" => "application/json"],
+    body = """{"select":["name","email"],"limit":10}""",
+)
+```
+
+`Dict` and `NamedTuple` bodies are encoded the same way as `HTTP.post` form
+bodies, with `Content-Type: application/x-www-form-urlencoded` set
+automatically:
+
+```julia
+HTTP.query("https://api.example.com/search"; body = (select = "name", limit = 10))
+```
+
+Servers that support `QUERY` can advertise accepted query content media types
+with the `Accept-Query` response header.
 
 ### Query parameters
 

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -10,7 +10,7 @@ while `Reseau` provides the transport, resolver, and TLS substrate.
 
 Common entrypoints:
 
-- `request`, `get`, `post`, `put`, `patch`, `delete`, `head`, and `options`
+- `request`, `get`, `post`, `put`, `patch`, `delete`, `head`, `options`, and `query`
   for high-level client requests.
 - `open` for client-side request/response streaming.
 - `serve!` / `serve` for `Request -> Response` servers.
@@ -80,10 +80,10 @@ include("http_websockets.jl")
         :close_idle_connections!, :defaultheader!, :delete, :do!, :expired, :fileserver,
         :forceclose, :get, :get!, :get_request_context, :hasheader, :head, :header,
         :headercontains, :headers, :idle_connection_count, :isaborted, :isrecoverable,
-        :listen, :listen!, :mkheaders, :nobody, :open, :options, :patch, :peeraddr, :port, :post, :put,
-        :read_request, :removeheader, :request, :retry_attempts, :roundtrip!, :serve, :serve!,
-        :servecontent, :servefile, :set_deadline!, :setheader, :setstatus, :sse_stream,
-        :startwrite, :streamhandler, :trailers, :write_request!, :write_response!,
+        :listen, :listen!, :mkheaders, :nobody, :open, :options, :patch, :peeraddr, :port, :post,
+        :put, :query, :read_request, :removeheader, :request, :retry_attempts, :roundtrip!,
+        :serve, :serve!, :servecontent, :servefile, :set_deadline!, :setheader, :setstatus,
+        :sse_stream, :startwrite, :streamhandler, :trailers, :write_request!, :write_response!,
     ))
 end
 

--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -2027,11 +2027,11 @@ Keyword arguments:
   fallback when neither is provided
 - `retry`: overall toggle for high-level request retries; lower-level reused-connection transport retries still happen independently
 - `retries`: maximum number of retry attempts after the initial request attempt
-- `retry_non_idempotent`: allow automatic retries for methods like `POST`/`PATCH`; `PUT` and `DELETE` are already treated as idempotent
+- `retry_non_idempotent`: allow automatic retries for methods like `POST`/`PATCH`; `QUERY`, `PUT`, and `DELETE` are already treated as idempotent
 - `retry_if`: optional callback `(attempt, err, req, resp) -> Bool | nothing`; request-path failures are passed as `RequestRetryError` so implementations can inspect `err.err`, while response-based retry checks pass `err = nothing` and `resp = response`; `true` forces a retry when the request body is replayable, `false` suppresses retry, and `nothing` defers to built-in retry rules
 - `respect_retry_after`: honor server `Retry-After` on retryable `429`/`503` responses
 - `retry_bucket`: `true` uses the request transport's default `RetryBucket`, `false` disables bucket coordination, and a custom `RetryBucket` overrides the transport default
-- automatic retries only occur for replayable request bodies; built-in policy retries idempotent methods (`GET`, `HEAD`, `OPTIONS`, `TRACE`, `PUT`, `DELETE`) plus requests carrying `Idempotency-Key`/`X-Idempotency-Key`
+- automatic retries only occur for replayable request bodies; built-in policy retries idempotent methods (`GET`, `HEAD`, `OPTIONS`, `TRACE`, `QUERY`, `PUT`, `DELETE`) plus requests carrying `Idempotency-Key`/`X-Idempotency-Key`
 - `status_exception`: throw `StatusError` for non-success responses
 - `redirect`: follow redirects through `do!`
 - `redirect_limit`: maximum number of redirects to follow for this call;
@@ -2232,6 +2232,7 @@ const _REQUEST_HELPER_DOC = """
     request(method, url, headers=Pair{String,String}[], body=nothing; kwargs...)
     get(url, headers=Pair{String,String}[]; kwargs...)
     head(url, headers=Pair{String,String}[]; kwargs...)
+    query(url, [headers], [body]; kwargs...)
     post(url, [headers], [body]; kwargs...)
     put(url, [headers], [body]; kwargs...)
     patch(url, [headers], [body]; kwargs...)
@@ -2257,6 +2258,12 @@ end
 @doc _REQUEST_HELPER_DOC
 function head(url::Union{AbstractString,URI}, headers=Pair{String,String}[]; kwargs...)
     return request("HEAD", url, headers, nothing; kwargs...)
+end
+
+@doc _REQUEST_HELPER_DOC
+function query(url::Union{AbstractString,URI}, args...; kwargs...)
+    headers, body = _split_headers_body_args(args)
+    return request("QUERY", url, headers, body; kwargs...)
 end
 
 @doc _REQUEST_HELPER_DOC
@@ -2301,6 +2308,11 @@ get(client::Client, url::Union{AbstractString,URI}, headers=Pair{String,String}[
 
 head(client::Client, url::Union{AbstractString,URI}, headers=Pair{String,String}[]; kwargs...) =
     request("HEAD", url, headers, nothing; client=client, kwargs...)
+
+function query(client::Client, url::Union{AbstractString,URI}, args...; kwargs...)
+    headers, body = _split_headers_body_args(args)
+    return request("QUERY", url, headers, body; client=client, kwargs...)
+end
 
 function post(client::Client, url::Union{AbstractString,URI}, args...; kwargs...)
     headers, body = _split_headers_body_args(args)
@@ -2365,6 +2377,12 @@ macro client(request_middleware, stream_middleware=:(()))
         function head(url, headers=Pair{String,String}[]; kwargs...)
             $__source__
             return request("HEAD", url, headers, nothing; kwargs...)
+        end
+
+        function query(url, args...; kwargs...)
+            $__source__
+            headers, body = HTTP._split_headers_body_args(args)
+            return request("QUERY", url, headers, body; kwargs...)
         end
 
         function post(url, args...; kwargs...)

--- a/src/http_client_redirect.jl
+++ b/src/http_client_redirect.jl
@@ -20,7 +20,7 @@ function _normalize_redirect_method_override(redirect_method)::Tuple{Union{Nothi
     redirect_method == :same && return nothing, true
     redirect_method isa AbstractString || redirect_method isa Symbol || throw(ArgumentError("redirect_method must be nothing, :same, or an HTTP method String/Symbol"))
     method = uppercase(String(redirect_method))
-    method in ("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH") || throw(ArgumentError("redirect_method must be one of GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH, or :same"))
+    method in ("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "QUERY") || throw(ArgumentError("redirect_method must be one of GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH, QUERY, or :same"))
     return method, false
 end
 
@@ -227,7 +227,7 @@ function _rewrite_method_for_redirect(method::String, status::Int, policy::_Redi
     if policy.redirect_method !== nothing
         return policy.redirect_method::String
     end
-    method == "HEAD" && return method
+    (method == "HEAD" || method == "QUERY") && return method
     return "GET"
 end
 

--- a/src/http_client_retry.jl
+++ b/src/http_client_retry.jl
@@ -25,7 +25,7 @@ end
 end
 
 @inline function _retryable_request_method(method::String)::Bool
-    return method == "GET" || method == "HEAD" || method == "OPTIONS" || method == "TRACE" || method == "PUT" || method == "DELETE"
+    return method == "GET" || method == "HEAD" || method == "OPTIONS" || method == "TRACE" || method == "PUT" || method == "DELETE" || method == "QUERY"
 end
 
 @inline function _retryable_request_headers(request::Request)::Bool

--- a/src/http_core.jl
+++ b/src/http_core.jl
@@ -517,6 +517,7 @@ const _COMMON_CANONICAL_HEADER_KEYS = Dict(
     "Accept-Charset" => "Accept-Charset",
     "Accept-Encoding" => "Accept-Encoding",
     "Accept-Language" => "Accept-Language",
+    "Accept-Query" => "Accept-Query",
     "Accept-Ranges" => "Accept-Ranges",
     "Cache-Control" => "Cache-Control",
     "Connection" => "Connection",

--- a/src/http_transport.jl
+++ b/src/http_transport.jl
@@ -1445,7 +1445,7 @@ end
 end
 
 @inline function _retryable_method(method::String)::Bool
-    return method == "GET" || method == "HEAD" || method == "OPTIONS" || method == "TRACE"
+    return method == "GET" || method == "HEAD" || method == "OPTIONS" || method == "TRACE" || method == "QUERY"
 end
 
 @inline function _retryable_request(request::Request)::Bool

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -124,6 +124,22 @@ function _run_precompile_workload_inner!()::Nothing
             payload = _precompile_body_string(req.body)
             return _precompile_text_response("echo:" * getparam(req, "name") * ":" * payload)
         end))
+        register!(request_router, "QUERY", "/search/{name}", Handlers.handlertimeout(0.5)(req -> begin
+            content_type = header(req, "Content-Type", "")
+            payload = _precompile_body_string(req.body)
+            response_headers = ["Accept-Query" => "application/x-www-form-urlencoded"]
+            req.method == "QUERY" || return Response(405, EmptyBody(); content_length=0)
+            occursin("application/x-www-form-urlencoded", content_type) || return Response(415, EmptyBody(); content_length=0)
+            return _precompile_text_response("query:" * getparam(req, "name") * ":" * payload, 200, response_headers)
+        end))
+        register!(request_router, "QUERY", "/search-redirect", req ->
+            Response(
+                307,
+                EmptyBody();
+                headers=["Location" => "/search/redirected"],
+                content_length=0,
+            )
+        )
         register!(request_router, "GET", "/redirect", req ->
             Response(
                 302,
@@ -247,6 +263,19 @@ function _run_precompile_workload_inner!()::Nothing
         echo = post("http://$(request_address)/echo/jane"; client=client, body="ping", stream_timeouts...)
         @assert echo.status == 200
         @assert String(echo.body) == "echo:jane:ping"
+
+        _precompile_trace("request query")
+        query_headers = ["Content-Type" => "application/x-www-form-urlencoded"]
+        query_resp = request("QUERY", "http://$(request_address)/search/jane", query_headers, (term="ping",); client=client, stream_timeouts...)
+        @assert query_resp.status == 200
+        @assert header(query_resp, "Accept-Query", nothing) == "application/x-www-form-urlencoded"
+        @assert String(query_resp.body) == "query:jane:term=ping"
+
+        _precompile_trace("request query redirect")
+        query_redirect = request("QUERY", "http://$(request_address)/search-redirect", query_headers, "term=redirect"; client=client, stream_timeouts...)
+        @assert query_redirect.status == 200
+        @assert header(query_redirect, "Accept-Query", nothing) == "application/x-www-form-urlencoded"
+        @assert String(query_redirect.body) == "query:redirected:term=redirect"
 
         _precompile_trace("request redirect")
         redirected = get("http://$(request_address)/redirect"; client=client, request_timeouts...)

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -121,6 +121,7 @@ end
     address = ND.join_host_port("127.0.0.1", Int(laddr.port))
     base_url = "http://$(address)"
     seen_tokens = String[]
+    seen_query_body = Ref("")
     server_task = errormonitor(Threads.@spawn begin
         conn1 = NC.accept(listener)
         try
@@ -133,10 +134,19 @@ end
         conn2 = NC.accept(listener)
         try
             req2 = HT.read_request(HT._ConnReader(conn2))
-            push!(seen_tokens, HT.header(req2.headers, "X-Stream-Token", ""))
-            _send_response_client!(conn2, req2; body_text="stream")
+            push!(seen_tokens, HT.header(req2.headers, "X-Client-Token", ""))
+            seen_query_body[] = String(_read_all_body_bytes_client(req2.body))
+            _send_response_client!(conn2, req2; body_text="query:" * seen_query_body[])
         finally
             HTTP.@try_ignore NC.close(conn2)
+        end
+        conn3 = NC.accept(listener)
+        try
+            req3 = HT.read_request(HT._ConnReader(conn3))
+            push!(seen_tokens, HT.header(req3.headers, "X-Stream-Token", ""))
+            _send_response_client!(conn3, req3; body_text="stream")
+        finally
+            HTTP.@try_ignore NC.close(conn3)
         end
         return nothing
     end)
@@ -144,6 +154,16 @@ end
         response = ClientSingleMiddleware.get("$(base_url)/request"; clienttoken="abc123", retry=false)
         @test response.status == 200
         @test String(response.body) == "request"
+        @test HT.header(response, "X-Client-Request") == "handled"
+
+        response = ClientSingleMiddleware.query(
+            "$(base_url)/query";
+            clienttoken = "query-abc",
+            body = (name = "value",),
+            retry = false,
+        )
+        @test response.status == 200
+        @test String(response.body) == "query:name=value"
         @test HT.header(response, "X-Client-Request") == "handled"
 
         seen_body = Ref("")
@@ -154,7 +174,8 @@ end
         end
         @test response.status == 200
         @test seen_body[] == "stream"
-        @test seen_tokens == ["abc123", "stream-xyz"]
+        @test seen_query_body[] == "name=value"
+        @test seen_tokens == ["abc123", "query-abc", "stream-xyz"]
         _wait_task_client!(server_task)
     finally
         HTTP.@try_ignore NC.close(listener)
@@ -377,6 +398,66 @@ end
     end
 end
 
+@testset "HTTP client QUERY redirect preserves method and replayable body" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    base_url = "http://$(address)"
+    seen_methods = String[]
+    seen_bodies = String[]
+    server_task = errormonitor(Threads.@spawn begin
+        conn1 = NC.accept(listener)
+        try
+            req1 = HT.read_request(HT._ConnReader(conn1))
+            push!(seen_methods, req1.method)
+            push!(seen_bodies, String(_read_all_body_bytes_client(req1.body)))
+            headers = HT.Headers()
+            HT.setheader(headers, "Location", "/final")
+            HT.setheader(headers, "Connection", "close")
+            _send_response_client!(conn1, req1; status = 302, reason = "Found", headers = headers, close_conn = true)
+        finally
+            HTTP.@try_ignore NC.close(conn1)
+        end
+        conn2 = NC.accept(listener)
+        try
+            req2 = HT.read_request(HT._ConnReader(conn2))
+            push!(seen_methods, req2.method)
+            push!(seen_bodies, String(_read_all_body_bytes_client(req2.body)))
+            _send_response_client!(conn2, req2; body_text = "ok", close_conn = true)
+        finally
+            HTTP.@try_ignore NC.close(conn2)
+        end
+        return nothing
+    end)
+    client = HT.Client()
+    try
+        policy = HT._redirect_policy(client)
+        override_method, preserve_method = HT._normalize_redirect_method_override("QUERY")
+        @test override_method == "QUERY"
+        @test !preserve_method
+        @test HT._rewrite_method_for_redirect("QUERY", 301, policy) == "QUERY"
+        @test HT._rewrite_method_for_redirect("QUERY", 302, policy) == "QUERY"
+        @test HT._rewrite_method_for_redirect("QUERY", 303, policy) == "GET"
+        @test HT._rewrite_method_for_redirect("QUERY", 307, policy) == "QUERY"
+        @test HT._rewrite_method_for_redirect("QUERY", 308, policy) == "QUERY"
+
+        response = HT.query(
+            "$(base_url)/start",
+            ["Content-Type" => "application/x-www-form-urlencoded"],
+            "select=name";
+            client = client,
+        )
+        @test response.status == 200
+        @test String(response.body) == "ok"
+        _wait_task_client!(server_task)
+        @test seen_methods == ["QUERY", "QUERY"]
+        @test seen_bodies == ["select=name", "select=name"]
+    finally
+        close(client)
+        HTTP.@try_ignore NC.close(listener)
+    end
+end
+
 @testset "HTTP request trace emits redirect events" begin
     listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
     laddr = NC.addr(listener)::NC.SocketAddrV4
@@ -465,6 +546,55 @@ end
         _wait_task_client!(server_task)
         @test seen_methods == ["POST", "POST"]
         @test seen_bodies == ["payload", "payload"]
+    finally
+        HTTP.@try_ignore NC.close(listener)
+    end
+end
+
+@testset "HTTP client QUERY requests retry as idempotent" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    base_url = "http://$(address)"
+    seen_methods = String[]
+    seen_bodies = String[]
+    server_task = errormonitor(Threads.@spawn begin
+        for attempt in 1:2
+            conn = NC.accept(listener)
+            try
+                req = HT.read_request(HT._ConnReader(conn))
+                push!(seen_methods, req.method)
+                push!(seen_bodies, String(_read_all_body_bytes_client(req.body)))
+                if attempt == 1
+                    _send_response_client!(
+                        conn,
+                        req;
+                        status = 503,
+                        reason = "Service Unavailable",
+                        body_text = "retry",
+                        close_conn = true,
+                    )
+                else
+                    _send_response_client!(conn, req; body_text = "ok", close_conn = true)
+                end
+            finally
+                HTTP.@try_ignore NC.close(conn)
+            end
+        end
+        return nothing
+    end)
+    try
+        response = HT.query(
+            "$(base_url)/retry",
+            ["Content-Type" => "application/sql"],
+            "select 1";
+            retries = 1,
+        )
+        @test response.status == 200
+        @test String(response.body) == "ok"
+        _wait_task_client!(server_task)
+        @test seen_methods == ["QUERY", "QUERY"]
+        @test seen_bodies == ["select 1", "select 1"]
     finally
         HTTP.@try_ignore NC.close(listener)
     end
@@ -1139,8 +1269,11 @@ end
     seen_targets = String[]
     seen_header = Ref{Union{Nothing, String}}(nothing)
     seen_auth = Union{Nothing, String}[]
+    seen_query_methods = String[]
+    seen_query_bodies = String[]
+    seen_query_content_types = Union{Nothing, String}[]
     server_task = errormonitor(Threads.@spawn begin
-        for _ in 1:15
+        for _ in 1:17
             conn = NC.accept(listener)
             try
                 req = HT.read_request(HT._ConnReader(conn))
@@ -1153,6 +1286,11 @@ end
                     seen_header[] = HT.header(req.headers, "X-Token", nothing)
                     payload = String(_read_all_body_bytes_client(req.body))
                     _send_response_client!(conn, req; body_text = payload, close_conn = true)
+                elseif req.target == "/body-query" || req.target == "/body-query-client"
+                    push!(seen_query_methods, req.method)
+                    push!(seen_query_bodies, String(_read_all_body_bytes_client(req.body)))
+                    push!(seen_query_content_types, HT.header(req.headers, "Content-Type", nothing))
+                    _send_response_client!(conn, req; body_text = "query:" * seen_query_bodies[end], close_conn = true)
                 elseif startswith(req.target, "/encoded?")
                     _send_response_client!(conn, req; body_text = req.target, close_conn = true)
                 elseif req.target == "/auth" || req.target == "/auth-url" || req.target == "/auth-url-uri" || req.target == "/auth-header"
@@ -1208,6 +1346,24 @@ end
         @test resp_echo_uri.status == 200
         @test String(resp_echo_uri.body) == "payload-uri"
         @test seen_header[] == "xyz789"
+
+        resp_body_query = HT.query("$(base_url)/body-query"; body = (select = "name", limit = 10))
+        @test resp_body_query.status == 200
+        @test String(resp_body_query.body) == "query:select=name&limit=10"
+
+        query_client = HT.Client()
+        try
+            resp_client_query = HT.query(
+                query_client,
+                "$(base_url)/body-query-client",
+                ["Content-Type" => "application/sql"],
+                "select 1",
+            )
+            @test resp_client_query.status == 200
+            @test String(resp_client_query.body) == "query:select 1"
+        finally
+            close(query_client)
+        end
 
         resp_auth = HT.get("$(base_url)/auth"; basicauth = ("alice", "secret"))
         @test resp_auth.status == 200
@@ -1320,11 +1476,16 @@ end
         @test "/echo" in seen_targets
         @test "/query?a=1&b=2" in seen_targets
         @test "/query?x=0&a=1&b=2" in seen_targets
+        @test "/body-query" in seen_targets
+        @test "/body-query-client" in seen_targets
         @test "/encoded?a%20b=c%2Bd&slash=%2Fx" in seen_targets
         @test "/auth" in seen_targets
         @test "/auth-url" in seen_targets
         @test "/auth-url-uri" in seen_targets
         @test "/auth-header" in seen_targets
+        @test seen_query_methods == ["QUERY", "QUERY"]
+        @test seen_query_bodies == ["select=name&limit=10", "select 1"]
+        @test seen_query_content_types == ["application/x-www-form-urlencoded", "application/sql"]
     finally
         HTTP.@try_ignore NC.close(listener)
     end
@@ -2440,6 +2601,7 @@ end
             @test String(HT.post(client, url; body="x").body) == "POST"
             @test String(HT.put(client, url; body="x").body) == "PUT"
             @test String(HT.patch(client, url; body="x").body) == "PATCH"
+            @test String(HT.query(client, url; body="x").body) == "QUERY"
             @test String(HT.delete(client, url).body) == "DELETE"
             @test HT.head(client, url).status == 200
             @test HT.options(client, url).status == 200

--- a/test/http_client_transport_tests.jl
+++ b/test/http_client_transport_tests.jl
@@ -1067,14 +1067,17 @@ end
     laddr = NC.addr(listener)::NC.SocketAddrV4
     address = ND.join_host_port("127.0.0.1", Int(laddr.port))
     accept_count = Ref(0)
+    methods = String[]
     paths = String[]
+    bodies = String[]
     server_task = errormonitor(Threads.@spawn begin
         conn1 = NC.accept(listener)
         accept_count[] += 1
         try
             req1 = HT.read_request(HT._ConnReader(conn1))
+            push!(methods, req1.method)
             push!(paths, req1.target)
-            _read_all_transport_body_bytes(req1.body)
+            push!(bodies, String(_read_all_transport_body_bytes(req1.body)))
             _write_response_to_conn!(conn1, req1; body_text = "warmup")
             sleep(0.15)
         finally
@@ -1084,8 +1087,9 @@ end
         accept_count[] += 1
         try
             req2 = HT.read_request(HT._ConnReader(conn2))
+            push!(methods, req2.method)
             push!(paths, req2.target)
-            _read_all_transport_body_bytes(req2.body)
+            push!(bodies, String(_read_all_transport_body_bytes(req2.body)))
             _write_response_to_conn!(conn2, req2; body_text = "retried", close_conn = true)
         finally
             HTTP.@try_ignore NC.close(conn2)
@@ -1098,13 +1102,21 @@ end
         res1 = HT.roundtrip!(transport, address, req1)
         @test String(_read_all_transport_body_bytes(res1.body)) == "warmup"
         sleep(0.20)
-        req2 = HT.Request("GET", "/retry"; host = address, body = HT.EmptyBody(), content_length = 0)
+        req2 = HT.Request(
+            "QUERY",
+            "/retry";
+            host = address,
+            body = HT.BytesBody(collect(codeunits("select=1"))),
+            content_length = 8,
+        )
         res2 = HT.roundtrip!(transport, address, req2)
         @test res2.status == 200
         @test String(_read_all_transport_body_bytes(res2.body)) == "retried"
         _wait_task!(server_task)
         @test accept_count[] == 2
+        @test methods == ["GET", "QUERY"]
         @test paths == ["/warmup", "/retry"]
+        @test bodies == ["", "select=1"]
     finally
         close(transport)
         HTTP.@try_ignore NC.close(listener)
@@ -1114,6 +1126,7 @@ end
 end
 
 @testset "HTTP client transport treats not-pollable reused errors as retryable" begin
+    @test HT._retryable_method("QUERY")
     @test HT._retryable_reused_conn_error(Reseau.IOPoll.NotPollableError())
 end
 

--- a/test/http_core_tests.jl
+++ b/test/http_core_tests.jl
@@ -8,6 +8,7 @@ const HT = HTTP
     @test HT.canonical_header_key("content-type") == "Content-Type"
     @test HT.canonical_header_key("X-CUSTOM-HEADER") == "X-Custom-Header"
     @test HT.canonical_header_key("x-forwarded-for") == "X-Forwarded-For"
+    @test HT.canonical_header_key("accept-query") == "Accept-Query"
     headers = HT.Headers()
     HT.setheader(headers, "content-type", "application/json")
     HT.appendheader(headers, "x-forwarded-for", "127.0.0.1")

--- a/test/http_handlers_tests.jl
+++ b/test/http_handlers_tests.jl
@@ -184,6 +184,7 @@ end
 @testset "HTTP router live request handler server" begin
     router = HT.Router()
     HT.register!(router, "GET", "/hello/{name}", _router_hello_request)
+    HT.register!(router, "QUERY", "/search/{name}", _router_echo_request)
     HT.register!(router, "POST", "/echo/{name}", _router_echo_request)
 
     server = HT.serve!(router, "127.0.0.1", 0; listenany = true)
@@ -192,6 +193,10 @@ end
         hello = HT.get("http://$(address)/hello/jane?lang=en")
         @test hello.status == 200
         @test String(_read_all_handler_bytes(hello.body)) == "hello:jane"
+
+        query = HT.query("http://$(address)/search/jane"; body = (q = "ping",))
+        @test query.status == 200
+        @test String(_read_all_handler_bytes(query.body)) == "echo:jane:q=ping"
 
         echo = HT.post("http://$(address)/echo/jane"; body = "ping")
         @test echo.status == 200


### PR DESCRIPTION
## Summary

Adds first-class support for the RFC 10008 HTTP `QUERY` method across HTTP.jl's client and server-facing APIs.

- Adds `HTTP.query(...)`, `HTTP.query(client, ...)`, and `HTTP.@client` helper support without adding a new bare export.
- Treats `QUERY` as safe/idempotent for high-level retries and stale reused-connection transport retries.
- Preserves `QUERY` method and replayable body across `301`, `302`, `307`, and `308` redirects while keeping `303` rewrite behavior to `GET`.
- Canonicalizes the `Accept-Query` header and documents `QUERY` request usage.
- Adds live client/router tests plus redirect, retry, transport, and header coverage.

## Validation

- `julia --project=. test/runtests.jl`
- `julia --project=docs docs/make.jl`
- Fresh temp-env focused run with clean `Reseau` 1.3.1 checkout: `http_core_tests.jl`, `http_handlers_tests.jl`, `http_client_tests.jl`, `http_client_transport_tests.jl`

Note: the local checkout has an untracked manifest pointing at an older dirty `~/.julia/dev/Reseau`, so the final focused verification used a temporary clean Reseau 1.3.1 checkout to match the current `master` compat.

Co-authored by Codex