### PR TITLE
Bugfix: Fix the logic for the "skip the precompile workload inside AutoMerge" detection

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -416,7 +416,7 @@ function _precompile_workload_enabled()::Bool
     Base.JLOptions().code_coverage == 0 || return false
 
     # https://github.com/JuliaWeb/HTTP.jl/issues/1280
-    is_julia_automerge() && return true
+    is_julia_automerge() && return false
 
     return _precompile_host_resolver_available()
 end


### PR DESCRIPTION
Follow-up to #1281 (https://github.com/JuliaWeb/HTTP.jl/pull/1281)

This fixes a very embarassing bug that I made.