### PR TITLE
Return 500 on invalid reuse of response body

### DIFF
--- a/src/http_server.jl
+++ b/src/http_server.jl
@@ -1162,6 +1162,15 @@ function _serve_h1_conn!(server::Server, tracked::_ServerConn, reader_source)::N
                         @try_ignore begin
                             setstatus(stream, status === nothing ? 500 : status::Int)
                             stream.response.close = true
+                            # The handler's response may declare framing for a
+                            # body the error path never writes (e.g. a reused
+                            # response whose body is already closed); reset it
+                            # so closewrite can flush the error head instead of
+                            # failing a Content-Length check before the head
+                            # reaches the wire.
+                            stream.response.content_length = 0
+                            removeheader(stream.response.headers, "Content-Length")
+                            removeheader(stream.response.headers, "Transfer-Encoding")
                             startwrite(stream)
                             closewrite(stream)
                         end

--- a/src/http_server_streams.jl
+++ b/src/http_server_streams.jl
@@ -452,7 +452,9 @@ function _write_response_body_to_stream!(stream::Stream, body)::Nothing
         return nothing
     end
     if body isa AbstractBody
-        if body_closed(body)
+        if body_closed(body) &&
+           _server_stream_allows_body(stream) &&
+           stream.response.content_length != 0
             throw(ArgumentError("body is closed"))
         end
         buf = Vector{UInt8}(undef, 16 * 1024)

--- a/src/http_server_streams.jl
+++ b/src/http_server_streams.jl
@@ -452,6 +452,9 @@ function _write_response_body_to_stream!(stream::Stream, body)::Nothing
         return nothing
     end
     if body isa AbstractBody
+        if body_closed(body)
+            throw(ArgumentError("body is closed"))
+        end
         buf = Vector{UInt8}(undef, 16 * 1024)
         try
             while true

--- a/src/http_server_streams.jl
+++ b/src/http_server_streams.jl
@@ -452,10 +452,14 @@ function _write_response_body_to_stream!(stream::Stream, body)::Nothing
         return nothing
     end
     if body isa AbstractBody
-        if body_closed(body) &&
-           _server_stream_allows_body(stream) &&
-           stream.response.content_length != 0
-            throw(ArgumentError("body is closed"))
+        if body_closed(body) && _server_stream_allows_body(stream)
+            # The handler may declare an empty payload via the Content-Length
+            # header alone; the content_length field stays -1 until startwrite
+            # resolves it, so consult the header before rejecting the body.
+            declared = stream.response.content_length >= 0 ?
+                stream.response.content_length :
+                _parse_content_length(stream.response.headers)
+            declared == 0 || throw(ArgumentError("body is closed"))
         end
         buf = Vector{UInt8}(undef, 16 * 1024)
         try

--- a/test/http_handlers_tests.jl
+++ b/test/http_handlers_tests.jl
@@ -198,6 +198,28 @@ end
     end
 end
 
+@testset "HTTP streamhandler ignores closed bodies when no body is written" begin
+    for (method, status, bytes) in (
+        ("GET", 200, UInt8[]),
+        ("GET", 204, collect(codeunits("ignored body"))),
+        ("HEAD", 200, collect(codeunits("head body"))),
+    )
+        body = HT.BytesBody(bytes)
+        HT.body_close!(body)
+        baked = HT.Response(status, body; content_length = length(bytes))
+        server = HT.listen!(HT.streamhandler(_ -> baked), "127.0.0.1", 0; listenany = true)
+        address = HT.server_addr(server)
+        try
+            resp = HT.request(method, "http://$(address)/"; status_exception = false, retry = false)
+            @test resp.status == status
+            @test isempty(_read_all_handler_bytes(resp.body))
+        finally
+            HT.forceclose(server)
+            wait(server)
+        end
+    end
+end
+
 @testset "HTTP router live request handler server" begin
     router = HT.Router()
     HT.register!(router, "GET", "/hello/{name}", _router_hello_request)

--- a/test/http_handlers_tests.jl
+++ b/test/http_handlers_tests.jl
@@ -181,6 +181,23 @@ end
     end
 end
 
+@testset "HTTP streamhandler reused String response body" begin
+    baked = HT.Response(200, ["Content-Type" => "text/plain"]; body = "baked string body")
+    server = HT.listen!(HT.streamhandler(_ -> baked), "127.0.0.1", 0; listenany = true)
+    address = HT.server_addr(server)
+    try
+        resp = HT.get("http://$(address)/")
+        @test resp.status == 200
+        @test String(_read_all_handler_bytes(resp.body)) == "baked string body"
+
+        reused = HT.get("http://$(address)/"; status_exception = false, retry = false)
+        @test reused.status == 500
+    finally
+        HT.forceclose(server)
+        wait(server)
+    end
+end
+
 @testset "HTTP router live request handler server" begin
     router = HT.Router()
     HT.register!(router, "GET", "/hello/{name}", _router_hello_request)

--- a/test/http_handlers_tests.jl
+++ b/test/http_handlers_tests.jl
@@ -220,6 +220,22 @@ end
     end
 end
 
+@testset "HTTP streamhandler ignores closed body with Content-Length: 0 header" begin
+    body = HT.CallbackBody(_ -> 0, () -> nothing)
+    HT.body_close!(body)
+    baked = HT.Response(200, ["Content-Length" => "0"], body)
+    server = HT.listen!(HT.streamhandler(_ -> baked), "127.0.0.1", 0; listenany = true)
+    address = HT.server_addr(server)
+    try
+        resp = HT.get("http://$(address)/"; status_exception = false, retry = false)
+        @test resp.status == 200
+        @test isempty(_read_all_handler_bytes(resp.body))
+    finally
+        HT.forceclose(server)
+        wait(server)
+    end
+end
+
 @testset "HTTP router live request handler server" begin
     router = HT.Router()
     HT.register!(router, "GET", "/hello/{name}", _router_hello_request)


### PR DESCRIPTION
In case a response with a consumable body is consumed, currently a 400 error will be returned. However, the error is actually from the server side, so a 500 should be returned.  This is done by throwing an error when _write_response_body_to_stream is called on a closed body. Additionally, the error path is modified so that the framing headers on the response are reset.

See https://github.com/JuliaWeb/HTTP.jl/issues/1333

Co-authored by Codex

