### PR TITLE
Preserve prepared requests on HTTP/2 fallback

### DIFF
--- a/src/http_client.jl
+++ b/src/http_client.jl
@@ -815,7 +815,6 @@ function _do_incoming!(
                     catch err
                         _drop_h2_conn!(client, proxy_plan, conn)
                         if protocol == :auto && _should_fallback_h2_to_h1(err)
-                            send_request = _copy_request_for_send(current_request, retry_attempt == 1)
                             _roundtrip_incoming!(
                                 client.transport,
                                 current_address,

--- a/test/http_integration_tests.jl
+++ b/test/http_integration_tests.jl
@@ -77,7 +77,9 @@ end
     )
     laddr = TL.addr(listener)::NC.SocketAddrV4
     address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    seen_authorization = Ref{Union{Nothing,String}}(nothing)
     server = HT.serve!(listener) do request
+        seen_authorization[] = HT.header(request.headers, "Authorization", nothing)
         payload = collect(codeunits("tls-h1:" * request.target))
         return HT.Response(200, HT.BytesBody(payload); content_length = length(payload))
     end
@@ -93,9 +95,22 @@ end
         prefer_http2 = true,
     )
     try
-        response = HT.get!(client, address, "/auto-tls"; secure = true, protocol = :auto)
+        trace = function(event)
+            if event isa HT.RequestEvent
+                HT.setheader(event.request.headers, "Authorization", "Signature trace-time")
+            end
+            return nothing
+        end
+        response = HT.request(
+            trace,
+            "GET",
+            "https://$(address)/auto-tls";
+            client,
+            protocol = :auto,
+        )
         @test response.status == 200
-        @test String(_read_all_integration(response.body)) == "tls-h1:/auto-tls"
+        @test String(response.body) == "tls-h1:/auto-tls"
+        @test seen_authorization[] == "Signature trace-time"
     finally
         close(client)
         HT.forceclose(server)


### PR DESCRIPTION
## Summary

- Reuse the prepared request when automatic HTTP/2 negotiation falls back to HTTP/1.1.
- Preserve trace-time header and body mutations, including cloud request signatures.
- Add a TLS regression test that signs the request from `RequestEvent` and verifies that the HTTP/1.1 server receives the signature.

## Root cause

`_do_incoming!` created and traced a send request before it tried HTTP/2. When ALPN selected HTTP/1.1, the fallback path discarded that prepared request and copied the unchanged source request again. The second copy lost all changes made after the first copy, including trace-time signing and cookie insertion.

The ALPN failure happens during connection setup. No HTTP request body has been sent or consumed at that point. The fallback can safely send the already prepared request.

## User impact

Callers can keep HTTP.jl's default `protocol=:auto` behavior. Authenticated clients no longer need to force HTTP/1.1 to keep trace-time request signatures on fallback.

## Validation

- Confirmed the new regression test fails on HTTP.jl 2.6.0 because the server receives no `Authorization` header.
- Confirmed the regression test passes after the fix.
- Ran `Pkg.test()` on Julia 1.12.6. The full HTTP.jl suite passed, including all 63 trim-compile checks.
- GitHub Actions CI run 1675 is green on stable and prerelease Julia across Linux and Windows, stable Julia on macOS ARM64, and documentation. The macOS job passed on rerun after an unrelated raw HTTP/1 first-byte timeout.

Co-authored by Codex