### PR TITLE
Write cookie attributes one value per call in stringify

### DIFF
--- a/src/http_cookies.jl
+++ b/src/http_cookies.jl
@@ -124,12 +124,30 @@ function stringify(c::Cookie, isrequest::Bool=true)::String
     nm = strip(c.name)
     !iscookienamevalid(nm) && return ""
     io = IOBuffer()
-    write(io, sanitizeCookieName(nm), '=', sanitizeCookieValue(c.value))
+    # One value per `write`: Base's varargs `write(io, x1, xs...)` iterates a
+    # heterogeneous tuple and dispatches each element dynamically, which
+    # juliac --trim cannot resolve; single-argument writes are direct.
+    write(io, sanitizeCookieName(nm))
+    write(io, '=')
+    write(io, sanitizeCookieValue(c.value))
     if !isrequest
-        length(c.path) > 0 && write(io, "; Path=", sanitizeCookiePath(c.path))
-        length(c.domain) > 0 && validCookieDomain(c.domain) && write(io, "; Domain=", c.domain[1] == '.' ? SubString(c.domain, 2) : c.domain)
-        validCookieExpires(c.expires) && write(io, "; Expires=", Dates.format(c.expires, Dates.RFC1123Format), " GMT")
-        c.maxage > 0 && write(io, "; Max-Age=", string(c.maxage))
+        if length(c.path) > 0
+            write(io, "; Path=")
+            write(io, sanitizeCookiePath(c.path))
+        end
+        if length(c.domain) > 0 && validCookieDomain(c.domain)
+            write(io, "; Domain=")
+            write(io, c.domain[1] == '.' ? SubString(c.domain, 2) : c.domain)
+        end
+        if validCookieExpires(c.expires)
+            write(io, "; Expires=")
+            write(io, Dates.format(c.expires, Dates.RFC1123Format))
+            write(io, " GMT")
+        end
+        if c.maxage > 0
+            write(io, "; Max-Age=")
+            write(io, string(c.maxage))
+        end
         c.maxage < 0 && write(io, "; Max-Age=0")
         c.httponly && write(io, "; HttpOnly")
         c.secure && write(io, "; Secure")

--- a/test/http_cookie_tests.jl
+++ b/test/http_cookie_tests.jl
@@ -1,6 +1,7 @@
 using Test
 using HTTP
 using Reseau
+using Dates
 
 const HT = HTTP
 
@@ -34,6 +35,24 @@ end
     @test occursin("; HttpOnly", rendered)
     @test occursin("; Secure", rendered)
     @test occursin("; SameSite=Lax", rendered)
+
+    expires = DateTime(2030, 1, 2, 3, 4, 5)
+    complete = HT.Cookie(
+        " complete ",
+        "a b";
+        path="/docs;private",
+        domain="example.com",
+        expires,
+        maxage=-1,
+        httponly=true,
+        secure=true,
+        samesite=HT.SameSiteStrictMode,
+    )
+    expires_text = Dates.format(expires, Dates.RFC1123Format)
+    @test HT.stringify(complete) == "complete=\"a b\""
+    @test HT.stringify(complete, false) ==
+          "complete=\"a b\"; Path=/docsprivate; Domain=example.com; " *
+          "Expires=$expires_text GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict"
 
     req_headers = HT.Headers()
     HT.appendheader(req_headers, "Cookie", "a=1; b=two")

--- a/test/http_trim_cookies.jl
+++ b/test/http_trim_cookies.jl
@@ -1,0 +1,29 @@
+include("trim_workload_common.jl")
+
+using Dates
+
+function run_http_trim_cookies()::Nothing
+    expires = DateTime(2030, 1, 2, 3, 4, 5)
+    cookie = HT.Cookie("session", "a b")
+    cookie.path = "/docs;private"
+    cookie.domain = ".example.com"
+    cookie.expires = expires
+    cookie.maxage = 60
+    cookie.secure = true
+    cookie.httponly = true
+    cookie.samesite = HT.SameSiteStrictMode
+    expected = "session=\"a b\"; Path=/docsprivate; Domain=example.com; " *
+               "Expires=Wed, 02 Jan 2030 03:04:05 GMT; Max-Age=60; " *
+               "HttpOnly; Secure; SameSite=Strict"
+    HT.stringify(cookie, false) == expected || error("unexpected response cookie")
+    HT.stringify(cookie) == "session=\"a b\"" || error("unexpected request cookie")
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_http_trim_cookies()
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -157,6 +157,7 @@ end
             ("http_trim_client_h2_tcp_roundtrip.jl", "http_trim_client_h2_tcp_roundtrip"),
             ("http_trim_client_h2_roundtrip.jl", "http_trim_client_h2_roundtrip"),
             ("http_trim_client_server.jl", "http_trim_client_server"),
+            ("http_trim_cookies.jl", "http_trim_cookies"),
             ("http_trim_open_fileserver.jl", "http_trim_open_fileserver"),
             ("http_trim_http2.jl", "http_trim_http2"),
             ("http_trim_websocket.jl", "http_trim_websocket"),


### PR DESCRIPTION
One small change so an HTTP.jl server compiled with `juliac --trim=safe` verifies cleanly, found while trimming a Servo application on Julia nightly (JuliaCon 2026 workshop prep).

Base's varargs `write(io, x1, xs...)` iterates a heterogeneous tuple and dispatches each element dynamically, which the trim verifier cannot resolve (a 5-line program writing `write(io, "a", '=', "b")` fails verification on nightly). Cookie `stringify` used it in four places; splitting them into single-value writes produces byte-identical output and compiles to direct calls.

The companion change on the server request path (rebuilds through the positional constructor) already landed in #1349 — an earlier draft of this PR duplicated it and has been trimmed down. Together with #1349, HTTP contributes zero verify errors to that app's `--trim=safe` build.

Tests: `http_cookie_tests.jl` passes locally (rerun on this rebased branch), and the core/h1 wire suites passed with the same cookie change before the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up

- Add exact request and response cookie rendering coverage.
- Add a trim workload that builds and runs the public cookie stringify path.

Validation: focused cookie tests pass. The new trim executable builds and runs with zero verifier errors.

Co-authored by Codex