### PR TITLE
Harden server timeout and shutdown tests

### DIFF
--- a/test/http_server_http1_tests.jl
+++ b/test/http_server_http1_tests.jl
@@ -977,7 +977,18 @@ end
         response = HT._read_response(HT._ConnReader(sock), request)
         @test response.status == 200
         @test String(_read_all_server_bytes(response.body)) == "ok"
-        @test isempty(read(sock))
+        # The timeout response is best-effort. Depending on whether its write
+        # wins the race with transport shutdown, the peer observes either a
+        # clean EOF or a complete 408 response followed by EOF.
+        trailing = read(sock)
+        if !isempty(trailing)
+            timeout_io = IOBuffer(trailing)
+            timeout_response = HT._read_response(timeout_io)
+            @test timeout_response.status == 408
+            @test timeout_response.close
+            @test timeout_response.content_length == 0
+            @test eof(timeout_io)
+        end
     finally
         HT.@try_ignore begin
             NC.close(sock)

--- a/test/http_websocket_server_tests.jl
+++ b/test/http_websocket_server_tests.jl
@@ -317,45 +317,54 @@ end
 end
 
 @testset "HTTP.WebSockets server close notifies active sessions" begin
-    started = Channel{Nothing}(1)
-    finished = Channel{Nothing}(1)
-    release_handler = Channel{Nothing}(1)
-    server = W.listen!("127.0.0.1", 0) do ws
-        put!(started, nothing)
-        try
-            while true
-                W.receive(ws)
-            end
-        catch
-        finally
-            put!(finished, nothing)
-            take!(release_handler)
-        end
-    end
-    ws = nothing
-    forceclose_task = nothing
-    try
-        address = W.server_addr(server)
-        ws = W.open("ws://$address/shutdown")
-        take!(started)
-        forceclose_task = errormonitor(Threads.@spawn W.forceclose(server))
-        take!(finished)
-        fetch(forceclose_task::Task)
-        put!(release_handler, nothing)
-        wait(server)
-        err = try
-            W.receive(ws::W.WebSocket)
+    for secure in (false, true)
+        started = Channel{Nothing}(1)
+        finished = Channel{Nothing}(1)
+        release_handler = Channel{Nothing}(1)
+        tls_config = secure ?
+            TL.Config(verify_peer = false, cert_file = _TLS_CERT_PATH, key_file = _TLS_KEY_PATH) :
             nothing
-        catch err
-            err
+        server = W.listen!("127.0.0.1", 0; tls_config = tls_config) do ws
+            put!(started, nothing)
+            try
+                while true
+                    W.receive(ws)
+                end
+            catch
+            finally
+                put!(finished, nothing)
+                take!(release_handler)
+            end
         end
-        @test err isa W.WebSocketError
-        @test (err::W.WebSocketError).message.code == 1001
-    finally
-        isready(release_handler) || HTTP.@try_ignore put!(release_handler, nothing)
-        forceclose_task === nothing || HTTP.@try_ignore fetch(forceclose_task::Task)
-        ws === nothing || HTTP.@try_ignore close(ws::W.WebSocket)
-        HTTP.@try_ignore W.forceclose(server)
-        HTTP.@try_ignore wait(server)
+        ws = nothing
+        forceclose_task = nothing
+        try
+            address = W.server_addr(server)
+            scheme = secure ? "wss" : "ws"
+            ws = W.open(
+                "$scheme://$address/shutdown";
+                require_ssl_verification = false,
+            )
+            take!(started)
+            forceclose_task = errormonitor(Threads.@spawn W.forceclose(server))
+            take!(finished)
+            fetch(forceclose_task::Task)
+            put!(release_handler, nothing)
+            wait(server)
+            err = try
+                W.receive(ws::W.WebSocket)
+                nothing
+            catch err
+                err
+            end
+            @test err isa W.WebSocketError
+            @test (err::W.WebSocketError).message.code == 1001
+        finally
+            isready(release_handler) || HTTP.@try_ignore put!(release_handler, nothing)
+            forceclose_task === nothing || HTTP.@try_ignore fetch(forceclose_task::Task)
+            ws === nothing || HTTP.@try_ignore close(ws::W.WebSocket)
+            HTTP.@try_ignore W.forceclose(server)
+            HTTP.@try_ignore wait(server)
+        end
     end
 end


### PR DESCRIPTION
## Summary

- accept either clean EOF or a complete 408 response when an idle keep-alive connection expires
- parse and validate any optional timeout response
- run the active-session WebSocket shutdown test over both TCP and TLS
- keep each test connection tracked until `forceclose` inspects it

## Root causes

The HTTP server writes timeout responses on a best-effort basis. The test required an empty read, but the Windows Julia prerelease job can receive the complete 408 response before transport shutdown wins the race. Both wire outcomes close the idle connection correctly.

The WebSocket server tests covered TLS connection shutdown only when cleanup lost a race. This caused project coverage to vary by two untouched lines. The active-session test now exercises both transports while its handler is deliberately blocked.

## Validation

- complete `test/http_server_http1_tests.jl` passed in an isolated environment
- complete `test/http_websocket_server_tests.jl` passed in an isolated environment
- local LCOV trace records hits for both TCP and TLS `forceclose` branches
- first exact-head CI run passed all six GitHub Actions jobs, including Windows Julia prerelease
- `git diff --check` passed

Co-authored by Codex