### PR TITLE
Stream server SSE events live instead of buffering until stream close

### DIFF
--- a/src/http2_server.jl
+++ b/src/http2_server.jl
@@ -1158,26 +1158,22 @@ function _write_response_body_h2_server!(
     end
     body isa AbstractBody || throw(ProtocolError("unsupported HTTP/2 response body type $(typeof(body))"))
     buf = Vector{UInt8}(undef, 16 * 1024)
-    pending = UInt8[]
-    have_pending = false
     try
         while true
             n = body_read!(body::AbstractBody, buf)
             if n == 0
-                if have_pending
-                    _write_data_frames_h2_server!(conn, write_lock, send_state, stream_id, pending; end_stream=end_stream, write_deadline_ns=write_deadline_ns)
-                elseif end_stream
-                    _write_frame_h2_server_threadsafe!(write_lock, conn, DataFrame(stream_id, true, UInt8[]), write_deadline_ns)
-                end
+                end_stream && _write_frame_h2_server_threadsafe!(write_lock, conn, DataFrame(stream_id, true, UInt8[]), write_deadline_ns)
                 return nothing
             end
-            current = Vector{UInt8}(undef, n)
-            copyto!(current, 1, buf, 1, n)
-            if have_pending
-                _write_data_frames_h2_server!(conn, write_lock, send_state, stream_id, pending; end_stream=false, write_deadline_ns=write_deadline_ns)
-            end
-            pending = current
-            have_pending = true
+            _write_data_frames_h2_server!(
+                conn,
+                write_lock,
+                send_state,
+                stream_id,
+                @view(buf[1:n]);
+                end_stream=false,
+                write_deadline_ns=write_deadline_ns,
+            )
         end
     finally
         @try_ignore begin

--- a/src/http_sse.jl
+++ b/src/http_sse.jl
@@ -118,11 +118,9 @@ function body_read!(stream::SSEStream, dst::Vector{UInt8})::Int
     # from the transport until the SSE stream ends instead of streaming them
     # live. `eof` blocks until at least one byte is available or the stream is
     # closed and drained.
-    while true
-        eof(buf) && return 0
-        available = min(bytesavailable(buf), length(dst))
-        available > 0 && return readbytes!(buf, dst, available)
-    end
+    eof(buf) && return 0
+    available = min(bytesavailable(buf), length(dst))
+    return readbytes!(buf, dst, available)
 end
 
 # Split `value` into logical lines, treating CR, LF and CRLF all as line

--- a/src/http_sse.jl
+++ b/src/http_sse.jl
@@ -111,7 +111,18 @@ end
 
 function body_read!(stream::SSEStream, dst::Vector{UInt8})::Int
     isempty(dst) && return 0
-    return readbytes!(stream.buffer, dst, length(dst))
+    buf = stream.buffer
+    # Return as soon as any bytes are buffered rather than asking readbytes! to
+    # fill `dst`: on a BufferStream that call blocks until length(dst) bytes
+    # accumulate or the stream closes, which would hold written events back
+    # from the transport until the SSE stream ends instead of streaming them
+    # live. `eof` blocks until at least one byte is available or the stream is
+    # closed and drained.
+    while true
+        eof(buf) && return 0
+        available = min(bytesavailable(buf), length(dst))
+        available > 0 && return readbytes!(buf, dst, available)
+    end
 end
 
 # Split `value` into logical lines, treating CR, LF and CRLF all as line

--- a/test/http2_server_tests.jl
+++ b/test/http2_server_tests.jl
@@ -237,6 +237,38 @@ end
     end
 end
 
+@testset "HTTP/2 server SSE events stream incrementally" begin
+    # The producer only writes the second event after the client receives the
+    # first. Holding one AbstractBody chunk until the next read or EOF makes the
+    # producer emit the sentinel instead and fails without a latency assertion.
+    saw_first = Channel{Nothing}(1)
+    server = HT.serve!("127.0.0.1", 0; listenany = true) do request
+            _ = request
+            return HT.sse_stream(200) do stream
+                write(stream, HT.SSEEvent("one"))
+                delivered = timedwait(() -> isready(saw_first), 5.0; pollint = 0.01)
+                write(stream, HT.SSEEvent(delivered === :ok ? "two" : "first event was not delivered before close"))
+            end
+        end
+    address = HT.server_addr(server)
+    conn = HT.connect_h2!(address; secure = false)
+    try
+        request = HT.Request("GET", "/"; host = address, body = HT.EmptyBody(), content_length = 0, proto_major = 2, proto_minor = 0)
+        response = HT.h2_roundtrip!(conn, request)
+        first_buffer = Vector{UInt8}(undef, 64)
+        first_count = HT.body_read!(response.body, first_buffer)
+        first_event = String(first_buffer[1:first_count])
+        first_event == "data: one\n\n" && put!(saw_first, nothing)
+        remaining = String(_read_all_h2_server(response.body))
+        @test response.status == 200
+        @test first_event * remaining == "data: one\n\ndata: two\n\n"
+    finally
+        close(conn)
+        HT.forceclose(server)
+        _ = timedwait(() -> istaskdone(server.serve_task::Task), 3.0; pollint = 0.001)
+    end
+end
+
 @testset "HTTP/2 server writes unread BytesBody response bytes directly" begin
     payload = collect(codeunits("abcdef"))
     returned_body = Ref{Union{Nothing,HT.BytesBody}}(nothing)

--- a/test/http2_server_tests.jl
+++ b/test/http2_server_tests.jl
@@ -195,6 +195,13 @@ function _drain_h2_server_responses!(conn::NC.Conn, reader::IO, decoder::HT.Deco
     return Dict(id => String(bodies[id]) for id in expected)
 end
 
+@testset "HTTP/2 server stream cancellation errors" begin
+    reset_error = HT._h2_server_stream_exception(HT._H2_SERVER_STREAM_RESET)
+    closed_error = HT._h2_server_stream_exception(HT._H2_SERVER_STREAM_CONN_CLOSED)
+    @test reset_error.message == "HTTP/2 stream reset by peer"
+    @test closed_error.message == "HTTP/2 connection is closed"
+end
+
 @testset "HTTP/2 server request handling" begin
     server = HT.serve!("127.0.0.1", 0; listenany = true) do request
             payload = collect(codeunits("h2:" * request.target))

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -289,6 +289,36 @@ end
     end
 end
 
+@testset "HTTP server SSE events stream incrementally" begin
+    # Events must reach the client as they are written, not in a burst when the
+    # stream closes. The producer only writes the second event after the client
+    # callback has observed the first; if the transport buffers until close,
+    # the producer times out and writes a sentinel instead, failing the test
+    # deterministically without wall-clock assertions.
+    saw_first = Threads.Atomic{Bool}(false)
+    server = HT.serve!("127.0.0.1", 0; listenany = true) do request
+            _ = request
+            return HT.sse_stream(200) do stream
+                write(stream, HT.SSEEvent("one"))
+                delivered = timedwait(() -> saw_first[], 5.0; pollint = 0.01)
+                write(stream, HT.SSEEvent(delivered === :ok ? "two" : "first event was not delivered before close"))
+            end
+        end
+    address = HT.server_addr(server)
+    try
+        events = String[]
+        response = HT.get("http://$(address)/"; sse_callback = event -> begin
+            push!(events, event.data)
+            event.data == "one" && (saw_first[] = true)
+        end)
+        @test response.status == 200
+        @test events == ["one", "two"]
+    finally
+        _run_with_timeout(() -> HT.forceclose(server); label = "server forceclose")
+        _run_with_timeout(() -> wait(server); label = "server task completion")
+    end
+end
+
 @testset "HTTP server SSE rejects CR/LF injection in event/id/retry fields" begin
     # Serialize an event offline by writing it into an SSEStream and reading the
     # framed bytes back out, so we can assert on the exact wire output.

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -295,12 +295,12 @@ end
     # callback has observed the first; if the transport buffers until close,
     # the producer times out and writes a sentinel instead, failing the test
     # deterministically without wall-clock assertions.
-    saw_first = Threads.Atomic{Bool}(false)
+    saw_first = Channel{Nothing}(1)
     server = HT.serve!("127.0.0.1", 0; listenany = true) do request
             _ = request
             return HT.sse_stream(200) do stream
                 write(stream, HT.SSEEvent("one"))
-                delivered = timedwait(() -> saw_first[], 5.0; pollint = 0.01)
+                delivered = timedwait(() -> isready(saw_first), 5.0; pollint = 0.01)
                 write(stream, HT.SSEEvent(delivered === :ok ? "two" : "first event was not delivered before close"))
             end
         end
@@ -309,7 +309,7 @@ end
         events = String[]
         response = HT.get("http://$(address)/"; sse_callback = event -> begin
             push!(events, event.data)
-            event.data == "one" && (saw_first[] = true)
+            event.data == "one" && put!(saw_first, nothing)
         end)
         @test response.status == 200
         @test events == ["one", "two"]

--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -252,6 +252,7 @@ end
     stream = response.body::HT.SSEStream
     @test HT.header(response.headers, "Content-Type") == "text/event-stream"
     @test HT.header(response.headers, "Cache-Control") == "no-cache"
+    @test HT.body_read!(stream, UInt8[]) == 0
     close(stream)
 end
 


### PR DESCRIPTION
## Summary

- Stream HTTP/1 SSE bytes as soon as they are available.
- Stream HTTP/2 AbstractBody chunks as soon as each read completes.
- Restore live delivery for long-lived SSE responses such as MCP 2026-07-28 subscriptions/listen.

## Root cause

SSEStream.body_read! used a BufferStream read that waited for the 16 KiB destination to fill or for the stream to close. This buffered HTTP/1 events until close.

HTTP/2 had a second delay. Its AbstractBody writer retained one complete chunk so it could mark that chunk END_STREAM later. A quiet subscription therefore held its first event until a second event arrived or the producer closed. For MCP, this could hide the required subscription acknowledgement indefinitely.

## Fix

- Wait for at least one SSE byte, then return all bytes that are immediately available.
- Send every non-empty HTTP/2 body chunk immediately.
- At body EOF, send an empty END_STREAM DATA frame when there are no trailers.
- Keep trailing HEADERS as the terminal frame when trailers are present.
- Add deterministic HTTP/1 and HTTP/2 client/producer handshake tests. The producer writes event two only after the client receives event one.

## Validation

- Rebased onto current master at e7fbc1f3.
- Full package test suite passed on Julia 1.12.6, including all 63 trim-compile checks.
- Complete HTTP/1 and HTTP/2 server test files passed on Julia 1.10.11 and 1.11.9.
- Live ModelContextProtocol.jl subscriptions/listen smoke passed: acknowledgement and later list-changed notification both arrived before stream close.
- HTTP/2 response trailers and a 40,008-byte SSE drain passed direct checks.

Initial change prepared with [Claude Code](https://claude.com/claude-code).

Co-authored by Codex