### PR TITLE
Isolate authenticated proxy connection pools

### DIFF
--- a/src/http_proxy.jl
+++ b/src/http_proxy.jl
@@ -2,6 +2,7 @@
 
 using EnumX
 using Reseau.HostResolvers
+using UUIDs
 
 struct _NoProxyIPRule{N}
     ip::NTuple{N,UInt8}
@@ -45,6 +46,7 @@ struct _ProxyTarget
     authorization::Union{Nothing,String}
     username::Union{Nothing,String}
     password::Union{Nothing,String}
+    pool_identity::Union{Nothing,UUID}
 end
 
 """
@@ -354,6 +356,7 @@ function _parse_socks_proxy_target(value::AbstractString, scheme::String)::_Prox
         authorization,
         username,
         password,
+        authorization === nothing ? nothing : uuid4(),
     )
 end
 
@@ -375,6 +378,7 @@ function _parse_proxy_target(url::AbstractString, allow_unsupported::Bool=false)
         parsed.authorization,
         nothing,
         nothing,
+        parsed.authorization === nothing ? nothing : uuid4(),
     )
 end
 
@@ -498,5 +502,8 @@ function _proxy_plan(
     else
         secure ? _ProxyPlanMode.HTTP_TUNNEL : _ProxyPlanMode.HTTP_FORWARD
     end
-    return _ProxyPlan(mode, proxy::_ProxyTarget, (proxy::_ProxyTarget).address, string((proxy::_ProxyTarget).url, "|", secure ? "https://" : "http://", address))
+    proxy_target = proxy::_ProxyTarget
+    proxy_pool_key = proxy_target.pool_identity === nothing ?
+        proxy_target.url : string(proxy_target.url, "|auth=", proxy_target.pool_identity::UUID)
+    return _ProxyPlan(mode, proxy_target, proxy_target.address, string(proxy_pool_key, "|", secure ? "https://" : "http://", address))
 end

--- a/test/http_client_proxy_tests.jl
+++ b/test/http_client_proxy_tests.jl
@@ -577,6 +577,20 @@ end
     @test socks5h_plan.first_hop_address == "proxy.local:1080"
     @test socks5h_plan.pool_key == "socks5h://proxy.local:1080/|https://origin.local:443"
 
+    socks_alice = HT.ProxyURL("socks5://alice:one@proxy.local:1080")
+    socks_bob = HT.ProxyURL("socks5://bob:two@proxy.local:1080")
+    socks_alice_plan = HT._proxy_plan(socks_alice, false, "origin.local:80")
+    socks_bob_plan = HT._proxy_plan(socks_bob, false, "origin.local:80")
+    @test socks_alice_plan.pool_key != socks_bob_plan.pool_key
+    @test socks_alice_plan.pool_key == HT._proxy_plan(socks_alice, false, "origin.local:80").pool_key
+    @test !occursin("alice", socks_alice_plan.pool_key)
+    @test !occursin("one", socks_alice_plan.pool_key)
+
+    tunnel_alice = HT.ProxyURL("http://alice:one@proxy.local:8080")
+    tunnel_bob = HT.ProxyURL("http://bob:two@proxy.local:8080")
+    @test HT._proxy_plan(tunnel_alice, true, "origin.local:443").pool_key !=
+          HT._proxy_plan(tunnel_bob, true, "origin.local:443").pool_key
+
     socks_no_proxy = HT.ProxyURL("socks5://proxy.local:1080"; no_proxy = "origin.local")
     skipped_plan = HT._proxy_plan(socks_no_proxy, false, "origin.local:80")
     @test skipped_plan.mode == HT._ProxyPlanMode.DIRECT


### PR DESCRIPTION
## Summary

- assign an opaque identity to each authenticated proxy configuration
- include that identity in HTTP/1 and HTTP/2 connection pool keys
- cover SOCKS5/SOCKS5H and authenticated HTTP CONNECT configurations
- verify credentials never appear in the generated pool key

## Root cause

Proxy userinfo is deliberately removed from the normalized proxy URL, but that credential-free URL was also used as the connection pool identity. SOCKS and HTTP CONNECT authentication happens only while establishing the connection, so a later request using a different authenticated proxy configuration could reuse a connection established under the first configuration.

## Impact

Authenticated proxy connections are now isolated by configuration without storing usernames, passwords, or reversible credential digests in internal pool keys. Reusing the same `ProxyConfig` still reuses its connections; independently parsed authenticated configurations are isolated conservatively.

## Validation

- full `Pkg.test()` on Julia 1.12, including all 63 trim-compilation checks
- `test/http_client_proxy_tests.jl` on Julia 1.10
- `git diff --check`

Co-authored by Codex